### PR TITLE
fix: 优化设置页响应式布局和空状态展示

### DIFF
--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -474,6 +474,7 @@
     "rules": {
       "title": "Alert Rules",
       "new": "New Rule",
+      "empty": "There are no alert rules yet",
       "confirmDelete": "Delete this rule? This cannot be undone.",
       "cooldown": "cooldown {seconds}s",
       "form": {
@@ -486,6 +487,7 @@
     "channels": {
       "title": "Notification Channels",
       "new": "New Channel",
+      "empty": "There are no notification channels yet",
       "confirmDelete": "Delete this notification channel? This cannot be undone.",
       "form": {
         "namePlaceholder": "Channel name",
@@ -1395,6 +1397,7 @@
   "model": {
     "loading": "Loading model market...",
     "empty": "No matching models found",
+    "emptyAll": "There are no models yet",
     "create": {
       "title": "Create Model",
       "name": "Model Name",
@@ -1467,6 +1470,7 @@
       "refreshFailed": "Failed to refresh logs"
     },
     "list": {
+      "empty": "There are no logs yet",
       "noMore": "No more logs"
     },
     "card": {

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -1490,6 +1490,7 @@
     }
   },
   "channel": {
+    "empty": "There are no channels yet",
     "card": {
       "requestCount": "Requests",
       "totalCost": "Total Cost",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -1490,6 +1490,7 @@
     }
   },
   "channel": {
+    "empty": "当前没有任何渠道",
     "card": {
       "requestCount": "请求次数",
       "totalCost": "总成本",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -474,6 +474,7 @@
     "rules": {
       "title": "告警规则",
       "new": "新建规则",
+      "empty": "当前没有任何告警规则",
       "confirmDelete": "确认删除该规则吗？此操作不可撤销。",
       "cooldown": "冷却 {seconds} 秒",
       "form": {
@@ -486,6 +487,7 @@
     "channels": {
       "title": "通知渠道",
       "new": "新建渠道",
+      "empty": "当前没有任何通知渠道",
       "confirmDelete": "确认删除该通知渠道吗？此操作不可撤销。",
       "form": {
         "namePlaceholder": "渠道名称",
@@ -1395,6 +1397,7 @@
   "model": {
     "loading": "加载模型广场中...",
     "empty": "当前没有匹配的模型",
+    "emptyAll": "当前没有任何模型",
     "create": {
       "title": "创建模型",
       "name": "模型名称",
@@ -1467,6 +1470,7 @@
       "refreshFailed": "日志刷新失败"
     },
     "list": {
+      "empty": "当前没有任何日志",
       "noMore": "没有更多日志了"
     },
     "card": {

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -1490,6 +1490,7 @@
     }
   },
   "channel": {
+    "empty": "目前沒有任何供應源",
     "card": {
       "requestCount": "請求次數",
       "totalCost": "總成本",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -474,6 +474,7 @@
     "rules": {
       "title": "告警規則",
       "new": "新增規則",
+      "empty": "目前沒有任何告警規則",
       "confirmDelete": "確認刪除此規則嗎？此操作無法復原。",
       "cooldown": "冷卻 {seconds} 秒",
       "form": {
@@ -486,6 +487,7 @@
     "channels": {
       "title": "通知渠道",
       "new": "新增渠道",
+      "empty": "目前沒有任何通知渠道",
       "confirmDelete": "確認刪除此通知渠道嗎？此操作無法復原。",
       "form": {
         "namePlaceholder": "渠道名稱",
@@ -1395,6 +1397,7 @@
   "model": {
     "loading": "載入模型廣場中...",
     "empty": "目前沒有符合條件的模型",
+    "emptyAll": "目前沒有任何模型",
     "create": {
       "title": "建立模型",
       "name": "模型名稱",
@@ -1467,6 +1470,7 @@
       "refreshFailed": "日誌重新整理失敗"
     },
     "list": {
+      "empty": "目前沒有任何日誌",
       "noMore": "沒有更多日誌了"
     },
     "card": {

--- a/web/src/components/modules/alert/index.tsx
+++ b/web/src/components/modules/alert/index.tsx
@@ -431,7 +431,11 @@ export function Alert() {
                     )}
 
                     <div className="space-y-2">
-                        {(rules || []).map((rule) => {
+                        {(!rules || rules.length === 0) ? (
+                            <div className="rounded-xl border border-dashed border-border/35 bg-card px-6 py-10 text-center text-sm text-muted-foreground">
+                                {t('rules.empty')}
+                            </div>
+                        ) : (rules || []).map((rule) => {
                             const isEditing = editingRuleId === rule.id;
 
                             return (
@@ -602,7 +606,11 @@ export function Alert() {
                     )}
 
                     <div className="space-y-2">
-                        {(channels || []).map((channel) => {
+                        {(!channels || channels.length === 0) ? (
+                            <div className="rounded-xl border border-dashed border-border/35 bg-card px-6 py-10 text-center text-sm text-muted-foreground">
+                                {t('channels.empty')}
+                            </div>
+                        ) : (channels || []).map((channel) => {
                             const isEditing = editingChannelId === channel.id;
 
                             return (

--- a/web/src/components/modules/analytics/index.tsx
+++ b/web/src/components/modules/analytics/index.tsx
@@ -29,9 +29,16 @@ export function Analytics() {
                             <BarChart3 className="h-5 w-5" />
                         </div>
                         {subtitle ? (
-                            <p className="min-w-0 max-w-3xl text-sm leading-6 text-muted-foreground">
-                                {subtitle}
-                            </p>
+                            <div className="min-w-0 space-y-3">
+                                <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+                                    {subtitle}
+                                </p>
+                                <div className="flex flex-wrap gap-2 text-xs font-medium text-muted-foreground">
+                                    <span className="rounded-lg border border-border/25 bg-card px-2.5 py-1">{t('cards.utilization.title')}</span>
+                                    <span className="rounded-lg border border-border/25 bg-card px-2.5 py-1">{t('cards.routeHealth.title')}</span>
+                                    <span className="rounded-lg border border-border/25 bg-card px-2.5 py-1">{t('evaluation.title')}</span>
+                                </div>
+                            </div>
                         ) : null}
                     </div>
                     <div className="flex items-center gap-2 self-start rounded-lg border border-border/25 bg-card px-3 py-2 text-sm text-muted-foreground">

--- a/web/src/components/modules/analytics/index.tsx
+++ b/web/src/components/modules/analytics/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { BarChart3, Orbit } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { PageWrapper } from '@/components/common/PageWrapper';
 import { Tabs, TabsContents, TabsContent, TabsList, TabsTrigger } from '@/components/animate-ui/components/animate/tabs';
@@ -17,9 +18,29 @@ export function Analytics() {
     const t = useTranslations('analytics');
     const [activeTab, setActiveTab] = useState<AnalyticsTab>('utilization');
     const [range, setRange] = useState<AnalyticsRange>('7d');
+    const subtitle = t('subtitle');
 
     return (
         <PageWrapper className="h-full min-h-0 overflow-y-auto overscroll-contain space-y-6 rounded-t-xl pb-24 md:pb-4">
+            <section className="relative overflow-hidden rounded-xl border border-border/35 bg-card p-5 text-card-foreground md:p-6">
+                <div className="relative flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="flex items-start gap-4">
+                        <div className="grid h-14 w-14 shrink-0 place-items-center rounded-lg border border-border/35 bg-card text-primary">
+                            <BarChart3 className="h-5 w-5" />
+                        </div>
+                        {subtitle ? (
+                            <p className="min-w-0 max-w-3xl text-sm leading-6 text-muted-foreground">
+                                {subtitle}
+                            </p>
+                        ) : null}
+                    </div>
+                    <div className="flex items-center gap-2 self-start rounded-lg border border-border/25 bg-card px-3 py-2 text-sm text-muted-foreground">
+                        <Orbit className="h-4 w-4 text-primary" />
+                        {t(`range.${range}`)}
+                    </div>
+                </div>
+            </section>
+
             <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as AnalyticsTab)}>
                 <section className="relative overflow-hidden rounded-xl border border-border/35 bg-card p-4 text-card-foreground md:p-5">
                     <div className="relative flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">

--- a/web/src/components/modules/analytics/index.tsx
+++ b/web/src/components/modules/analytics/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { BarChart3, Waves, Orbit } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { PageWrapper } from '@/components/common/PageWrapper';
 import { Tabs, TabsContents, TabsContent, TabsList, TabsTrigger } from '@/components/animate-ui/components/animate/tabs';
@@ -18,38 +17,9 @@ export function Analytics() {
     const t = useTranslations('analytics');
     const [activeTab, setActiveTab] = useState<AnalyticsTab>('utilization');
     const [range, setRange] = useState<AnalyticsRange>('7d');
-    const subtitle = t('subtitle');
 
     return (
         <PageWrapper className="h-full min-h-0 overflow-y-auto overscroll-contain space-y-6 rounded-t-xl pb-24 md:pb-4">
-            <section className="relative overflow-hidden rounded-xl border border-border/35 bg-card p-5 text-card-foreground md:p-6">
-                <div className="relative flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                    <div className="flex items-start gap-4">
-                        <div className="grid h-14 w-14 shrink-0 place-items-center rounded-lg border border-border/35 bg-card text-primary">
-                            <BarChart3 className="h-5 w-5" />
-                        </div>
-                        <div className="min-w-0 space-y-3">
-                            <div className="inline-flex items-center gap-2 rounded-full border border-primary/15 bg-card px-3 py-1 text-[0.68rem] font-semibold text-primary">
-                                <Waves className="h-3.5 w-3.5" />
-                                {t('title')}
-                            </div>
-                            <div className="space-y-2">
-                                <h2 className="text-2xl font-bold tracking-tight md:text-[2rem]">{t('title')}</h2>
-                                {subtitle ? (
-                                    <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
-                                        {subtitle}
-                                    </p>
-                                ) : null}
-                            </div>
-                        </div>
-                    </div>
-                    <div className="flex items-center gap-2 self-start rounded-lg border border-border/25 bg-card px-3 py-2 text-sm text-muted-foreground">
-                        <Orbit className="h-4 w-4 text-primary" />
-                        {t(`range.${range}`)}
-                    </div>
-                </div>
-            </section>
-
             <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as AnalyticsTab)}>
                 <section className="relative overflow-hidden rounded-xl border border-border/35 bg-card p-4 text-card-foreground md:p-5">
                     <div className="relative flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">

--- a/web/src/components/modules/log/index.tsx
+++ b/web/src/components/modules/log/index.tsx
@@ -53,19 +53,29 @@ export function Log() {
     return (
         <div className="flex h-full min-h-0 flex-col gap-4">
             <div className="min-h-0 flex-1">
-                <VirtualizedGrid
-                    items={logs}
-                    layout="list"
-                    columns={{ default: 1 }}
-                    estimateItemHeight={80}
-                    overscan={8}
-                    getItemKey={(log) => `log-${log.id}`}
-                    renderItem={(log) => <LogCard log={log} channelNameById={channelNameById} />}
-                    footer={footer}
-                    onReachEnd={handleReachEnd}
-                    reachEndEnabled={canLoadMore}
-                    reachEndOffset={2}
-                />
+                {isLoading && logs.length === 0 ? (
+                    <div className="flex h-full min-h-[18rem] items-center justify-center rounded-xl border border-border/35 bg-card">
+                        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                    </div>
+                ) : logs.length === 0 ? (
+                    <div className="flex h-full min-h-[18rem] items-center justify-center rounded-xl border border-dashed border-border/35 bg-card px-6 text-center">
+                        <p className="text-sm text-muted-foreground">{t('list.empty')}</p>
+                    </div>
+                ) : (
+                    <VirtualizedGrid
+                        items={logs}
+                        layout="list"
+                        columns={{ default: 1 }}
+                        estimateItemHeight={80}
+                        overscan={8}
+                        getItemKey={(log) => `log-${log.id}`}
+                        renderItem={(log) => <LogCard log={log} channelNameById={channelNameById} />}
+                        footer={footer}
+                        onReachEnd={handleReachEnd}
+                        reachEndEnabled={canLoadMore}
+                        reachEndOffset={2}
+                    />
+                )}
             </div>
         </div>
     );

--- a/web/src/components/modules/model/MarketSummary.tsx
+++ b/web/src/components/modules/model/MarketSummary.tsx
@@ -65,25 +65,22 @@ export function ModelMarketSummary({
     return (
         <section className="relative overflow-hidden rounded-xl border border-border/35 bg-card p-3.5 text-card-foreground md:p-4.5">
             <div className="relative flex flex-col gap-3">
-                <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
-                    <h2 className="text-xl font-semibold tracking-tight md:text-2xl">{t('summary.title')}</h2>
-                    <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
-                        <div className="flex items-center gap-2 rounded-lg border-border/30 bg-card px-3 py-2 text-xs text-muted-foreground sm:text-sm">
-                            <Clock3 className="h-4 w-4 text-primary" />
-                            <span className="truncate">{t('summary.lastUpdate')}: {lastUpdateLabel}</span>
-                        </div>
-                        <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={onRefresh}
-                            disabled={isRefreshing}
-                            className="h-10 rounded-lg border-border/30 bg-card px-3.5"
-                        >
-                            <RefreshCw className={`mr-2 h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
-                            {isRefreshing ? t('summary.refreshing') : t('summary.refresh')}
-                        </Button>
+                <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
+                    <div className="flex items-center gap-2 rounded-lg border-border/30 bg-card px-3 py-2 text-xs text-muted-foreground sm:text-sm">
+                        <Clock3 className="h-4 w-4 text-primary" />
+                        <span className="truncate">{t('summary.lastUpdate')}: {lastUpdateLabel}</span>
                     </div>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={onRefresh}
+                        disabled={isRefreshing}
+                        className="h-10 rounded-lg border-border/30 bg-card px-3.5"
+                    >
+                        <RefreshCw className={`mr-2 h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+                        {isRefreshing ? t('summary.refreshing') : t('summary.refresh')}
+                    </Button>
                 </div>
 
                 <div className="grid grid-cols-2 gap-2 xl:grid-cols-4">

--- a/web/src/components/modules/model/index.tsx
+++ b/web/src/components/modules/model/index.tsx
@@ -9,7 +9,6 @@ import { sortModelMarketItems } from './sort';
 
 export function Model() {
     const { data: market } = useModelMarket();
-    const updateModelPrice = useUpdateModelPrice();
     const pageKey = 'model' as const;
     const searchTerm = useSearchStore((s) => s.getSearchTerm(pageKey));
     const layout = useToolbarViewOptionsStore((s) => s.getLayout(pageKey));

--- a/web/src/components/modules/model/index.tsx
+++ b/web/src/components/modules/model/index.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import { useModelMarket, useUpdateModelPrice } from '@/api/endpoints/model';
+import { useTranslations } from 'next-intl';
 import { ModelItem } from './Item';
 import { ModelMarketSummary } from './MarketSummary';
 import { useSearchStore, useToolbarViewOptionsStore } from '@/components/modules/toolbar';
@@ -9,6 +10,7 @@ import { VirtualizedGrid } from '@/components/common/VirtualizedGrid';
 import { sortModelMarketItems } from './sort';
 
 export function Model() {
+    const t = useTranslations('model');
     const { data: market } = useModelMarket();
     const updateModelPrice = useUpdateModelPrice();
     const pageKey = 'model' as const;
@@ -21,6 +23,7 @@ export function Model() {
         const items = market?.items ?? [];
         return sortModelMarketItems(items, modelSortMode);
     }, [market, modelSortMode]);
+    const hasAnyModel = (market?.items.length ?? 0) > 0;
 
     const visibleModels = useMemo(() => {
         const term = searchTerm.toLowerCase().trim();
@@ -67,10 +70,15 @@ export function Model() {
                         />
                     ) : (
                         <div className="relative flex h-full min-h-[18rem] items-center justify-center overflow-hidden rounded-xl border border-dashed border-border/35 bg-card">
-                            <div className="relative flex items-end gap-3">
-                                <span className="h-24 w-16 rounded-lg border border-border/30 bg-card" />
-                                <span className="h-28 w-20 rounded-xl border border-primary/18 bg-card" />
-                                <span className="h-20 w-14 rounded-lg border border-border/30 bg-card" />
+                            <div className="relative flex flex-col items-center gap-4 px-6 text-center">
+                                <div className="flex items-end gap-3">
+                                    <span className="h-24 w-16 rounded-lg border border-border/30 bg-card" />
+                                    <span className="h-28 w-20 rounded-xl border border-primary/18 bg-card" />
+                                    <span className="h-20 w-14 rounded-lg border border-border/30 bg-card" />
+                                </div>
+                                <p className="text-sm text-muted-foreground">
+                                    {hasAnyModel ? t('empty') : t('emptyAll')}
+                                </p>
                             </div>
                         </div>
                     )}

--- a/web/src/components/modules/model/index.tsx
+++ b/web/src/components/modules/model/index.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { useMemo } from 'react';
-import { useModelMarket, useUpdateModelPrice } from '@/api/endpoints/model';
+import { useModelMarket } from '@/api/endpoints/model';
 import { ModelItem } from './Item';
-import { ModelMarketSummary } from './MarketSummary';
 import { useSearchStore, useToolbarViewOptionsStore } from '@/components/modules/toolbar';
 import { VirtualizedGrid } from '@/components/common/VirtualizedGrid';
 import { sortModelMarketItems } from './sort';
@@ -38,22 +37,8 @@ export function Model() {
         return byName;
     }, [sortedModels, searchTerm, filter]);
 
-    const summary = market?.summary ?? {
-        model_count: 0,
-        coverage_count: 0,
-        unique_channel_count: 0,
-        average_latency_ms: 0,
-        last_update_time: '',
-    };
-
     return (
-        <section className="relative flex h-full min-h-0 flex-col gap-4" aria-label={pageKey}>
-            <ModelMarketSummary
-                summary={summary}
-                onRefresh={() => updateModelPrice.mutate()}
-                isRefreshing={updateModelPrice.isPending}
-            />
-
+        <section className="relative flex h-full min-h-0 flex-col" aria-label={pageKey}>
             <section className="relative flex min-h-0 flex-1 flex-col rounded-xl border border-border/35 bg-card p-3 text-card-foreground md:p-4">
                 <div className="relative min-h-0 flex-1">
                     {visibleModels.length > 0 ? (

--- a/web/src/components/modules/model/index.tsx
+++ b/web/src/components/modules/model/index.tsx
@@ -1,14 +1,16 @@
 'use client';
 
 import { useMemo } from 'react';
-import { useModelMarket } from '@/api/endpoints/model';
+import { useModelMarket, useUpdateModelPrice } from '@/api/endpoints/model';
 import { ModelItem } from './Item';
+import { ModelMarketSummary } from './MarketSummary';
 import { useSearchStore, useToolbarViewOptionsStore } from '@/components/modules/toolbar';
 import { VirtualizedGrid } from '@/components/common/VirtualizedGrid';
 import { sortModelMarketItems } from './sort';
 
 export function Model() {
     const { data: market } = useModelMarket();
+    const updateModelPrice = useUpdateModelPrice();
     const pageKey = 'model' as const;
     const searchTerm = useSearchStore((s) => s.getSearchTerm(pageKey));
     const layout = useToolbarViewOptionsStore((s) => s.getLayout(pageKey));
@@ -36,8 +38,22 @@ export function Model() {
         return byName;
     }, [sortedModels, searchTerm, filter]);
 
+    const summary = market?.summary ?? {
+        model_count: 0,
+        coverage_count: 0,
+        unique_channel_count: 0,
+        average_latency_ms: 0,
+        last_update_time: '',
+    };
+
     return (
-        <section className="relative flex h-full min-h-0 flex-col" aria-label={pageKey}>
+        <section className="relative flex h-full min-h-0 flex-col gap-4" aria-label={pageKey}>
+            <ModelMarketSummary
+                summary={summary}
+                onRefresh={() => updateModelPrice.mutate()}
+                isRefreshing={updateModelPrice.isPending}
+            />
+
             <section className="relative flex min-h-0 flex-1 flex-col rounded-xl border border-border/35 bg-card p-3 text-card-foreground md:p-4">
                 <div className="relative min-h-0 flex-1">
                     {visibleModels.length > 0 ? (

--- a/web/src/components/modules/ops/index.tsx
+++ b/web/src/components/modules/ops/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { Wrench } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { PageWrapper } from '@/components/common/PageWrapper';
 import { Tabs, TabsContents, TabsContent, TabsList, TabsTrigger } from '@/components/animate-ui/components/animate/tabs';
@@ -16,26 +15,9 @@ type OpsTab = 'cache' | 'quota' | 'health' | 'system' | 'audit';
 export function Ops() {
     const t = useTranslations('ops');
     const [activeTab, setActiveTab] = useState<OpsTab>('cache');
-    const subtitle = t('subtitle');
 
     return (
         <PageWrapper className="h-full min-h-0 overflow-y-auto overscroll-contain space-y-6 pb-24 md:pb-4 rounded-t-xl">
-            <section className="rounded-xl border border-border bg-card p-5 text-card-foreground">
-                <div className="flex items-start gap-4">
-                    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
-                        <Wrench className="h-5 w-5" />
-                    </div>
-                    <div className="min-w-0 space-y-2">
-                        <h2 className="text-2xl font-bold">{t('title')}</h2>
-                        {subtitle ? (
-                            <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
-                                {subtitle}
-                            </p>
-                        ) : null}
-                    </div>
-                </div>
-            </section>
-
             <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as OpsTab)}>
                 <section className="rounded-xl border border-border bg-card p-5 text-card-foreground">
                     <div className="overflow-x-auto">

--- a/web/src/components/modules/ops/index.tsx
+++ b/web/src/components/modules/ops/index.tsx
@@ -26,9 +26,17 @@ export function Ops() {
                         <Wrench className="h-5 w-5" />
                     </div>
                     {subtitle ? (
-                        <p className="min-w-0 max-w-3xl text-sm leading-6 text-muted-foreground">
-                            {subtitle}
-                        </p>
+                        <div className="min-w-0 space-y-3">
+                            <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+                                {subtitle}
+                            </p>
+                            <div className="flex flex-wrap gap-2 text-xs font-medium text-muted-foreground">
+                                <span className="rounded-lg border border-border/25 bg-card px-2.5 py-1">{t('tabs.cache')}</span>
+                                <span className="rounded-lg border border-border/25 bg-card px-2.5 py-1">{t('tabs.quota')}</span>
+                                <span className="rounded-lg border border-border/25 bg-card px-2.5 py-1">{t('tabs.health')}</span>
+                                <span className="rounded-lg border border-border/25 bg-card px-2.5 py-1">{t('tabs.system')}</span>
+                            </div>
+                        </div>
                     ) : null}
                 </div>
             </section>

--- a/web/src/components/modules/ops/index.tsx
+++ b/web/src/components/modules/ops/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { Wrench } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { PageWrapper } from '@/components/common/PageWrapper';
 import { Tabs, TabsContents, TabsContent, TabsList, TabsTrigger } from '@/components/animate-ui/components/animate/tabs';
@@ -15,9 +16,23 @@ type OpsTab = 'cache' | 'quota' | 'health' | 'system' | 'audit';
 export function Ops() {
     const t = useTranslations('ops');
     const [activeTab, setActiveTab] = useState<OpsTab>('cache');
+    const subtitle = t('subtitle');
 
     return (
         <PageWrapper className="h-full min-h-0 overflow-y-auto overscroll-contain space-y-6 pb-24 md:pb-4 rounded-t-xl">
+            <section className="rounded-xl border border-border bg-card p-5 text-card-foreground">
+                <div className="flex items-start gap-4">
+                    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                        <Wrench className="h-5 w-5" />
+                    </div>
+                    {subtitle ? (
+                        <p className="min-w-0 max-w-3xl text-sm leading-6 text-muted-foreground">
+                            {subtitle}
+                        </p>
+                    ) : null}
+                </div>
+            </section>
+
             <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as OpsTab)}>
                 <section className="rounded-xl border border-border bg-card p-5 text-card-foreground">
                     <div className="overflow-x-auto">

--- a/web/src/components/modules/setting/Appearance.tsx
+++ b/web/src/components/modules/setting/Appearance.tsx
@@ -318,7 +318,7 @@ export function SettingAppearance() {
                         </Select>
                     </div>
 
-                    <div className="grid gap-4 lg:grid-cols-3">
+                    <div className="grid gap-4 lg:grid-cols-2">
                         <div className="flex flex-col gap-4 rounded-lg border-border/30 bg-card p-4 shadow-sm">
                             <div className="flex items-center gap-3">
                                 <Languages className="h-5 w-5 text-muted-foreground" />

--- a/web/src/components/modules/setting/Retry.tsx
+++ b/web/src/components/modules/setting/Retry.tsx
@@ -47,16 +47,19 @@ export function SettingRetry() {
     };
 
     return (
-        <div className="rounded-xl border-border/35 bg-card p-6 space-y-5 text-card-foreground shadow-md ">
-            <h2 className="text-lg font-bold text-card-foreground flex items-center gap-2">
+        <div className="space-y-5 rounded-xl border-border/35 bg-card p-6 text-card-foreground shadow-md">
+            <h2 className="flex items-center gap-2 text-lg font-bold text-card-foreground">
                 <RotateCcw className="h-5 w-5" />
                 {t('retry.title')}
             </h2>
 
             <div className="space-y-4">
                 {RETRY_FIELDS.map((field) => (
-                    <div key={field.key} className="flex flex-col gap-3 rounded-lg border-border/30 bg-card p-4 shadow-sm md:flex-row md:items-center md:justify-between">
-                        <div className="flex flex-col gap-1">
+                    <div
+                        key={field.key}
+                        className="flex min-w-0 flex-col gap-3 rounded-lg border-border/30 bg-card p-4 shadow-sm md:flex-row md:items-center md:justify-between"
+                    >
+                        <div className="min-w-0 flex flex-col gap-1">
                             <span className="text-sm font-medium">{t(field.labelKey)}</span>
                             {field.hintKey ? (
                                 <span className="text-xs text-muted-foreground">{t(field.hintKey)}</span>
@@ -70,7 +73,7 @@ export function SettingRetry() {
                             onChange={(e) => setValues((prev) => ({ ...prev, [field.key]: e.target.value }))}
                             onBlur={() => handleSave(field.key)}
                             placeholder={t(field.placeholderKey)}
-                            className="w-48 rounded-xl"
+                            className="w-full rounded-xl md:w-48"
                         />
                     </div>
                 ))}

--- a/web/src/components/modules/setting/SemanticCache.tsx
+++ b/web/src/components/modules/setting/SemanticCache.tsx
@@ -165,9 +165,9 @@ export function SettingSemanticCache() {
     };
 
     return (
-        <div className="rounded-xl border border-border/35 bg-card p-6 space-y-5 text-card-foreground">
+        <div className="min-w-0 space-y-5 rounded-xl border border-border/35 bg-card p-6 text-card-foreground">
             <div className="space-y-1">
-                <h2 className="text-lg font-bold text-card-foreground flex items-center gap-2">
+                <h2 className="flex items-center gap-2 text-lg font-bold text-card-foreground">
                     <Database className="h-5 w-5" />
                     {t('semanticCache.title')}
                 </h2>
@@ -176,8 +176,8 @@ export function SettingSemanticCache() {
                 </p>
             </div>
 
-            <div className="flex items-center justify-between gap-4 rounded-lg border border-border/30 bg-card p-4">
-                <div className="flex items-center gap-3">
+            <div className="flex min-w-0 flex-col gap-3 rounded-lg border border-border/30 bg-card p-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0 flex items-center gap-3">
                     <Sparkles className="h-5 w-5 text-muted-foreground" />
                     <span className="text-sm font-medium">{t('semanticCache.enabled.label')}</span>
                 </div>
@@ -185,8 +185,8 @@ export function SettingSemanticCache() {
             </div>
 
             <div className="space-y-2 rounded-lg border border-border/30 bg-card p-4">
-                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                    <div className="flex items-center gap-3">
+                <div className="flex min-w-0 flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <div className="min-w-0 flex items-center gap-3">
                         <Clock3 className="h-5 w-5 text-muted-foreground" />
                         <span className="text-sm font-medium">{t('semanticCache.ttl.label')}</span>
                     </div>
@@ -197,7 +197,7 @@ export function SettingSemanticCache() {
                         onChange={(event) => setTTL(event.target.value)}
                         onBlur={() => saveTextSetting(SettingKey.SemanticCacheTTL, ttl)}
                         placeholder={t('semanticCache.ttl.placeholder')}
-                        className="w-72 rounded-xl"
+                        className="w-full rounded-xl md:w-72"
                     />
                 </div>
                 <p className="pl-8 text-xs text-muted-foreground">
@@ -206,8 +206,8 @@ export function SettingSemanticCache() {
             </div>
 
             <div className="space-y-2 rounded-lg border border-border/30 bg-card p-4">
-                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                    <div className="flex items-center gap-3">
+                <div className="flex min-w-0 flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <div className="min-w-0 flex items-center gap-3">
                         <Percent className="h-5 w-5 text-muted-foreground" />
                         <span className="text-sm font-medium">{t('semanticCache.threshold.label')}</span>
                     </div>
@@ -219,7 +219,7 @@ export function SettingSemanticCache() {
                         onChange={(event) => setThreshold(event.target.value)}
                         onBlur={() => saveTextSetting(SettingKey.SemanticCacheThreshold, threshold)}
                         placeholder={t('semanticCache.threshold.placeholder')}
-                        className="w-72 rounded-xl"
+                        className="w-full rounded-xl md:w-72"
                     />
                 </div>
                 <p className="pl-8 text-xs text-muted-foreground">
@@ -228,8 +228,8 @@ export function SettingSemanticCache() {
             </div>
 
             <div className="space-y-2 rounded-lg border border-border/30 bg-card p-4">
-                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                    <div className="flex items-center gap-3">
+                <div className="flex min-w-0 flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <div className="min-w-0 flex items-center gap-3">
                         <HardDrive className="h-5 w-5 text-muted-foreground" />
                         <span className="text-sm font-medium">{t('semanticCache.maxEntries.label')}</span>
                     </div>
@@ -240,7 +240,7 @@ export function SettingSemanticCache() {
                         onChange={(event) => setMaxEntries(event.target.value)}
                         onBlur={() => saveTextSetting(SettingKey.SemanticCacheMaxEntries, maxEntries)}
                         placeholder={t('semanticCache.maxEntries.placeholder')}
-                        className="w-72 rounded-xl"
+                        className="w-full rounded-xl md:w-72"
                     />
                 </div>
                 <p className="pl-8 text-xs text-muted-foreground">
@@ -258,8 +258,8 @@ export function SettingSemanticCache() {
                     </p>
                 </div>
 
-                <div className="flex items-center justify-between gap-4">
-                    <div className="flex items-center gap-3">
+                <div className="flex min-w-0 flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <div className="min-w-0 flex items-center gap-3">
                         <Link2 className="h-5 w-5 text-muted-foreground" />
                         <span className="text-sm font-medium">{t('semanticCache.baseUrl.label')}</span>
                     </div>
@@ -273,12 +273,12 @@ export function SettingSemanticCache() {
                             )
                         }
                         placeholder={t('semanticCache.baseUrl.placeholder')}
-                        className="w-72 rounded-xl"
+                        className="w-full rounded-xl md:w-72"
                     />
                 </div>
 
-                <div className="flex items-center justify-between gap-4">
-                    <div className="flex items-center gap-3">
+                <div className="flex min-w-0 flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <div className="min-w-0 flex items-center gap-3">
                         <KeyRound className="h-5 w-5 text-muted-foreground" />
                         <span className="text-sm font-medium">{t('semanticCache.apiKey.label')}</span>
                     </div>
@@ -293,12 +293,12 @@ export function SettingSemanticCache() {
                             )
                         }
                         placeholder={t('semanticCache.apiKey.placeholder')}
-                        className="w-72 rounded-xl"
+                        className="w-full rounded-xl md:w-72"
                     />
                 </div>
 
-                <div className="flex items-center justify-between gap-4">
-                    <div className="flex items-center gap-3">
+                <div className="flex min-w-0 flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <div className="min-w-0 flex items-center gap-3">
                         <Bot className="h-5 w-5 text-muted-foreground" />
                         <span className="text-sm font-medium">{t('semanticCache.model.label')}</span>
                     </div>
@@ -312,13 +312,13 @@ export function SettingSemanticCache() {
                             )
                         }
                         placeholder={t('semanticCache.model.placeholder')}
-                        className="w-72 rounded-xl"
+                        className="w-full rounded-xl md:w-72"
                     />
                 </div>
 
                 <div className="space-y-2">
-                    <div className="flex items-center justify-between gap-4">
-                        <div className="flex items-center gap-3">
+                    <div className="flex min-w-0 flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                        <div className="min-w-0 flex items-center gap-3">
                             <Clock3 className="h-5 w-5 text-muted-foreground" />
                             <span className="text-sm font-medium">{t('semanticCache.timeoutSeconds.label')}</span>
                         </div>
@@ -334,7 +334,7 @@ export function SettingSemanticCache() {
                                 )
                             }
                             placeholder={t('semanticCache.timeoutSeconds.placeholder')}
-                            className="w-72 rounded-xl"
+                            className="w-full rounded-xl md:w-72"
                         />
                     </div>
                     <p className="pl-8 text-xs text-muted-foreground">

--- a/web/src/components/modules/setting/index.tsx
+++ b/web/src/components/modules/setting/index.tsx
@@ -20,26 +20,18 @@ export function Setting() {
     return (
         <div className="h-full min-h-0 overflow-y-auto overscroll-contain rounded-t-xl">
             <PageWrapper className="pb-24 md:pb-6">
-                <div className="grid gap-5 xl:grid-cols-[minmax(0,1.42fr)_minmax(20rem,0.78fr)] xl:items-start">
-                    <div className="min-w-0 space-y-5">
-                        <div className="grid gap-5 2xl:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)] 2xl:items-start">
-                            <SettingAppearance key="setting-appearance" />
-                            <SettingAccount key="setting-account" />
-                        </div>
-
+                <div className="grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)_minmax(20rem,0.82fr)] xl:items-start">
+                    <div className="flex min-w-0 flex-col gap-5">
+                        <SettingAppearance key="setting-appearance" />
                         <SettingAIRoute key="setting-ai-route" />
+                        <SettingAutoStrategy key="setting-auto-strategy" />
+                    </div>
 
-                        <div className="grid gap-5 2xl:grid-cols-[minmax(0,1.1fr)_minmax(18rem,0.9fr)]">
-                            <SettingSemanticCache key="setting-semantic-cache" />
-                            <div className="flex min-w-0 flex-col gap-5">
-                                <SettingRetry key="setting-retry" />
-                            </div>
-                        </div>
-
-                        <div className="grid gap-5 2xl:grid-cols-2">
-                            <SettingAutoStrategy key="setting-auto-strategy" />
-                            <SettingLog key="setting-log" />
-                        </div>
+                    <div className="flex min-w-0 flex-col gap-5">
+                        <SettingAccount key="setting-account" />
+                        <SettingSemanticCache key="setting-semantic-cache" />
+                        <SettingRetry key="setting-retry" />
+                        <SettingLog key="setting-log" />
                     </div>
 
                     <div className="flex min-w-0 flex-col gap-5">

--- a/web/src/components/modules/setting/index.tsx
+++ b/web/src/components/modules/setting/index.tsx
@@ -17,32 +17,32 @@ import { SettingSemanticCache } from './SemanticCache';
 import { SettingRouteGroupDanger } from './RouteGroupDanger';
 
 export function Setting() {
+    const cards = [
+        { id: 'setting-appearance', node: <SettingAppearance /> },
+        { id: 'setting-ai-route', node: <SettingAIRoute /> },
+        { id: 'setting-auto-strategy', node: <SettingAutoStrategy /> },
+        { id: 'setting-account', node: <SettingAccount /> },
+        { id: 'setting-semantic-cache', node: <SettingSemanticCache /> },
+        { id: 'setting-retry', node: <SettingRetry /> },
+        { id: 'setting-log', node: <SettingLog /> },
+        { id: 'setting-info', node: <SettingInfo /> },
+        { id: 'setting-system', node: <SettingSystem /> },
+        { id: 'setting-llmprice', node: <SettingLLMPrice /> },
+        { id: 'setting-llmsync', node: <SettingLLMSync /> },
+        { id: 'setting-circuit-breaker', node: <SettingCircuitBreaker /> },
+        { id: 'setting-backup', node: <SettingBackup /> },
+        { id: 'setting-route-group-danger', node: <SettingRouteGroupDanger /> },
+    ];
+
     return (
         <div className="h-full min-h-0 overflow-y-auto overscroll-contain rounded-t-xl">
             <PageWrapper className="pb-24 md:pb-6">
-                <div className="grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)_minmax(20rem,0.82fr)] xl:items-start">
-                    <div className="flex min-w-0 flex-col gap-5">
-                        <SettingAppearance key="setting-appearance" />
-                        <SettingAIRoute key="setting-ai-route" />
-                        <SettingAutoStrategy key="setting-auto-strategy" />
-                    </div>
-
-                    <div className="flex min-w-0 flex-col gap-5">
-                        <SettingAccount key="setting-account" />
-                        <SettingSemanticCache key="setting-semantic-cache" />
-                        <SettingRetry key="setting-retry" />
-                        <SettingLog key="setting-log" />
-                    </div>
-
-                    <div className="flex min-w-0 flex-col gap-5">
-                        <SettingInfo key="setting-info" />
-                        <SettingSystem key="setting-system" />
-                        <SettingLLMPrice key="setting-llmprice" />
-                        <SettingLLMSync key="setting-llmsync" />
-                        <SettingCircuitBreaker key="setting-circuit-breaker" />
-                        <SettingBackup key="setting-backup" />
-                        <SettingRouteGroupDanger key="setting-route-group-danger" />
-                    </div>
+                <div className="columns-1 gap-5 lg:columns-2 xl:columns-3 [column-fill:balance]">
+                    {cards.map((card) => (
+                        <div key={card.id} className="mb-5 min-w-0 break-inside-avoid">
+                            {card.node}
+                        </div>
+                    ))}
                 </div>
             </PageWrapper>
         </div>

--- a/web/src/components/modules/setting/index.tsx
+++ b/web/src/components/modules/setting/index.tsx
@@ -22,27 +22,27 @@ export function Setting() {
             <PageWrapper className="pb-24 md:pb-6">
                 <div className="grid gap-5 xl:grid-cols-[minmax(0,1.42fr)_minmax(20rem,0.78fr)] xl:items-start">
                     <div className="min-w-0 space-y-5">
-                        <div className="grid gap-5 xl:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)] xl:items-start">
+                        <div className="grid gap-5 2xl:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)] 2xl:items-start">
                             <SettingAppearance key="setting-appearance" />
                             <SettingAccount key="setting-account" />
                         </div>
 
                         <SettingAIRoute key="setting-ai-route" />
 
-                        <div className="grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(18rem,0.9fr)]">
+                        <div className="grid gap-5 2xl:grid-cols-[minmax(0,1.1fr)_minmax(18rem,0.9fr)]">
                             <SettingSemanticCache key="setting-semantic-cache" />
                             <div className="flex min-w-0 flex-col gap-5">
                                 <SettingRetry key="setting-retry" />
                             </div>
                         </div>
 
-                        <div className="grid gap-5 xl:grid-cols-2">
+                        <div className="grid gap-5 2xl:grid-cols-2">
                             <SettingAutoStrategy key="setting-auto-strategy" />
                             <SettingLog key="setting-log" />
                         </div>
                     </div>
 
-                    <div className="flex min-w-0 flex-col gap-5 xl:sticky xl:top-0">
+                    <div className="flex min-w-0 flex-col gap-5">
                         <SettingInfo key="setting-info" />
                         <SettingSystem key="setting-system" />
                         <SettingLLMPrice key="setting-llmprice" />

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -19,9 +19,16 @@ function SelectGroup({
 }
 
 function SelectValue({
+  className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("min-w-0 flex-1 truncate text-left", className)}
+      {...props}
+    />
+  )
 }
 
 function SelectTrigger({
@@ -37,7 +44,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/30 focus-visible:ring-[4px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm whitespace-nowrap shadow-sm transition-[border-color,box-shadow,background-color] duration-150 outline-none hover:border-primary/20 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/30 focus-visible:ring-[4px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex min-w-0 w-fit items-center justify-between gap-2 overflow-hidden rounded-lg border border-border bg-card px-3 py-2 text-sm whitespace-nowrap shadow-sm transition-[border-color,box-shadow,background-color] duration-150 outline-none hover:border-primary/20 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}


### PR DESCRIPTION
## 变更内容

- 修复设置页在手机端横向溢出的问题。
- 优化设置页在桌面和 4K 宽屏下的三列布局，避免列高度和间距不协调。
- 修复语言、用户时区、告警发送语言等选择框内容显示不全的问题。
- 保留模型广场、分析中心、运维中心的顶部信息卡片，同时移除重复标题文字。
- 为渠道、模型广场、日志、告警规则、通知渠道补充空状态文案。
- 补齐相关英文、简体中文、繁体中文语言文案。

## 测试

- `node web/tests/i18n.test.mjs`
- Codespaces 中执行 `corepack pnpm build` 构建通过，无报错。