### PR TITLE
feat(setting): redesign settings page with dialog popups + drag-sort ordering

### DIFF
--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -1241,6 +1241,12 @@
       "minimumVisibleHint": "Keep at least {count} pages visible. The Settings page cannot be hidden.",
       "minimumVisibleError": "At least {count} pages must remain visible",
       "toggleAriaLabel": "Toggle page visibility: {page}"
+    },
+    "settingOrder": {
+      "title": "Setting Item Order",
+      "description": "Drag to reorder setting page sections. Changes are saved immediately on drop.",
+      "reset": "Reset to Default",
+      "resetSuccess": "Setting item order has been reset"
     }
   },
   "group": {

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -1241,6 +1241,12 @@
       "minimumVisibleHint": "最少保留 {count} 个页面；设置页面不可隐藏。",
       "minimumVisibleError": "最少需要保留 {count} 个页面",
       "toggleAriaLabel": "切换页面显示状态：{page}"
+    },
+    "settingOrder": {
+      "title": "设置项排序",
+      "description": "拖拽调整设置页面各选项的排列顺序，松手后立即保存。",
+      "reset": "恢复默认顺序",
+      "resetSuccess": "设置项顺序已恢复默认"
     }
   },
   "group": {

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -1241,6 +1241,12 @@
       "minimumVisibleHint": "最少保留 {count} 個頁面；設定頁面不可隱藏。",
       "minimumVisibleError": "最少需要保留 {count} 個頁面",
       "toggleAriaLabel": "切換頁面顯示狀態：{page}"
+    },
+    "settingOrder": {
+      "title": "設定項排序",
+      "description": "拖曳調整設定頁面各選項的排列順序，放開後立即儲存。",
+      "reset": "恢復預設順序",
+      "resetSuccess": "設定項順序已恢復預設"
     }
   },
   "group": {

--- a/web/src/components/modules/setting/Appearance.tsx
+++ b/web/src/components/modules/setting/Appearance.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTheme } from 'next-themes';
+import { SettingOrder } from './SettingOrder';
 import { useTranslations } from 'next-intl';
 import { Bell, Clock3, GripVertical, Languages, ListOrdered, Monitor, Moon, RotateCcw, Sun } from 'lucide-react';
 import {
@@ -375,6 +376,7 @@ export function SettingAppearance() {
                     </div>
 
                     <NavigationPreferences />
+                    <SettingOrder />
                 </div>
             </div>
         </div>

--- a/web/src/components/modules/setting/SettingOrder.tsx
+++ b/web/src/components/modules/setting/SettingOrder.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useCallback, useState, useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import { GripVertical, ListOrdered, RotateCcw } from 'lucide-react';
+import {
+    DragDropContext,
+    Draggable,
+    Droppable,
+    type DraggableProvided,
+    type DropResult,
+} from '@hello-pangea/dnd';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { toast } from '@/components/common/Toast';
+
+export type SettingItemId =
+    | 'appearance'
+    | 'ai-route'
+    | 'auto-strategy'
+    | 'account'
+    | 'semantic-cache'
+    | 'retry'
+    | 'log'
+    | 'info'
+    | 'system'
+    | 'llmsync'
+    | 'circuit-breaker'
+    | 'backup'
+    | 'route-group-danger';
+
+export const DEFAULT_SETTING_ORDER: SettingItemId[] = [
+    'appearance',
+    'ai-route',
+    'auto-strategy',
+    'account',
+    'semantic-cache',
+    'retry',
+    'log',
+    'info',
+    'system',
+    'llmsync',
+    'circuit-breaker',
+    'backup',
+    'route-group-danger',
+];
+
+export const SETTING_ORDER_STORAGE_KEY = 'octopus-setting-order';
+
+function loadStoredOrder(): SettingItemId[] {
+    try {
+        const raw = localStorage.getItem(SETTING_ORDER_STORAGE_KEY);
+        if (!raw) return [...DEFAULT_SETTING_ORDER];
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [...DEFAULT_SETTING_ORDER];
+        const filtered = parsed.filter((id): id is SettingItemId =>
+            DEFAULT_SETTING_ORDER.includes(id as SettingItemId)
+        );
+        const missing = DEFAULT_SETTING_ORDER.filter((id) => !filtered.includes(id));
+        return [...filtered, ...missing];
+    } catch {
+        return [...DEFAULT_SETTING_ORDER];
+    }
+}
+
+function persistOrder(items: readonly SettingItemId[]) {
+    localStorage.setItem(SETTING_ORDER_STORAGE_KEY, JSON.stringify(items));
+}
+
+function reorderList<T>(list: readonly T[], startIndex: number, endIndex: number): T[] {
+    const result = [...list];
+    const [removed] = result.splice(startIndex, 1);
+    result.splice(endIndex, 0, removed);
+    return result;
+}
+
+export function useSettingOrder() {
+    const [order, setOrder] = useState<SettingItemId[]>(loadStoredOrder);
+
+    const handleDragEnd = useCallback((result: DropResult) => {
+        const { destination, source } = result;
+        if (!destination || destination.index === source.index) return;
+        setOrder((prev) => {
+            const next = reorderList(prev, source.index, destination.index);
+            persistOrder(next);
+            return next;
+        });
+    }, []);
+
+    const reset = useCallback(() => {
+        const def = [...DEFAULT_SETTING_ORDER];
+        setOrder(def);
+        persistOrder(def);
+    }, []);
+
+    return { order, handleDragEnd, reset };
+}
+
+export function SettingOrder() {
+    const t = useTranslations('setting');
+    const { order, handleDragEnd, reset } = useSettingOrder();
+    const settingT = useTranslations('setting');
+
+    const titleByKey = useMemo(() => {
+        const map: Record<SettingItemId, string> = {
+            appearance: settingT('appearance'),
+            'ai-route': settingT('aiRoute.title'),
+            'auto-strategy': settingT('autoStrategy.title'),
+            account: settingT('account.title'),
+            'semantic-cache': settingT('semanticCache.title'),
+            retry: settingT('retry.title'),
+            log: settingT('log.title'),
+            info: settingT('info.title'),
+            system: settingT('system'),
+            llmsync: settingT('llmSync.title'),
+            'circuit-breaker': settingT('circuitBreaker.title'),
+            backup: settingT('backup.title'),
+            'route-group-danger': settingT('routeGroups.title'),
+        };
+        return map;
+    }, [settingT]);
+
+    return (
+        <div className="space-y-4 rounded-lg border-border/30 bg-card p-4 shadow-sm">
+            <div className="flex items-start justify-between gap-3">
+                <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                        <ListOrdered className="size-4 text-muted-foreground" />
+                        <h3 className="text-sm font-semibold text-foreground">{t('settingOrder.title')}</h3>
+                    </div>
+                    <p className="text-xs leading-5 text-muted-foreground">{t('settingOrder.description')}</p>
+                </div>
+
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                        reset();
+                        toast.success(t('settingOrder.resetSuccess'));
+                    }}
+                    className="shrink-0 rounded-xl"
+                >
+                    <RotateCcw className="mr-1.5 size-3.5" />
+                    {t('settingOrder.reset')}
+                </Button>
+            </div>
+
+            <div className="rounded-lg border border-border/30 bg-card p-1.5 shadow-sm">
+                <DragDropContext onDragEnd={handleDragEnd}>
+                    <Droppable droppableId="setting-item-order">
+                        {(droppableProvided) => (
+                            <div
+                                ref={droppableProvided.innerRef}
+                                {...droppableProvided.droppableProps}
+                                className="max-h-[24rem] space-y-2 overflow-y-auto p-2 pr-3"
+                            >
+                                {order.map((id, index) => (
+                                    <Draggable key={id} draggableId={id} index={index}>
+                                        {(draggableProvided, snapshot) => (
+                                            <div
+                                                ref={draggableProvided.innerRef}
+                                                {...draggableProvided.draggableProps}
+                                                className={cn(
+                                                    'flex items-center gap-3 rounded-lg border-border/30 bg-card px-3 py-3 shadow-sm transition-[transform,border-color,box-shadow]',
+                                                    snapshot.isDragging && 'border-primary/40 shadow-md'
+                                                )}
+                                                style={draggableProvided.draggableProps.style}
+                                            >
+                                                <span className="grid size-7 shrink-0 place-items-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+                                                    {index + 1}
+                                                </span>
+                                                <div
+                                                    className="rounded-lg p-1 text-muted-foreground"
+                                                    {...(draggableProvided.dragHandleProps as DraggableProvided['dragHandleProps'])}
+                                                >
+                                                    <GripVertical className="size-4" />
+                                                </div>
+                                                <span className="truncate text-sm font-medium text-foreground">
+                                                    {titleByKey[id]}
+                                                </span>
+                                            </div>
+                                        )}
+                                    </Draggable>
+                                ))}
+                                {droppableProvided.placeholder}
+                            </div>
+                        )}
+                    </Droppable>
+                </DragDropContext>
+            </div>
+        </div>
+    );
+}

--- a/web/src/components/modules/setting/index.tsx
+++ b/web/src/components/modules/setting/index.tsx
@@ -3,9 +3,9 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import {
-    Sun, User, Database, Cog, Shield, RotateCcw, Zap,
-    ScrollText, Monitor, RefreshCw, AlertTriangle, ChevronsUpDown,
-    Info,
+    Sun, User, Database, Shield, RotateCcw, Zap,
+    ScrollText, Monitor, RefreshCw, ChevronsUpDown,
+    Info, Bot, Sparkles, FolderX,
 } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { SettingAppearance } from './Appearance';
@@ -31,18 +31,18 @@ type SettingItem = {
 
 const SETTING_ITEMS: SettingItem[] = [
     { id: 'appearance',        icon: <Sun className="h-5 w-5" />,              titleKey: 'appearance',           component: <SettingAppearance /> },
-    { id: 'ai-route',          icon: <Zap className="h-5 w-5" />,               titleKey: 'aiRoute.title',        component: <SettingAIRoute /> },
-    { id: 'auto-strategy',     icon: <Cog className="h-5 w-5" />,               titleKey: 'autoStrategy.title',   component: <SettingAutoStrategy /> },
+    { id: 'ai-route',          icon: <Bot className="h-5 w-5" />,              titleKey: 'aiRoute.title',        component: <SettingAIRoute /> },
+    { id: 'auto-strategy',     icon: <Sparkles className="h-5 w-5" />,         titleKey: 'autoStrategy.title',   component: <SettingAutoStrategy /> },
     { id: 'account',           icon: <User className="h-5 w-5" />,              titleKey: 'account.title',         component: <SettingAccount /> },
     { id: 'semantic-cache',    icon: <Database className="h-5 w-5" />,          titleKey: 'semanticCache.title',  component: <SettingSemanticCache /> },
     { id: 'retry',             icon: <RotateCcw className="h-5 w-5" />,         titleKey: 'retry.title',          component: <SettingRetry /> },
     { id: 'log',               icon: <ScrollText className="h-5 w-5" />,        titleKey: 'log.title',            component: <SettingLog /> },
-    { id: 'info',              icon: <Info className="h-5 w-5" />,            titleKey: 'info.title',           component: <SettingInfo /> },
-    { id: 'system',            icon: <Monitor className="h-5 w-5" />,         titleKey: 'system',               component: <SettingSystem /> },
-    { id: 'llmsync',           icon: <RefreshCw className="h-5 w-5" />,      titleKey: 'llmSync.title',        component: <SettingLLMSync /> },
-    { id: 'circuit-breaker',   icon: <Shield className="h-5 w-5" />,            titleKey: 'circuitBreaker.title', component: <SettingCircuitBreaker /> },
+    { id: 'info',              icon: <Info className="h-5 w-5" />,              titleKey: 'info.title',           component: <SettingInfo /> },
+    { id: 'system',            icon: <Monitor className="h-5 w-5" />,           titleKey: 'system',               component: <SettingSystem /> },
+    { id: 'llmsync',           icon: <RefreshCw className="h-5 w-5" />,        titleKey: 'llmSync.title',        component: <SettingLLMSync /> },
+    { id: 'circuit-breaker',   icon: <Zap className="h-5 w-5" />,              titleKey: 'circuitBreaker.title', component: <SettingCircuitBreaker /> },
     { id: 'backup',            icon: <Database className="h-5 w-5" />,          titleKey: 'backup.title',         component: <SettingBackup /> },
-    { id: 'route-group-danger',icon: <AlertTriangle className="h-5 w-5" />,     titleKey: 'routeGroups.title',    component: <SettingRouteGroupDanger /> },
+    { id: 'route-group-danger',icon: <FolderX className="h-5 w-5" />,          titleKey: 'routeGroups.title',    component: <SettingRouteGroupDanger /> },
 ];
 
 export function Setting() {

--- a/web/src/components/modules/setting/index.tsx
+++ b/web/src/components/modules/setting/index.tsx
@@ -3,10 +3,11 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import {
-    Sun, User, Database, Cog, Shield, RotateCcw, Bell, Route, Zap,
-    ScrollText, Globe, Server, KeyRound, AlertTriangle, ChevronsUpDown,
+    Sun, User, Database, Cog, Shield, RotateCcw, Zap,
+    ScrollText, Monitor, RefreshCw, AlertTriangle, ChevronsUpDown,
+    Info,
 } from 'lucide-react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { SettingAppearance } from './Appearance';
 import { SettingAccount } from './Account';
 import { SettingBackup } from './Backup';
@@ -36,9 +37,9 @@ const SETTING_ITEMS: SettingItem[] = [
     { id: 'semantic-cache',    icon: <Database className="h-5 w-5" />,          titleKey: 'semanticCache.title',  component: <SettingSemanticCache /> },
     { id: 'retry',             icon: <RotateCcw className="h-5 w-5" />,         titleKey: 'retry.title',          component: <SettingRetry /> },
     { id: 'log',               icon: <ScrollText className="h-5 w-5" />,        titleKey: 'log.title',            component: <SettingLog /> },
-    { id: 'info',              icon: <AlertTriangle className="h-5 w-5" />,     titleKey: 'info.title',           component: <SettingInfo /> },
-    { id: 'system',            icon: <Server className="h-5 w-5" />,             titleKey: 'system',               component: <SettingSystem /> },
-    { id: 'llmsync',           icon: <KeyRound className="h-5 w-5" />,          titleKey: 'llmSync.title',        component: <SettingLLMSync /> },
+    { id: 'info',              icon: <Info className="h-5 w-5" />,            titleKey: 'info.title',           component: <SettingInfo /> },
+    { id: 'system',            icon: <Monitor className="h-5 w-5" />,         titleKey: 'system',               component: <SettingSystem /> },
+    { id: 'llmsync',           icon: <RefreshCw className="h-5 w-5" />,      titleKey: 'llmSync.title',        component: <SettingLLMSync /> },
     { id: 'circuit-breaker',   icon: <Shield className="h-5 w-5" />,            titleKey: 'circuitBreaker.title', component: <SettingCircuitBreaker /> },
     { id: 'backup',            icon: <Database className="h-5 w-5" />,          titleKey: 'backup.title',         component: <SettingBackup /> },
     { id: 'route-group-danger',icon: <AlertTriangle className="h-5 w-5" />,     titleKey: 'routeGroups.title',    component: <SettingRouteGroupDanger /> },
@@ -72,19 +73,7 @@ export function Setting() {
 
             <Dialog open={openId !== null} onOpenChange={(open) => { if (!open) setOpenId(null); }}>
                 <DialogContent className="w-[min(95vw,720px)] max-h-[90vh] overflow-y-auto p-0 gap-0 sm:rounded-2xl">
-                    {activeItem && (
-                        <>
-                            <DialogHeader className="px-6 pt-5 pb-3 border-b border-border/30">
-                                <DialogTitle className="flex items-center gap-2 text-base font-bold">
-                                    {activeItem.icon}
-                                    {t(activeItem.titleKey)}
-                                </DialogTitle>
-                            </DialogHeader>
-                            <div className="px-6 py-5">
-                                {activeItem.component}
-                            </div>
-                        </>
-                    )}
+                    {activeItem && activeItem.component}
                 </DialogContent>
             </Dialog>
         </div>

--- a/web/src/components/modules/setting/index.tsx
+++ b/web/src/components/modules/setting/index.tsx
@@ -21,15 +21,16 @@ import { SettingAutoStrategy } from './AutoStrategy';
 import { SettingAIRoute } from './AIRoute';
 import { SettingSemanticCache } from './SemanticCache';
 import { SettingRouteGroupDanger } from './RouteGroupDanger';
+import { DEFAULT_SETTING_ORDER } from './SettingOrder';
 
-type SettingItem = {
+type SettingItemDef = {
     id: string;
     icon: React.ReactNode;
     titleKey: string;
     component: React.ReactNode;
 };
 
-const SETTING_ITEMS: SettingItem[] = [
+const SETTING_ITEM_DEFS: SettingItemDef[] = [
     { id: 'appearance',        icon: <Sun className="h-5 w-5" />,              titleKey: 'appearance',           component: <SettingAppearance /> },
     { id: 'ai-route',          icon: <Bot className="h-5 w-5" />,              titleKey: 'aiRoute.title',        component: <SettingAIRoute /> },
     { id: 'auto-strategy',     icon: <Sparkles className="h-5 w-5" />,         titleKey: 'autoStrategy.title',   component: <SettingAutoStrategy /> },
@@ -45,16 +46,56 @@ const SETTING_ITEMS: SettingItem[] = [
     { id: 'route-group-danger',icon: <FolderX className="h-5 w-5" />,          titleKey: 'routeGroups.title',    component: <SettingRouteGroupDanger /> },
 ];
 
+const SETTING_ITEM_MAP = new Map<string, SettingItemDef>(
+    SETTING_ITEM_DEFS.map((def) => [def.id, def])
+);
+
+function getOrderedItems(order: string[]): SettingItemDef[] {
+    const seen = new Set<string>();
+    const result: SettingItemDef[] = [];
+    for (const id of order) {
+        const def = SETTING_ITEM_MAP.get(id);
+        if (def && !seen.has(id)) {
+            seen.add(id);
+            result.push(def);
+        }
+    }
+    // append any missing defaults
+    for (const def of SETTING_ITEM_DEFS) {
+        if (!seen.has(def.id)) {
+            result.push(def);
+        }
+    }
+    return result;
+}
+
+function loadOrder(): string[] {
+    try {
+        const raw = localStorage.getItem('octopus-setting-order');
+        if (!raw) return [...DEFAULT_SETTING_ORDER];
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [...DEFAULT_SETTING_ORDER];
+        const filtered = parsed.filter((id: unknown) =>
+            typeof id === 'string' && SETTING_ITEM_MAP.has(id)
+        );
+        const missing = DEFAULT_SETTING_ORDER.filter((id) => !filtered.includes(id));
+        return [...filtered, ...missing];
+    } catch {
+        return [...DEFAULT_SETTING_ORDER];
+    }
+}
+
 export function Setting() {
     const t = useTranslations('setting');
     const [openId, setOpenId] = useState<string | null>(null);
-    const activeItem = SETTING_ITEMS.find((item) => item.id === openId);
+    const items = getOrderedItems(loadOrder());
+    const activeItem = items.find((item) => item.id === openId);
 
     return (
         <div className="h-full min-h-0 overflow-y-auto overscroll-contain rounded-t-xl">
             <div className="pb-24 md:pb-6 px-4 md:px-6 pt-4">
                 <div className="space-y-2 max-w-2xl mx-auto">
-                    {SETTING_ITEMS.map((item) => (
+                    {items.map((item) => (
                         <button
                             key={item.id}
                             type="button"

--- a/web/src/components/modules/setting/index.tsx
+++ b/web/src/components/modules/setting/index.tsx
@@ -32,15 +32,15 @@ const SETTING_ITEMS: SettingItem[] = [
     { id: 'appearance',        icon: <Sun className="h-5 w-5" />,              titleKey: 'appearance',           component: <SettingAppearance /> },
     { id: 'ai-route',          icon: <Zap className="h-5 w-5" />,               titleKey: 'aiRoute.title',        component: <SettingAIRoute /> },
     { id: 'auto-strategy',     icon: <Cog className="h-5 w-5" />,               titleKey: 'autoStrategy.title',   component: <SettingAutoStrategy /> },
-    { id: 'account',           icon: <User className="h-5 w-5" />,              titleKey: 'account',              component: <SettingAccount /> },
+    { id: 'account',           icon: <User className="h-5 w-5" />,              titleKey: 'account.title',         component: <SettingAccount /> },
     { id: 'semantic-cache',    icon: <Database className="h-5 w-5" />,          titleKey: 'semanticCache.title',  component: <SettingSemanticCache /> },
     { id: 'retry',             icon: <RotateCcw className="h-5 w-5" />,         titleKey: 'retry.title',          component: <SettingRetry /> },
-    { id: 'log',               icon: <ScrollText className="h-5 w-5" />,        titleKey: 'log',                  component: <SettingLog /> },
+    { id: 'log',               icon: <ScrollText className="h-5 w-5" />,        titleKey: 'log.title',            component: <SettingLog /> },
     { id: 'info',              icon: <AlertTriangle className="h-5 w-5" />,     titleKey: 'info.title',           component: <SettingInfo /> },
     { id: 'system',            icon: <Server className="h-5 w-5" />,             titleKey: 'system',               component: <SettingSystem /> },
     { id: 'llmsync',           icon: <KeyRound className="h-5 w-5" />,          titleKey: 'llmSync.title',        component: <SettingLLMSync /> },
     { id: 'circuit-breaker',   icon: <Shield className="h-5 w-5" />,            titleKey: 'circuitBreaker.title', component: <SettingCircuitBreaker /> },
-    { id: 'backup',            icon: <Database className="h-5 w-5" />,          titleKey: 'backup',               component: <SettingBackup /> },
+    { id: 'backup',            icon: <Database className="h-5 w-5" />,          titleKey: 'backup.title',         component: <SettingBackup /> },
     { id: 'route-group-danger',icon: <AlertTriangle className="h-5 w-5" />,     titleKey: 'routeGroups.title',    component: <SettingRouteGroupDanger /> },
 ];
 

--- a/web/src/components/modules/setting/index.tsx
+++ b/web/src/components/modules/setting/index.tsx
@@ -1,13 +1,19 @@
 'use client';
 
-import { PageWrapper } from '@/components/common/PageWrapper';
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+    Sun, User, Database, Cog, Shield, RotateCcw, Bell, Route, Zap,
+    ScrollText, Globe, Server, KeyRound, AlertTriangle, ChevronsUpDown,
+} from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { SettingAppearance } from './Appearance';
-import { SettingSystem } from './System';
 import { SettingAccount } from './Account';
+import { SettingBackup } from './Backup';
+import { SettingSystem } from './System';
 import { SettingInfo } from './Info';
 import { SettingLLMSync } from './LLMSync';
 import { SettingLog } from './Log';
-import { SettingBackup } from './Backup';
 import { SettingCircuitBreaker } from './CircuitBreaker';
 import { SettingRetry } from './Retry';
 import { SettingAutoStrategy } from './AutoStrategy';
@@ -15,34 +21,72 @@ import { SettingAIRoute } from './AIRoute';
 import { SettingSemanticCache } from './SemanticCache';
 import { SettingRouteGroupDanger } from './RouteGroupDanger';
 
+type SettingItem = {
+    id: string;
+    icon: React.ReactNode;
+    titleKey: string;
+    component: React.ReactNode;
+};
+
+const SETTING_ITEMS: SettingItem[] = [
+    { id: 'appearance',        icon: <Sun className="h-5 w-5" />,              titleKey: 'appearance',           component: <SettingAppearance /> },
+    { id: 'ai-route',          icon: <Zap className="h-5 w-5" />,               titleKey: 'aiRoute.title',        component: <SettingAIRoute /> },
+    { id: 'auto-strategy',     icon: <Cog className="h-5 w-5" />,               titleKey: 'autoStrategy.title',   component: <SettingAutoStrategy /> },
+    { id: 'account',           icon: <User className="h-5 w-5" />,              titleKey: 'account',              component: <SettingAccount /> },
+    { id: 'semantic-cache',    icon: <Database className="h-5 w-5" />,          titleKey: 'semanticCache.title',  component: <SettingSemanticCache /> },
+    { id: 'retry',             icon: <RotateCcw className="h-5 w-5" />,         titleKey: 'retry.title',          component: <SettingRetry /> },
+    { id: 'log',               icon: <ScrollText className="h-5 w-5" />,        titleKey: 'log',                  component: <SettingLog /> },
+    { id: 'info',              icon: <AlertTriangle className="h-5 w-5" />,     titleKey: 'info.title',           component: <SettingInfo /> },
+    { id: 'system',            icon: <Server className="h-5 w-5" />,             titleKey: 'system',               component: <SettingSystem /> },
+    { id: 'llmsync',           icon: <KeyRound className="h-5 w-5" />,          titleKey: 'llmSync.title',        component: <SettingLLMSync /> },
+    { id: 'circuit-breaker',   icon: <Shield className="h-5 w-5" />,            titleKey: 'circuitBreaker.title', component: <SettingCircuitBreaker /> },
+    { id: 'backup',            icon: <Database className="h-5 w-5" />,          titleKey: 'backup',               component: <SettingBackup /> },
+    { id: 'route-group-danger',icon: <AlertTriangle className="h-5 w-5" />,     titleKey: 'routeGroups.title',    component: <SettingRouteGroupDanger /> },
+];
+
 export function Setting() {
-    const cards = [
-        { id: 'setting-appearance', node: <SettingAppearance /> },
-        { id: 'setting-ai-route', node: <SettingAIRoute /> },
-        { id: 'setting-auto-strategy', node: <SettingAutoStrategy /> },
-        { id: 'setting-account', node: <SettingAccount /> },
-        { id: 'setting-semantic-cache', node: <SettingSemanticCache /> },
-        { id: 'setting-retry', node: <SettingRetry /> },
-        { id: 'setting-log', node: <SettingLog /> },
-        { id: 'setting-info', node: <SettingInfo /> },
-        { id: 'setting-system', node: <SettingSystem /> },
-        { id: 'setting-llmsync', node: <SettingLLMSync /> },
-        { id: 'setting-circuit-breaker', node: <SettingCircuitBreaker /> },
-        { id: 'setting-backup', node: <SettingBackup /> },
-        { id: 'setting-route-group-danger', node: <SettingRouteGroupDanger /> },
-    ];
+    const t = useTranslations('setting');
+    const [openId, setOpenId] = useState<string | null>(null);
+    const activeItem = SETTING_ITEMS.find((item) => item.id === openId);
 
     return (
         <div className="h-full min-h-0 overflow-y-auto overscroll-contain rounded-t-xl">
-            <PageWrapper className="pb-24 md:pb-6">
-                <div className="columns-1 gap-5 lg:columns-2 xl:columns-3 [column-fill:balance]">
-                    {cards.map((card) => (
-                        <div key={card.id} className="mb-5 min-w-0 break-inside-avoid">
-                            {card.node}
-                        </div>
+            <div className="pb-24 md:pb-6 px-4 md:px-6 pt-4">
+                <div className="space-y-2 max-w-2xl mx-auto">
+                    {SETTING_ITEMS.map((item) => (
+                        <button
+                            key={item.id}
+                            type="button"
+                            onClick={() => setOpenId(item.id)}
+                            className="w-full flex items-center gap-3 rounded-xl border border-border/35 bg-card px-4 py-3.5 text-left shadow-sm transition-colors hover:bg-accent/40 active:bg-accent/60"
+                        >
+                            <span className="shrink-0 text-muted-foreground">{item.icon}</span>
+                            <span className="flex-1 text-sm font-semibold text-card-foreground truncate">
+                                {t(item.titleKey)}
+                            </span>
+                            <ChevronsUpDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        </button>
                     ))}
                 </div>
-            </PageWrapper>
+            </div>
+
+            <Dialog open={openId !== null} onOpenChange={(open) => { if (!open) setOpenId(null); }}>
+                <DialogContent className="w-[min(95vw,720px)] max-h-[90vh] overflow-y-auto p-0 gap-0 sm:rounded-2xl">
+                    {activeItem && (
+                        <>
+                            <DialogHeader className="px-6 pt-5 pb-3 border-b border-border/30">
+                                <DialogTitle className="flex items-center gap-2 text-base font-bold">
+                                    {activeItem.icon}
+                                    {t(activeItem.titleKey)}
+                                </DialogTitle>
+                            </DialogHeader>
+                            <div className="px-6 py-5">
+                                {activeItem.component}
+                            </div>
+                        </>
+                    )}
+                </DialogContent>
+            </Dialog>
         </div>
     );
 }


### PR DESCRIPTION
重构设置页面交互：瀑布流 → 弹窗展开 + 自定义排序

改动范围：仅前端 setting 页面，共 6 个文件，+313 / -25 行

## 问题

上游原生设置页面使用瀑布流（multi-column masonry layout）排列所有设置项卡片。在设置项数量较多的情况下（共 13 个），存在以下问题：

1. 所有卡片同时铺开，页面纵向过长，查找目标设置项需要大量滚动
2. 卡片跨列排列时视觉动线不规律，扫视效率低
3. 某些卡片内容较长时会进一步撑高页面，加剧滚动负担

## 方案

### 1. 设置项改为卡片列表 + 弹窗展开

将原有的瀑布流卡片布局改为垂直排列的紧凑卡片列表，点击后通过 Dialog 弹窗打开对应内容。用户可快速定位和切换不同设置项，不受页面滚动位置限制。

### 2. 新增设置项自定义排序

在「外观」页面底部新增「设置项排序」模块（位于「页面顺序与显示」下方）：

- 拖拽调整各设置项的排列顺序
- 松手后立即持久化到 `localStorage`
- 支持一键恢复默认顺序
- 设置页面的卡片列表按保存的顺序渲染

## 文件变更

| 文件 | 说明 |
|---|---|
| `setting/index.tsx` | 重构为卡片列表 + 弹窗展开模式；card 列表支持自定义顺序渲染 |
| `setting/SettingOrder.tsx` | 新增：拖拽排序组件（`@hello-pangea/dnd`，已有依赖） |
| `setting/Appearance.tsx` | 集成 SettingOrder 组件 |
| `locale/zh_hans.json` | 新增 `settingOrder.*` 简体中文翻译 |
| `locale/zh_hant.json` | 新增 `settingOrder.*` 繁体中文翻译 |
| `locale/en.json` | 新增 `settingOrder.*` 英文翻译 |