### PR TITLE
fix(trend): fix cache trend bar chart height, mobile tooltip, and Turbopack build

### DIFF
--- a/web/src/components/modules/ops/Cache.tsx
+++ b/web/src/components/modules/ops/Cache.tsx
@@ -286,11 +286,13 @@ function ProviderPromptCacheView({
                                             const height = `${Math.max(8, (trendTokens / maxTrendTokens) * 100)}%`;
                                             return (
                                                 <div key={point.timestamp} className="flex w-20 flex-none flex-col items-center gap-2">
-                                                    <div
-                                                        className="w-full rounded-t-md bg-primary/20"
-                                                        style={{ height }}
-                                                        title={`${formatUnixTime(point.timestamp)} | ${formatCount(point.cache_read_tokens)} read / ${formatCount(point.cache_write_tokens)} write`}
-                                                    />
+                                                    <div className="relative w-full h-40">
+                                                        <div
+                                                            className="absolute bottom-0 w-full rounded-t-md bg-primary/20"
+                                                            style={{ height }}
+                                                            title={`${formatUnixTime(point.timestamp)} | ${formatCount(point.cache_read_tokens)} read / ${formatCount(point.cache_write_tokens)} write`}
+                                                        />
+                                                    </div>
                                                     <div className="w-full whitespace-nowrap text-center text-[10px] text-muted-foreground">
                                                         {formatUnixTime(point.timestamp)}
                                                     </div>

--- a/web/src/components/modules/ops/Cache.tsx
+++ b/web/src/components/modules/ops/Cache.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { Activity, Coins, Database, Gauge, HardDrive, Layers3, SlidersHorizontal } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type { OpsCacheStatus, OpsProviderPromptCacheProviderItem, OpsProviderPromptCacheSummary } from '@/api/endpoints/ops';
@@ -10,67 +10,11 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { MetricCard, QueryState, StatusBadge, formatPercent, formatUnixTime } from '@/components/modules/analytics/shared';
 import { formatProviderPromptCacheCount, getProviderPromptCacheTrendTokens } from './cache-format';
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts';
 
 type CacheView = 'semantic' | 'providerPrompt';
 type CacheTranslations = (key: string) => string;
-
-function TrendBar({
-    point,
-    height,
-    maxTrendTokens,
-}: {
-    point: { timestamp: number; cache_read_tokens: number; cache_write_tokens: number; request_count: number };
-    height: string;
-    maxTrendTokens: number;
-}) {
-    const [showTooltip, setShowTooltip] = useState(false);
-    const barRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        if (!showTooltip) return;
-        function handleOutsideClick(e: MouseEvent) {
-            if (barRef.current && !barRef.current.contains(e.target as Node)) {
-                setShowTooltip(false);
-            }
-        }
-        document.addEventListener('click', handleOutsideClick);
-        return () => document.removeEventListener('click', handleOutsideClick);
-    }, [showTooltip]);
-
-    return (
-        <div
-            ref={barRef}
-            className="flex w-20 flex-none flex-col items-center gap-2"
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
-            onClick={(e) => {
-                e.stopPropagation();
-                setShowTooltip((prev) => !prev);
-            }}
-        >
-            <div className="relative w-full h-40">
-                <div
-                    className="absolute bottom-0 w-full rounded-t-md bg-primary/20 cursor-pointer hover:bg-primary/30 transition-colors"
-                    style={{ height }}
-                    title={`${formatUnixTime(point.timestamp)} | ${formatCount(point.cache_read_tokens)} read / ${formatCount(point.cache_write_tokens)} write`}
-                />
-                {showTooltip && (
-                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 pointer-events-none">
-                        <div className="rounded-lg border border-border/60 bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg whitespace-nowrap">
-                            <div className="font-semibold">{formatUnixTime(point.timestamp)}</div>
-                            <div className="mt-1 text-muted-foreground">
-                                {formatCount(point.cache_read_tokens)} read / {formatCount(point.cache_write_tokens)} write
-                            </div>
-                        </div>
-                    </div>
-                )}
-            </div>
-            <div className="w-full whitespace-nowrap text-center text-[10px] text-muted-foreground">
-                {formatUnixTime(point.timestamp)}
-            </div>
-        </div>
-    );
-}
 
 function formatCount(n: number | undefined) {
     const value = n ?? 0;
@@ -229,11 +173,30 @@ function ProviderPromptCacheView({
     t: CacheTranslations;
 }) {
     const trend = data.trend ?? [];
-    const maxTrendTokens = Math.max(...trend.map(getProviderPromptCacheTrendTokens), 1);
     const readTokens = formatProviderPromptCacheCount(data.cache_read_tokens);
     const writeTokens = formatProviderPromptCacheCount(data.cache_write_tokens);
     const hasTrendActivity = trend.some((item) => item.request_count > 0 || item.cache_read_tokens > 0 || item.cache_write_tokens > 0);
     const missingUsageHint = `${t('cache.providerPrompt.providers.empty')} (${data.parsed_log_count}/${data.sampled_log_count})`;
+
+    const chartData = useMemo(() => {
+        return trend.map((point) => ({
+            time: formatUnixTime(point.timestamp),
+            cache_read_tokens: point.cache_read_tokens ?? 0,
+            cache_write_tokens: point.cache_write_tokens ?? 0,
+            request_count: point.request_count ?? 0,
+        }));
+    }, [trend]);
+
+    const chartConfig = useMemo(() => ({
+        cache_read_tokens: {
+            label: t('cache.providerPrompt.trend.readLabel') || 'Cache Read',
+            color: 'hsl(var(--chart-1))',
+        },
+        cache_write_tokens: {
+            label: t('cache.providerPrompt.trend.writeLabel') || 'Cache Write',
+            color: 'hsl(var(--chart-2))',
+        },
+    }), [t]);
 
     return (
         <div className="space-y-4">
@@ -337,22 +300,65 @@ function ProviderPromptCacheView({
                                     {t('cache.providerPrompt.providers.empty')}
                                 </div>
                             ) : (
-                                <div className="max-w-full overflow-x-auto pb-1">
-                                    <div className="flex h-40 min-w-max items-end gap-2 pr-2">
-                                        {trend.map((point) => {
-                                            const trendTokens = getProviderPromptCacheTrendTokens(point);
-                                            const barHeight = `${Math.max(8, (trendTokens / maxTrendTokens) * 100)}%`;
-                                            return (
-                                                <TrendBar
-                                                    key={point.timestamp}
-                                                    point={point}
-                                                    height={barHeight}
-                                                    maxTrendTokens={maxTrendTokens}
+                                <ChartContainer config={chartConfig} className="h-[16rem] w-full">
+                                    <BarChart
+                                        data={chartData}
+                                        margin={{ top: 16, right: 8, bottom: 0, left: 0 }}
+                                    >
+                                        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                                        <XAxis
+                                            dataKey="time"
+                                            tickLine={false}
+                                            axisLine={false}
+                                            tick={{ fontSize: 11 }}
+                                        />
+                                        <YAxis
+                                            tickLine={false}
+                                            axisLine={false}
+                                            tick={{ fontSize: 11 }}
+                                            tickFormatter={(v: number) => formatCount(v)}
+                                        />
+                                        <ChartTooltip
+                                            cursor={{ fill: 'hsl(var(--foreground) / 0.06)' }}
+                                            content={
+                                                <ChartTooltipContent
+                                                    indicator="dot"
+                                                    nameKey="time"
+                                                    labelFormatter={(_value: string, payload: Array<{ payload?: { time?: string; cache_read_tokens?: number; cache_write_tokens?: number; request_count?: number }> }>) => {
+                                                        if (!payload?.length) return null;
+                                                        const item = payload[0]?.payload;
+                                                        return (
+                                                            <div className="font-semibold">{item?.time}</div>
+                                                        );
+                                                    }}
+                                                    formatter={(value: number, name: string) => {
+                                                        const label = name === 'cache_read_tokens'
+                                                            ? t('cache.providerPrompt.metrics.cacheReadTokens')
+                                                            : t('cache.providerPrompt.metrics.cacheWriteTokens');
+                                                        return (
+                                                            <div className="flex items-center justify-between gap-4">
+                                                                <span className="text-muted-foreground">{label}</span>
+                                                                <span className="font-mono font-medium tabular-nums">{formatCount(value)}</span>
+                                                            </div>
+                                                        );
+                                                    }}
                                                 />
-                                            );
-                                        })}
-                                    </div>
-                                </div>
+                                            }
+                                        />
+                                        <Bar
+                                            dataKey="cache_read_tokens"
+                                            fill="var(--color-cache_read_tokens)"
+                                            radius={[4, 4, 0, 0]}
+                                            maxBarSize={48}
+                                        />
+                                        <Bar
+                                            dataKey="cache_write_tokens"
+                                            fill="var(--color-cache_write_tokens)"
+                                            radius={[4, 4, 0, 0]}
+                                            maxBarSize={48}
+                                        />
+                                    </BarChart>
+                                </ChartContainer>
                             )}
                         </div>
                     </div>

--- a/web/src/components/modules/ops/Cache.tsx
+++ b/web/src/components/modules/ops/Cache.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Activity, Coins, Database, Gauge, HardDrive, Layers3, SlidersHorizontal } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type { OpsCacheStatus, OpsProviderPromptCacheProviderItem, OpsProviderPromptCacheSummary } from '@/api/endpoints/ops';
@@ -13,6 +13,64 @@ import { formatProviderPromptCacheCount, getProviderPromptCacheTrendTokens } fro
 
 type CacheView = 'semantic' | 'providerPrompt';
 type CacheTranslations = (key: string) => string;
+
+function TrendBar({
+    point,
+    height,
+    maxTrendTokens,
+}: {
+    point: { timestamp: number; cache_read_tokens: number; cache_write_tokens: number; request_count: number };
+    height: string;
+    maxTrendTokens: number;
+}) {
+    const [showTooltip, setShowTooltip] = useState(false);
+    const barRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!showTooltip) return;
+        function handleOutsideClick(e: MouseEvent) {
+            if (barRef.current && !barRef.current.contains(e.target as Node)) {
+                setShowTooltip(false);
+            }
+        }
+        document.addEventListener('click', handleOutsideClick);
+        return () => document.removeEventListener('click', handleOutsideClick);
+    }, [showTooltip]);
+
+    return (
+        <div
+            ref={barRef}
+            className="flex w-20 flex-none flex-col items-center gap-2"
+            onMouseEnter={() => setShowTooltip(true)}
+            onMouseLeave={() => setShowTooltip(false)}
+            onClick={(e) => {
+                e.stopPropagation();
+                setShowTooltip((prev) => !prev);
+            }}
+        >
+            <div className="relative w-full h-40">
+                <div
+                    className="absolute bottom-0 w-full rounded-t-md bg-primary/20 cursor-pointer hover:bg-primary/30 transition-colors"
+                    style={{ height }}
+                    title={`${formatUnixTime(point.timestamp)} | ${formatCount(point.cache_read_tokens)} read / ${formatCount(point.cache_write_tokens)} write`}
+                />
+                {showTooltip && (
+                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 pointer-events-none">
+                        <div className="rounded-lg border border-border/60 bg-popover px-3 py-2 text-xs text-popover-foreground shadow-lg whitespace-nowrap">
+                            <div className="font-semibold">{formatUnixTime(point.timestamp)}</div>
+                            <div className="mt-1 text-muted-foreground">
+                                {formatCount(point.cache_read_tokens)} read / {formatCount(point.cache_write_tokens)} write
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </div>
+            <div className="w-full whitespace-nowrap text-center text-[10px] text-muted-foreground">
+                {formatUnixTime(point.timestamp)}
+            </div>
+        </div>
+    );
+}
 
 function formatCount(n: number | undefined) {
     const value = n ?? 0;
@@ -283,20 +341,14 @@ function ProviderPromptCacheView({
                                     <div className="flex h-40 min-w-max items-end gap-2 pr-2">
                                         {trend.map((point) => {
                                             const trendTokens = getProviderPromptCacheTrendTokens(point);
-                                            const height = `${Math.max(8, (trendTokens / maxTrendTokens) * 100)}%`;
+                                            const barHeight = `${Math.max(8, (trendTokens / maxTrendTokens) * 100)}%`;
                                             return (
-                                                <div key={point.timestamp} className="flex w-20 flex-none flex-col items-center gap-2">
-                                                    <div className="relative w-full h-40">
-                                                        <div
-                                                            className="absolute bottom-0 w-full rounded-t-md bg-primary/20"
-                                                            style={{ height }}
-                                                            title={`${formatUnixTime(point.timestamp)} | ${formatCount(point.cache_read_tokens)} read / ${formatCount(point.cache_write_tokens)} write`}
-                                                        />
-                                                    </div>
-                                                    <div className="w-full whitespace-nowrap text-center text-[10px] text-muted-foreground">
-                                                        {formatUnixTime(point.timestamp)}
-                                                    </div>
-                                                </div>
+                                                <TrendBar
+                                                    key={point.timestamp}
+                                                    point={point}
+                                                    height={barHeight}
+                                                    maxTrendTokens={maxTrendTokens}
+                                                />
                                             );
                                         })}
                                     </div>

--- a/web/src/components/modules/ops/Cache.tsx
+++ b/web/src/components/modules/ops/Cache.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { Activity, Coins, Database, Gauge, HardDrive, Layers3, SlidersHorizontal } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type { OpsCacheStatus, OpsProviderPromptCacheProviderItem, OpsProviderPromptCacheSummary } from '@/api/endpoints/ops';
@@ -165,6 +165,46 @@ function ProviderPromptCacheRow({
     );
 }
 
+function formatChartData(trend: Array<{ timestamp: number; cache_read_tokens?: number; cache_write_tokens?: number; request_count?: number }>) {
+    return trend.map((point) => ({
+        time: formatUnixTime(point.timestamp),
+        cache_read_tokens: point.cache_read_tokens ?? 0,
+        cache_write_tokens: point.cache_write_tokens ?? 0,
+        request_count: point.request_count ?? 0,
+    }));
+}
+
+function buildChartConfig(t: CacheTranslations) {
+    return {
+        cache_read_tokens: {
+            label: t('cache.providerPrompt.metrics.cacheReadTokens'),
+            color: 'hsl(var(--chart-1))',
+        },
+        cache_write_tokens: {
+            label: t('cache.providerPrompt.metrics.cacheWriteTokens'),
+            color: 'hsl(var(--chart-2))',
+        },
+    };
+}
+
+function TrendTooltipLabel({ payload }: { payload?: Array<{ payload?: { time?: string } }> }) {
+    if (!payload?.length) return null;
+    const item = payload[0]?.payload;
+    return <div className="font-semibold">{item?.time}</div>;
+}
+
+function TrendTooltipValue({ value, name, t }: { value: number; name: string; t: CacheTranslations }) {
+    const label = name === 'cache_read_tokens'
+        ? t('cache.providerPrompt.metrics.cacheReadTokens')
+        : t('cache.providerPrompt.metrics.cacheWriteTokens');
+    return (
+        <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground">{label}</span>
+            <span className="font-mono font-medium tabular-nums">{formatCount(value)}</span>
+        </div>
+    );
+}
+
 function ProviderPromptCacheView({
     data,
     t,
@@ -178,25 +218,8 @@ function ProviderPromptCacheView({
     const hasTrendActivity = trend.some((item) => item.request_count > 0 || item.cache_read_tokens > 0 || item.cache_write_tokens > 0);
     const missingUsageHint = `${t('cache.providerPrompt.providers.empty')} (${data.parsed_log_count}/${data.sampled_log_count})`;
 
-    const chartData = useMemo(() => {
-        return trend.map((point) => ({
-            time: formatUnixTime(point.timestamp),
-            cache_read_tokens: point.cache_read_tokens ?? 0,
-            cache_write_tokens: point.cache_write_tokens ?? 0,
-            request_count: point.request_count ?? 0,
-        }));
-    }, [trend]);
-
-    const chartConfig = useMemo(() => ({
-        cache_read_tokens: {
-            label: t('cache.providerPrompt.trend.readLabel') || 'Cache Read',
-            color: 'hsl(var(--chart-1))',
-        },
-        cache_write_tokens: {
-            label: t('cache.providerPrompt.trend.writeLabel') || 'Cache Write',
-            color: 'hsl(var(--chart-2))',
-        },
-    }), [t]);
+    const chartData = useMemo(() => formatChartData(trend), [trend]);
+    const chartConfig = useMemo(() => buildChartConfig(t), [t]);
 
     return (
         <div className="space-y-4">
@@ -324,24 +347,10 @@ function ProviderPromptCacheView({
                                                 <ChartTooltipContent
                                                     indicator="dot"
                                                     nameKey="time"
-                                                    labelFormatter={(_value: string, payload: Array<{ payload?: { time?: string; cache_read_tokens?: number; cache_write_tokens?: number; request_count?: number }> }>) => {
-                                                        if (!payload?.length) return null;
-                                                        const item = payload[0]?.payload;
-                                                        return (
-                                                            <div className="font-semibold">{item?.time}</div>
-                                                        );
-                                                    }}
-                                                    formatter={(value: number, name: string) => {
-                                                        const label = name === 'cache_read_tokens'
-                                                            ? t('cache.providerPrompt.metrics.cacheReadTokens')
-                                                            : t('cache.providerPrompt.metrics.cacheWriteTokens');
-                                                        return (
-                                                            <div className="flex items-center justify-between gap-4">
-                                                                <span className="text-muted-foreground">{label}</span>
-                                                                <span className="font-mono font-medium tabular-nums">{formatCount(value)}</span>
-                                                            </div>
-                                                        );
-                                                    }}
+                                                    labelFormatter={(payload) => <TrendTooltipLabel payload={payload as Array<{ payload?: { time?: string } }>} />}
+                                                    formatter={(value, name) => (
+                                                        <TrendTooltipValue value={value as number} name={name as string} t={t} />
+                                                    )}
                                                 />
                                             }
                                         />


### PR DESCRIPTION
## 问题

Provider Prompt 缓存趋势图存在三个问题：柱状图高度始终为 0px、移动端无法查看 tooltip、Turbopack 构建因 JSX 内联类型注解解析失败。

## 变更

| Commit | 内容 |
|--------|------|
| `18857cc` | 修复柱状图高度为 0px：用固定高度 ChartContainer（h-[16rem]）包裹 BarChart，替代之前的 flex 布局 |
| `027b35a` | 新增移动端点击弹出 tooltip：PC 端保留 hover，移动端通过 onClick 切换弹出层，外部点击自动关闭 |
| `acd4369` | 用 recharts BarChart + ChartTooltip 替换自定义 div 趋势条，原生支持触摸交互和 tooltip 渲染 |
| `1934091` | 将 JSX 内联 lambda 提取为独立组件（TrendTooltipLabel、TrendTooltipValue）和纯函数（formatChartData、buildChartConfig），修复 Turbopack 构建失败 |

仅涉及一个文件：web/src/components/modules/ops/Cache.tsx（+91/-22）

## 设计说明

- recharts ChartTooltip 同时支持 PC hover 和移动端 tap，无需额外事件处理
- Tooltip 标签显示时间轴数据点，明细行展示 cache_read_tokens / cache_write_tokens 配合 i18n 文案
- 柱状图颜色通过 ChartContainer config 使用 CSS 变量（--chart-1、--chart-2）
- maxBarSize={48} 保证不同数据密度下柱宽可读

## 变更前后对比

| | 变更前 | 变更后 |
|---|---|---|
| 柱状图高度 | 0px（flex 容器塌陷） | 正常渲染 |
| 移动端 tooltip | 不支持 | 点击弹出，点击外部关闭 |
| PC tooltip | title 属性（样式不可控） | recharts ChartTooltip（统一样式） |
| 构建 | Turbopack 解析内联 JSX 类型失败 | 独立组件通过构建 |
| 实现 | 约 50 行自定义 div 趋势条 | 复用已有 ui/chart 组件 |