### PR TITLE
fix(web): 优化首页排行与 CC Switch 弹窗布局

### DIFF
--- a/web/src/components/modules/group/CCSwitchLinkButton.tsx
+++ b/web/src/components/modules/group/CCSwitchLinkButton.tsx
@@ -326,11 +326,9 @@ export function CCSwitchLinkButton({ className }: { className?: string }) {
                         </div>
                     </MorphingDialogDescription>
 
-                    <div className="mt-4 shrink-0">
-                        <MorphingDialogClose className="w-full">
-                            <Button variant="secondary" className="w-full rounded-lg">
-                                {t('detail.actions.cancel')}
-                            </Button>
+                    <div className="mt-4 flex shrink-0 justify-end">
+                        <MorphingDialogClose className="relative right-0 top-0 inline-flex h-9 items-center justify-center rounded-lg border border-transparent bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground opacity-100 transition-[color,background-color,border-color,box-shadow,opacity,transform] duration-100 ease-out hover:bg-secondary/82 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/40 focus-visible:outline-none active:scale-[0.98]">
+                            {t('detail.actions.cancel')}
                         </MorphingDialogClose>
                     </div>
                 </MorphingDialogContent>

--- a/web/src/components/modules/home/chart.tsx
+++ b/web/src/components/modules/home/chart.tsx
@@ -190,12 +190,14 @@ export function StatsChart() {
                         </button>
                     </div>
                     <Tabs value={chartMetricType} onValueChange={(value) => setChartMetricType(value as ChartMetricType)}>
-                        <TabsList className="flex w-full flex-wrap rounded-lg border border-border bg-card p-1 sm:w-max">
-                            <TabsTrigger value="cost">{t('metricType.cost')}</TabsTrigger>
-                            <TabsTrigger value="count">{t('metricType.count')}</TabsTrigger>
-                            <TabsTrigger value="tokens">{t('metricType.tokens')}</TabsTrigger>
-                            <TabsTrigger value="success-rate">{t('metricType.successRate')}</TabsTrigger>
-                        </TabsList>
+                        <div className="w-full overflow-x-auto sm:w-auto">
+                            <TabsList className="flex w-max min-w-full flex-nowrap rounded-lg border border-border bg-card p-1 sm:min-w-0">
+                                <TabsTrigger value="cost">{t('metricType.cost')}</TabsTrigger>
+                                <TabsTrigger value="count">{t('metricType.count')}</TabsTrigger>
+                                <TabsTrigger value="tokens">{t('metricType.tokens')}</TabsTrigger>
+                                <TabsTrigger value="success-rate">{t('metricType.successRate')}</TabsTrigger>
+                            </TabsList>
+                        </div>
                     </Tabs>
                 </div>
 

--- a/web/src/components/modules/home/rank.tsx
+++ b/web/src/components/modules/home/rank.tsx
@@ -234,12 +234,14 @@ export function Rank() {
                         <Leaf className="h-3.5 w-3.5" strokeWidth={1.5} />
                         <span>{t('title')}</span>
                     </div>
-                    <TabsList className="flex w-full flex-wrap rounded-lg border border-border bg-card p-1 lg:w-max">
-                        <TabsTrigger value="cost">{t('sortByCost')}</TabsTrigger>
-                        <TabsTrigger value="count">{t('sortByCount')}</TabsTrigger>
-                        <TabsTrigger value="tokens">{t('sortByTokens')}</TabsTrigger>
-                        <TabsTrigger value="key-usage">{t('sortByKeyUsage')}</TabsTrigger>
-                    </TabsList>
+                    <div className="w-full overflow-x-auto lg:w-auto">
+                        <TabsList className="flex w-max min-w-full flex-nowrap rounded-lg border border-border bg-card p-1 lg:min-w-0">
+                            <TabsTrigger value="cost">{t('sortByCost')}</TabsTrigger>
+                            <TabsTrigger value="count">{t('sortByCount')}</TabsTrigger>
+                            <TabsTrigger value="tokens">{t('sortByTokens')}</TabsTrigger>
+                            <TabsTrigger value="key-usage">{t('sortByKeyUsage')}</TabsTrigger>
+                        </TabsList>
+                    </div>
                 </div>
                 <TabsContents className="relative mt-4">
                     <TabsContent value="cost">


### PR DESCRIPTION
## 变更内容

- 优化首页排行榜切换按钮在窄屏下的布局，避免“Token 使用”等按钮被挤到下一行。
- 优化首页图表指标切换按钮的窄屏显示，空间不足时横向滚动而不是换行破版。
- 修复分组页面 CC Switch 弹窗里取消按钮位置/结构异常的问题，避免出现嵌套 button 导致的点击和布局问题。

## 测试

- 已运行 ESLint 检查相关改动文件，通过。
- 已运行 `git diff --check`，通过。
- 已在 Codespace 页面检查过相关界面显示。