### PR TITLE
fix(backup): export/import skip users to prevent empty passwords

### DIFF
--- a/internal/op/backup/backup.go
+++ b/internal/op/backup/backup.go
@@ -47,9 +47,10 @@ func ExportAll(ctx context.Context, includeLogs, includeStats bool) (*model.DBDu
 	if err := conn.Find(&d.APIKeys).Error; err != nil {
 		return nil, fmt.Errorf("export api_keys: %w", err)
 	}
-	if err := conn.Find(&d.Users).Error; err != nil {
-		return nil, fmt.Errorf("export users: %w", err)
-	}
+	// Users are intentionally NOT exported: User.Password is tagged
+	// json:"-" so it is omitted during JSON serialisation. If users
+	// were exported and later imported, every password would become
+	// an empty string, locking the admin out of the restored instance.
 	if err := conn.Find(&d.Settings).Error; err != nil {
 		return nil, fmt.Errorf("export settings: %w", err)
 	}
@@ -198,7 +199,7 @@ func ImportWithModeToDB(ctx context.Context, target *gorm.DB, dump *model.DBDump
 				"group_items", "channel_groups", "groups",
 				"alert_histories", "alert_state_records", "alert_rules", "alert_notif_channels",
 				"audit_logs", "auto_strategy_states", "circuit_breaker_states",
-				"api_keys", "users", "channel_keys", "channel_groups", "channels",
+				"api_keys", "channel_keys", "channels",
 				"llm_infos", "settings",
 			}
 			for i, table := range deleteOrder {
@@ -255,12 +256,11 @@ func ImportWithModeToDB(ctx context.Context, target *gorm.DB, dump *model.DBDump
 			return err
 		}
 
-		// Users — skip existing (backward compat: might be nil in old dumps)
-		if len(dump.Users) > 0 {
-			if err := cfg.doNothing("users", &dump.Users, len(dump.Users)); err != nil {
-				return err
-			}
-		}
+		// Users are intentionally NOT imported.
+		// Passwords are hashed (json:"-") so they are lost during export.
+		// Importing users would create accounts with empty passwords,
+		// locking the admin out of the restored instance.
+		// Users should be created manually on each instance.
 
 		// Settings — upsert by key
 		if err := cfg.upsertSettings(dump.Settings); err != nil {


### PR DESCRIPTION
## What

ExportAll导出users表时，因User.Password标记为json:"-"，密码哈希在JSON序列化时丢失。若备份文件被导入，所有用户密码变为空字符串，导致管理员无法登录。

## Changes

- ExportAll: 跳过users导出
- ImportWithModeToDB: 从deleteOrder中移除users；移除users的doNothing导入逻辑
- 顺手修复deleteOrder中channel_groups重复条目

## Design

不改User模型的json:"-" tag（API安全策略）。用户应在每个实例上手动创建，确保密码完整性。兼容旧备份文件（含users字段的dump不会导致空密码插入）。

## 测试

- [x] 导出备份文件，确认不含users字段
- [x] 全量导入备份，确认不删除现有用户
- [x] 增量导入备份，确认不覆盖现有用户密码
- [x] 导入旧备份文件（含users字段），确认不插入空密码用户
- [x] 实机测试通过