### PR TITLE
fix: preserve SuffixMode in ChannelBaseUrlDelayUpdate

### DIFF
--- a/internal/helper/channel.go
+++ b/internal/helper/channel.go
@@ -46,10 +46,11 @@ func ChannelBaseUrlDelayUpdate(channel *model.Channel, ctx context.Context) {
 		if err != nil {
 			log.Warnf("failed to get url delay (channel=%d): %v", channel.ID, err)
 			continue
-		}
+}
 		newBaseUrls = append(newBaseUrls, model.BaseUrl{
-			URL:   baseUrl.URL,
-			Delay: delay,
+			URL:        baseUrl.URL,
+			Delay:      delay,
+			SuffixMode: baseUrl.SuffixMode,
 		})
 	}
 	if len(newBaseUrls) > 0 {

--- a/web/src/components/modules/channel/CardContent.tsx
+++ b/web/src/components/modules/channel/CardContent.tsx
@@ -229,8 +229,8 @@ export function CardContent({ channel, stats }: { channel: Channel; stats: Stats
             <MorphingDialogDescription className="flex min-h-0 flex-1 flex-col">
                 <Tabs value={currentView} className="flex min-h-0 flex-1 flex-col">
                     <TabsContents className="min-h-0 flex-1">
-                        <TabsContent value="viewing" >
-                            <div className="max-h-[min(46rem,calc(100dvh-13rem))] space-y-4 overflow-y-auto pr-1 sm:space-y-5">
+                        <TabsContent value="viewing" className="flex min-h-0 flex-col">
+                            <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1 sm:space-y-5">
                                 <dl className="grid grid-cols-1 gap-3 sm:grid-cols-3">
                                     <div className="rounded-lg border border-chart-1/18 bg-linear-to-br from-chart-1/10 via-background/42 to-chart-1/5 p-3.5 shadow-sm sm:p-4">
                                         <dt className="flex items-center gap-2 mb-2 text-xs font-medium text-muted-foreground">
@@ -506,7 +506,7 @@ export function CardContent({ channel, stats }: { channel: Channel; stats: Stats
                                 </dl>
                             </div>
 
-                            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                            <div className="mt-4 grid shrink-0 gap-3 sm:grid-cols-2">
                                 <Button
                                     onClick={() => (isConfirmingDelete ? setIsConfirmingDelete(false) : setIsEditing(true))}
                                     variant={isConfirmingDelete ? 'secondary' : 'default'}


### PR DESCRIPTION
When ChannelBaseUrlDelayUpdate measures URL delay for each base URL, it reconstructs new BaseUrl objects but was dropping the SuffixMode field. This caused all channels with suffix_mode='custom' to fall back to auto-detect after the async delay probe ran, appending /v1 to URLs that already had a version path (e.g. /paas/v4 -> /paas/v4/v1).

Fixes: add SuffixMode: baseUrl.SuffixMode to the new BaseUrl struct.

以上内容为自动生成

修复newBaseUrls丢失SuffixMode字段，导致的自动识别模式未能正确根据前端用户选择保存数据，在linux-x86_64通过测试