### PR TITLE
feat: 日志清理支持按条数保留 + 批量50%清理优化

### DIFF
--- a/internal/model/ops.go
+++ b/internal/model/ops.go
@@ -122,6 +122,7 @@ type OpsSystemSummary struct {
 	ProxyURL                     string                     `json:"proxy_url"`
 	RelayLogKeepEnabled          bool                       `json:"relay_log_keep_enabled"`
 	RelayLogKeepDays             int                        `json:"relay_log_keep_days"`
+	RelayLogKeepCount            int                        `json:"relay_log_keep_count"`
 	StatsSaveIntervalMinutes     int                        `json:"stats_save_interval_minutes"`
 	SyncLLMIntervalHours         int                        `json:"sync_llm_interval_hours"`
 	ModelInfoUpdateIntervalHours int                        `json:"model_info_update_interval_hours"`

--- a/internal/model/setting.go
+++ b/internal/model/setting.go
@@ -15,6 +15,7 @@ const (
 	SettingKeyModelInfoUpdateInterval              SettingKey = "model_info_update_interval"               // 模型信息更新间隔(小时)
 	SettingKeySyncLLMInterval                      SettingKey = "sync_llm_interval"                        // LLM 同步间隔(小时)
 	SettingKeyRelayLogKeepPeriod                   SettingKey = "relay_log_keep_period"                    // 日志保存时间范围(天)
+	SettingKeyRelayLogKeepCount                    SettingKey = "relay_log_keep_count"                     // 日志保留条数(0=不按条数)
 	SettingKeyRelayLogKeepEnabled                  SettingKey = "relay_log_keep_enabled"                   // 是否保留历史日志
 	SettingKeyCORSAllowOrigins                     SettingKey = "cors_allow_origins"                       // 跨域白名单(逗号分隔, 如 "example.com,example2.com"). 为空不允许跨域, "*"允许所有
 	SettingKeyRelayRetryCount                      SettingKey = "relay_retry_count"                        // 单个候选渠道内 Key 级最大重试次数
@@ -75,6 +76,7 @@ func DefaultSettings() []Setting {
 		{Key: SettingKeyModelInfoUpdateInterval, Value: "24"},    // 默认24小时更新一次模型信息
 		{Key: SettingKeySyncLLMInterval, Value: "24"},            // 默认24小时同步一次LLM
 		{Key: SettingKeyRelayLogKeepPeriod, Value: "7"},          // 默认日志保存7天
+		{Key: SettingKeyRelayLogKeepCount, Value: "0"},           // 默认不按条数保留(0=禁用)
 		{Key: SettingKeyRelayLogKeepEnabled, Value: "true"},      // 默认保留历史日志
 		{Key: SettingKeyRelayRetryCount, Value: "3"},             // 默认单个渠道内 Key 级重试3次
 		{Key: SettingKeyRelayRouteRetries, Value: "2"},           // 默认路由级重试2次（全部渠道遍历两轮）
@@ -124,7 +126,7 @@ func DefaultSettings() []Setting {
 
 func (s *Setting) Validate() error {
 	switch s.Key {
-	case SettingKeyModelInfoUpdateInterval, SettingKeySyncLLMInterval, SettingKeyRelayLogKeepPeriod,
+	case SettingKeyModelInfoUpdateInterval, SettingKeySyncLLMInterval, SettingKeyRelayLogKeepPeriod, SettingKeyRelayLogKeepCount,
 		SettingKeyRelayRetryCount, SettingKeyRelayRouteRetries, SettingKeyCircuitBreakerThreshold, SettingKeyCircuitBreakerCooldown,
 		SettingKeyCircuitBreakerMaxCooldown, SettingKeyRatelimitCooldown, SettingKeyRelayMaxTotalAttempts,
 		SettingKeySemanticCacheTTL, SettingKeySemanticCacheThreshold, SettingKeySemanticCacheMaxEntries,

--- a/internal/op/ops/ops.go
+++ b/internal/op/ops/ops.go
@@ -150,6 +150,10 @@ func OpsSystemSummaryGet(ctx context.Context) (*model.OpsSystemSummary, error) {
 	if err != nil {
 		return nil, err
 	}
+	relayLogKeepCount, err := setting.GetInt(model.SettingKeyRelayLogKeepCount)
+	if err != nil {
+		return nil, err
+	}
 	statsSaveIntervalMinutes, err := setting.GetInt(model.SettingKeyStatsSaveInterval)
 	if err != nil {
 		return nil, err
@@ -206,6 +210,7 @@ func OpsSystemSummaryGet(ctx context.Context) (*model.OpsSystemSummary, error) {
 		ProxyURL:                     strings.TrimSpace(proxyURL),
 		RelayLogKeepEnabled:          relayLogKeepEnabled,
 		RelayLogKeepDays:             relayLogKeepDays,
+		RelayLogKeepCount:            relayLogKeepCount,
 		StatsSaveIntervalMinutes:     statsSaveIntervalMinutes,
 		SyncLLMIntervalHours:         syncLLMIntervalHours,
 		ModelInfoUpdateIntervalHours: modelInfoUpdateIntervalHours,

--- a/internal/op/relaylog/relaylog.go
+++ b/internal/op/relaylog/relaylog.go
@@ -252,13 +252,23 @@ func relayLogCleanup(ctx context.Context) error {
 	}
 
 	if keepCount > 0 {
-		// Delete oldest rows exceeding the count limit
+		// Count-based cleanup with batch deletion (50% when over threshold)
+		// Avoids high-frequency small deletes under heavy load
+		var total int64
+		if err := db.GetDB().Model(&model.RelayLog{}).Count(&total).Error; err != nil {
+			return err
+		}
+		if total <= int64(keepCount) {
+			return nil // Under threshold, no cleanup needed
+		}
+		// Delete 50% of current records to create buffer before next cleanup
+		deleteCount := total / 2
 		subQuery := db.GetDB().Model(&model.RelayLog{}).
-			Order("id DESC").
-			Limit(keepCount).
+			Order("id ASC").
+			Limit(int(deleteCount)).
 			Select("id")
 		return db.GetDB().WithContext(ctx).
-			Where("id NOT IN (?)", subQuery).
+			Where("id IN (?)", subQuery).
 			Delete(&model.RelayLog{}).Error
 	}
 

--- a/internal/op/relaylog/relaylog.go
+++ b/internal/op/relaylog/relaylog.go
@@ -245,6 +245,24 @@ func RelayLogSaveDBTask(ctx context.Context) error {
 }
 
 func relayLogCleanup(ctx context.Context) error {
+	// Priority: keep count > keep period (days)
+	keepCount, err := setting.GetInt(model.SettingKeyRelayLogKeepCount)
+	if err != nil {
+		return err
+	}
+
+	if keepCount > 0 {
+		// Delete oldest rows exceeding the count limit
+		subQuery := db.GetDB().Model(&model.RelayLog{}).
+			Order("id DESC").
+			Limit(keepCount).
+			Select("id")
+		return db.GetDB().WithContext(ctx).
+			Where("id NOT IN (?)", subQuery).
+			Delete(&model.RelayLog{}).Error
+	}
+
+	// Fallback to days-based cleanup
 	keepPeriod, err := setting.GetInt(model.SettingKeyRelayLogKeepPeriod)
 	if err != nil {
 		return err

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -1522,11 +1522,17 @@
       "clearFailed": "Failed to clear logs",
       "keepCount": {
         "label": "Log Retention Count",
-        "description": "Oldest logs are deleted when count exceeds limit",
+        "description": "Automatically deletes oldest 50% of logs when exceeding the limit, avoiding frequent cleanup overhead",
         "placeholder": "e.g. 1000"
       },
       "keepMode": {
         "label": "Retention Mode",
+        "count": "By Count",
+        "days": "By Days"
+      },
+      "mode": {
+        "label": "Log Retention Mode",
+        "description": "Choose to auto-clean logs by count or by days",
         "count": "By Count",
         "days": "By Days"
       }

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -1511,7 +1511,8 @@
       },
       "keepPeriod": {
         "label": "Log Retention Days",
-        "placeholder": "e.g. 7"
+        "placeholder": "e.g. 7",
+        "description": "Logs older than the specified days will be automatically deleted"
       },
       "clear": {
         "label": "Clear History Logs",

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -1519,7 +1519,12 @@
         "clearing": "Clearing..."
       },
       "clearSuccess": "Logs cleared",
-      "clearFailed": "Failed to clear logs"
+      "clearFailed": "Failed to clear logs",
+      "keepCount": {
+        "label": "Log Retention Count",
+        "description": "Oldest logs are deleted when count exceeds limit",
+        "placeholder": "e.g. 1000"
+      }
     },
     "navOrder": {
       "title": "Page Order & Visibility",
@@ -2266,5 +2271,10 @@
     "databaseSchemaOutdatedRestart": "Database schema is outdated; restart the service to apply the latest migrations",
     "upstreamServiceUnavailable": "Upstream service unavailable",
     "unexpectedError": "Unexpected error"
+  },
+  "system": {
+    "fields": {
+      "logCountUnit": "entries"
+    }
   }
 }

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -1510,8 +1510,8 @@
         "label": "Enable History Logs"
       },
       "keepPeriod": {
-        "label": "Log Retention (days)",
-        "placeholder": "Enter days"
+        "label": "Log Retention Days",
+        "placeholder": "e.g. 7"
       },
       "clear": {
         "label": "Clear History Logs",
@@ -1524,6 +1524,11 @@
         "label": "Log Retention Count",
         "description": "Oldest logs are deleted when count exceeds limit",
         "placeholder": "e.g. 1000"
+      },
+      "keepMode": {
+        "label": "Retention Mode",
+        "count": "By Count",
+        "days": "By Days"
       }
     },
     "navOrder": {

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -1511,7 +1511,7 @@
       },
       "keepPeriod": {
         "label": "日志保存天数",
-        "placeholder": "请输入天数"
+        "placeholder": "例如：7"
       },
       "clear": {
         "label": "清空历史日志",
@@ -1524,6 +1524,11 @@
         "label": "日志保留条数",
         "description": "超出条数时自动删除最早的日志",
         "placeholder": "例如：1000"
+      },
+      "keepMode": {
+        "label": "保留方式",
+        "count": "按条数",
+        "days": "按天数"
       }
     },
     "navOrder": {

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -1511,7 +1511,8 @@
       },
       "keepPeriod": {
         "label": "日志保存天数",
-        "placeholder": "例如：7"
+        "placeholder": "例如：7",
+        "description": "超过保存天数的日志将被自动删除"
       },
       "clear": {
         "label": "清空历史日志",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -1522,11 +1522,17 @@
       "clearFailed": "清空失败",
       "keepCount": {
         "label": "日志保留条数",
-        "description": "超出条数时自动删除最早的日志",
+        "description": "超出设定值时自动删除最旧的50%日志，避免频繁清理影响性能",
         "placeholder": "例如：1000"
       },
       "keepMode": {
         "label": "保留方式",
+        "count": "按条数",
+        "days": "按天数"
+      },
+      "mode": {
+        "label": "日志保留模式",
+        "description": "选择按条数或按天数自动清理历史日志",
         "count": "按条数",
         "days": "按天数"
       }

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -1519,7 +1519,12 @@
         "clearing": "清空中..."
       },
       "clearSuccess": "日志已清空",
-      "clearFailed": "清空失败"
+      "clearFailed": "清空失败",
+      "keepCount": {
+        "label": "日志保留条数",
+        "description": "超出条数时自动删除最早的日志",
+        "placeholder": "例如：1000"
+      }
     },
     "navOrder": {
       "title": "页面顺序与显示",
@@ -2266,5 +2271,10 @@
     "databaseSchemaOutdatedRestart": "数据库结构已过期，请重启服务以应用最新迁移",
     "upstreamServiceUnavailable": "上游服务不可用",
     "unexpectedError": "未预期的错误"
+  },
+  "system": {
+    "fields": {
+      "logCountUnit": "条"
+    }
   }
 }

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -1522,11 +1522,17 @@
       "clearFailed": "清空失敗",
       "keepCount": {
         "label": "日誌保留條數",
-        "description": "超出條數時自動刪除最早的日誌",
+        "description": "超出設定值時自動刪除最舊的50%日誌，避免頻繁清理影響效能",
         "placeholder": "例如：1000"
       },
       "keepMode": {
         "label": "保留方式",
+        "count": "按條數",
+        "days": "按天數"
+      },
+      "mode": {
+        "label": "日誌保留模式",
+        "description": "選擇按條數或按天數自動清理歷史日誌",
         "count": "按條數",
         "days": "按天數"
       }

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -1511,7 +1511,8 @@
       },
       "keepPeriod": {
         "label": "日誌保存天數",
-        "placeholder": "例如：7"
+        "placeholder": "例如：7",
+        "description": "超過保存天數的日誌將被自動刪除"
       },
       "clear": {
         "label": "清空歷史日誌",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -1519,7 +1519,12 @@
         "clearing": "清空中..."
       },
       "clearSuccess": "日誌已清空",
-      "clearFailed": "清空失敗"
+      "clearFailed": "清空失敗",
+      "keepCount": {
+        "label": "日誌保留條數",
+        "description": "超出條數時自動刪除最早的日誌",
+        "placeholder": "例如：1000"
+      }
     },
     "navOrder": {
       "title": "頁面順序與顯示",
@@ -2266,5 +2271,10 @@
     "databaseSchemaOutdatedRestart": "資料庫結構已過期，請重啟服務以套用最新遷移",
     "upstreamServiceUnavailable": "上游服務不可用",
     "unexpectedError": "未預期的錯誤"
+  },
+  "system": {
+    "fields": {
+      "logCountUnit": "條"
+    }
   }
 }

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -1511,7 +1511,7 @@
       },
       "keepPeriod": {
         "label": "日誌保存天數",
-        "placeholder": "請輸入天數"
+        "placeholder": "例如：7"
       },
       "clear": {
         "label": "清空歷史日誌",
@@ -1524,6 +1524,11 @@
         "label": "日誌保留條數",
         "description": "超出條數時自動刪除最早的日誌",
         "placeholder": "例如：1000"
+      },
+      "keepMode": {
+        "label": "保留方式",
+        "count": "按條數",
+        "days": "按天數"
       }
     },
     "navOrder": {

--- a/web/src/api/endpoints/ops.ts
+++ b/web/src/api/endpoints/ops.ts
@@ -127,6 +127,7 @@ export interface OpsSystemSummary {
     proxy_url: string;
     relay_log_keep_enabled: boolean;
     relay_log_keep_days: number;
+    relay_log_keep_count: number;
     stats_save_interval_minutes: number;
     sync_llm_interval_hours: number;
     model_info_update_interval_hours: number;

--- a/web/src/api/endpoints/setting.ts
+++ b/web/src/api/endpoints/setting.ts
@@ -20,6 +20,7 @@ export const SettingKey = {
     SyncLLMInterval: 'sync_llm_interval',
     RelayLogKeepEnabled: 'relay_log_keep_enabled',
     RelayLogKeepPeriod: 'relay_log_keep_period',
+    RelayLogKeepCount: 'relay_log_keep_count',
     CORSAllowOrigins: 'cors_allow_origins',
     RelayRetryCount: 'relay_retry_count',
     RelayRouteRetries: 'relay_route_retries',

--- a/web/src/components/modules/ops/System.tsx
+++ b/web/src/components/modules/ops/System.tsx
@@ -86,7 +86,11 @@ export function System() {
                             <InfoRow label={t('system.fields.proxyUrl')} value={data?.proxy_url || '-'} />
                             <InfoRow
                                 label={t('system.fields.relayLogRetention')}
-                                value={data?.relay_log_keep_enabled ? `${data?.relay_log_keep_days}d` : t('system.fields.disabled')}
+                                value={data?.relay_log_keep_enabled
+                                    ? (data?.relay_log_keep_count > 0
+                                        ? `${data.relay_log_keep_count} ${t('system.fields.logCountUnit')}`
+                                        : `${data?.relay_log_keep_days}d`)
+                                    : t('system.fields.disabled')}
                             />
                             <InfoRow
                                 label={t('system.fields.statsSaveInterval')}

--- a/web/src/components/modules/setting/Log.tsx
+++ b/web/src/components/modules/setting/Log.tsx
@@ -2,13 +2,15 @@
 
 import { useEffect, useState, useRef } from 'react';
 import { useTranslations } from 'next-intl';
-import { ScrollText, Calendar, Trash2 } from 'lucide-react';
+import { ScrollText, Calendar, Hash, Trash2 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { useSettingList, useSetSetting, SettingKey } from '@/api/endpoints/setting';
 import { useClearLogs } from '@/api/endpoints/log';
 import { toast } from '@/components/common/Toast';
+
+type KeepMode = 'count' | 'days';
 
 export function SettingLog() {
     const t = useTranslations('setting');
@@ -17,27 +19,50 @@ export function SettingLog() {
     const clearLogs = useClearLogs();
 
     const [enabled, setEnabled] = useState(true);
+    const [mode, setMode] = useState<KeepMode>('count');
     const [keepCount, setKeepCount] = useState('1000');
+    const [keepDays, setKeepDays] = useState('7');
     const [isClearing, setIsClearing] = useState(false);
 
     const initialEnabled = useRef(true);
+    const initialMode = useRef<KeepMode>('count');
     const initialKeepCount = useRef('1000');
+    const initialKeepDays = useRef('7');
 
     useEffect(() => {
         if (settings) {
             const enabledSetting = settings.find(s => s.key === SettingKey.RelayLogKeepEnabled);
             const countSetting = settings.find(s => s.key === SettingKey.RelayLogKeepCount);
+            const periodSetting = settings.find(s => s.key === SettingKey.RelayLogKeepPeriod);
+
             if (enabledSetting) {
                 const isEnabled = enabledSetting.value === 'true';
                 queueMicrotask(() => setEnabled(isEnabled));
                 initialEnabled.current = isEnabled;
             }
-            if (countSetting) {
-                const val = countSetting.value;
-                // Default to 1000 if 0 or empty (migration from days-based)
-                const displayVal = (!val || val === '0') ? '1000' : val;
-                queueMicrotask(() => setKeepCount(displayVal));
-                initialKeepCount.current = displayVal;
+
+            // Determine mode: if keepCount > 0 → count mode, else days mode
+            const countVal = countSetting?.value || '0';
+            const daysVal = periodSetting?.value || '7';
+
+            if (parseInt(countVal) > 0) {
+                queueMicrotask(() => {
+                    setMode('count');
+                    setKeepCount(countVal);
+                    setKeepDays(daysVal);
+                });
+                initialMode.current = 'count';
+                initialKeepCount.current = countVal;
+                initialKeepDays.current = daysVal;
+            } else {
+                queueMicrotask(() => {
+                    setMode('days');
+                    setKeepCount(countVal === '0' ? '1000' : countVal);
+                    setKeepDays(daysVal);
+                });
+                initialMode.current = 'days';
+                initialKeepCount.current = countVal === '0' ? '1000' : countVal;
+                initialKeepDays.current = daysVal;
             }
         }
     }, [settings]);
@@ -55,15 +80,48 @@ export function SettingLog() {
         );
     };
 
+    const handleModeChange = (newMode: KeepMode) => {
+        setMode(newMode);
+        initialMode.current = newMode;
+
+        if (newMode === 'count') {
+            // Switch to count mode: save current keepCount, clear period effect
+            const val = keepCount || '1000';
+            setSetting.mutate({ key: SettingKey.RelayLogKeepCount, value: val });
+            initialKeepCount.current = val;
+        } else {
+            // Switch to days mode: set keepCount=0 to disable count-based cleanup
+            setSetting.mutate({ key: SettingKey.RelayLogKeepCount, value: '0' });
+            initialKeepCount.current = '0';
+        }
+        toast.success(t('saved'));
+    };
+
     const handleKeepCountSave = () => {
         if (keepCount === initialKeepCount.current) return;
-
+        const val = Math.max(1, parseInt(keepCount) || 1000).toString();
+        setKeepCount(val);
         setSetting.mutate(
-            { key: SettingKey.RelayLogKeepCount, value: keepCount },
+            { key: SettingKey.RelayLogKeepCount, value: val },
             {
                 onSuccess: () => {
                     toast.success(t('saved'));
-                    initialKeepCount.current = keepCount;
+                    initialKeepCount.current = val;
+                }
+            }
+        );
+    };
+
+    const handleKeepDaysSave = () => {
+        if (keepDays === initialKeepDays.current) return;
+        const val = Math.max(1, parseInt(keepDays) || 7).toString();
+        setKeepDays(val);
+        setSetting.mutate(
+            { key: SettingKey.RelayLogKeepPeriod, value: val },
+            {
+                onSuccess: () => {
+                    toast.success(t('saved'));
+                    initialKeepDays.current = val;
                 }
             }
         );
@@ -84,7 +142,7 @@ export function SettingLog() {
     };
 
     return (
-        <div className="rounded-xl border-border/35 bg-card p-6 space-y-5 text-card-foreground shadow-md ">
+        <div className="rounded-xl border-border/35 bg-card p-6 space-y-5 text-card-foreground shadow-md">
             <h2 className="text-lg font-bold text-card-foreground flex items-center gap-2">
                 <ScrollText className="h-5 w-5" />
                 {t('log.title')}
@@ -102,26 +160,84 @@ export function SettingLog() {
                 />
             </div>
 
-            {/* 历史日志保留条数 */}
-            <div className="flex flex-col gap-3 rounded-lg border-border/30 bg-card p-4 shadow-sm md:flex-row md:items-center md:justify-between">
+            {/* 保留模式切换 */}
+            <div className="flex flex-col gap-3 rounded-lg border-border/30 bg-card p-4 shadow-sm">
                 <div className="flex items-center gap-3">
-                    <Calendar className="h-5 w-5 text-muted-foreground" />
+                    <Hash className="h-5 w-5 text-muted-foreground" />
                     <div className="flex flex-col">
-                        <span className="text-sm font-medium">{t('log.keepCount.label')}</span>
-                        <span className="text-xs text-muted-foreground">{t('log.keepCount.description')}</span>
+                        <span className="text-sm font-medium">{t('log.mode.label')}</span>
+                        <span className="text-xs text-muted-foreground">{t('log.mode.description')}</span>
                     </div>
                 </div>
-                <Input
-                    type="number"
-                    value={keepCount}
-                    onChange={(e) => setKeepCount(e.target.value)}
-                    onBlur={handleKeepCountSave}
-                    placeholder={t('log.keepCount.placeholder')}
-                    className="w-48 rounded-xl"
-                    disabled={!enabled}
-                    min={1}
-                />
+                <div className="flex gap-2 mt-1">
+                    <Button
+                        variant={mode === 'count' ? 'default' : 'outline'}
+                        size="sm"
+                        onClick={() => handleModeChange('count')}
+                        disabled={!enabled}
+                        className="rounded-xl flex-1 md:flex-none"
+                    >
+                        <Hash className="mr-1.5 h-3.5 w-3.5" />
+                        {t('log.mode.count')}
+                    </Button>
+                    <Button
+                        variant={mode === 'days' ? 'default' : 'outline'}
+                        size="sm"
+                        onClick={() => handleModeChange('days')}
+                        disabled={!enabled}
+                        className="rounded-xl flex-1 md:flex-none"
+                    >
+                        <Calendar className="mr-1.5 h-3.5 w-3.5" />
+                        {t('log.mode.days')}
+                    </Button>
+                </div>
             </div>
+
+            {/* 按条数保留设置 */}
+            {mode === 'count' && (
+                <div className="flex flex-col gap-3 rounded-lg border-border/30 bg-card p-4 shadow-sm md:flex-row md:items-center md:justify-between">
+                    <div className="flex items-center gap-3">
+                        <Hash className="h-5 w-5 text-muted-foreground" />
+                        <div className="flex flex-col">
+                            <span className="text-sm font-medium">{t('log.keepCount.label')}</span>
+                            <span className="text-xs text-muted-foreground">{t('log.keepCount.description')}</span>
+                        </div>
+                    </div>
+                    <Input
+                        type="number"
+                        value={keepCount}
+                        onChange={(e) => setKeepCount(e.target.value)}
+                        onBlur={handleKeepCountSave}
+                        placeholder={t('log.keepCount.placeholder')}
+                        className="w-48 rounded-xl"
+                        disabled={!enabled}
+                        min={1}
+                    />
+                </div>
+            )}
+
+            {/* 按天数保留设置 */}
+            {mode === 'days' && (
+                <div className="flex flex-col gap-3 rounded-lg border-border/30 bg-card p-4 shadow-sm md:flex-row md:items-center md:justify-between">
+                    <div className="flex items-center gap-3">
+                        <Calendar className="h-5 w-5 text-muted-foreground" />
+                        <div className="flex flex-col">
+                            <span className="text-sm font-medium">{t('log.keepPeriod.label')}</span>
+                            <span className="text-xs text-muted-foreground">{t('log.keepPeriod.description')}</span>
+                        </div>
+                    </div>
+                    <Input
+                        type="number"
+                        value={keepDays}
+                        onChange={(e) => setKeepDays(e.target.value)}
+                        onBlur={handleKeepDaysSave}
+                        placeholder={t('log.keepPeriod.placeholder')}
+                        className="w-48 rounded-xl"
+                        disabled={!enabled}
+                        min={1}
+                    />
+                </div>
+            )}
 
             {/* 清空历史日志 */}
             <div className="flex flex-col gap-3 rounded-lg border-border/30 bg-card p-4 shadow-sm md:flex-row md:items-center md:justify-between">
@@ -142,4 +258,3 @@ export function SettingLog() {
         </div>
     );
 }
-

--- a/web/src/components/modules/setting/Log.tsx
+++ b/web/src/components/modules/setting/Log.tsx
@@ -17,24 +17,27 @@ export function SettingLog() {
     const clearLogs = useClearLogs();
 
     const [enabled, setEnabled] = useState(true);
-    const [keepPeriod, setKeepPeriod] = useState('7');
+    const [keepCount, setKeepCount] = useState('1000');
     const [isClearing, setIsClearing] = useState(false);
 
     const initialEnabled = useRef(true);
-    const initialKeepPeriod = useRef('7');
+    const initialKeepCount = useRef('1000');
 
     useEffect(() => {
         if (settings) {
             const enabledSetting = settings.find(s => s.key === SettingKey.RelayLogKeepEnabled);
-            const periodSetting = settings.find(s => s.key === SettingKey.RelayLogKeepPeriod);
+            const countSetting = settings.find(s => s.key === SettingKey.RelayLogKeepCount);
             if (enabledSetting) {
                 const isEnabled = enabledSetting.value === 'true';
                 queueMicrotask(() => setEnabled(isEnabled));
                 initialEnabled.current = isEnabled;
             }
-            if (periodSetting) {
-                queueMicrotask(() => setKeepPeriod(periodSetting.value));
-                initialKeepPeriod.current = periodSetting.value;
+            if (countSetting) {
+                const val = countSetting.value;
+                // Default to 1000 if 0 or empty (migration from days-based)
+                const displayVal = (!val || val === '0') ? '1000' : val;
+                queueMicrotask(() => setKeepCount(displayVal));
+                initialKeepCount.current = displayVal;
             }
         }
     }, [settings]);
@@ -52,15 +55,15 @@ export function SettingLog() {
         );
     };
 
-    const handleKeepPeriodSave = () => {
-        if (keepPeriod === initialKeepPeriod.current) return;
+    const handleKeepCountSave = () => {
+        if (keepCount === initialKeepCount.current) return;
 
         setSetting.mutate(
-            { key: SettingKey.RelayLogKeepPeriod, value: keepPeriod },
+            { key: SettingKey.RelayLogKeepCount, value: keepCount },
             {
                 onSuccess: () => {
                     toast.success(t('saved'));
-                    initialKeepPeriod.current = keepPeriod;
+                    initialKeepCount.current = keepCount;
                 }
             }
         );
@@ -99,20 +102,24 @@ export function SettingLog() {
                 />
             </div>
 
-            {/* 历史日志保存范围 */}
+            {/* 历史日志保留条数 */}
             <div className="flex flex-col gap-3 rounded-lg border-border/30 bg-card p-4 shadow-sm md:flex-row md:items-center md:justify-between">
                 <div className="flex items-center gap-3">
                     <Calendar className="h-5 w-5 text-muted-foreground" />
-                    <span className="text-sm font-medium">{t('log.keepPeriod.label')}</span>
+                    <div className="flex flex-col">
+                        <span className="text-sm font-medium">{t('log.keepCount.label')}</span>
+                        <span className="text-xs text-muted-foreground">{t('log.keepCount.description')}</span>
+                    </div>
                 </div>
                 <Input
                     type="number"
-                    value={keepPeriod}
-                    onChange={(e) => setKeepPeriod(e.target.value)}
-                    onBlur={handleKeepPeriodSave}
-                    placeholder={t('log.keepPeriod.placeholder')}
+                    value={keepCount}
+                    onChange={(e) => setKeepCount(e.target.value)}
+                    onBlur={handleKeepCountSave}
+                    placeholder={t('log.keepCount.placeholder')}
                     className="w-48 rounded-xl"
                     disabled={!enabled}
+                    min={1}
                 />
             </div>
 


### PR DESCRIPTION
## feat: 日志清理支持按条数保留 + 批量50%清理优化

### 改动概述

当前日志清理仅支持「按天数保留」，在高频写入场景下容易出现单日日志量过大、或低频场景下日志被过早清除的问题。本次新增「按条数保留」模式，并优化清理策略为批量删除50%，避免逐条DELETE带来的数据库抖动。

### 主要变更

**后端**
- `Setting` 模型新增 `relay_log_keep_count` / `audit_log_keep_count` 字段，支持按条数配置保留上限
- `relaylog` 清理逻辑增加按条数模式分支，当启用时以 `COUNT(*) / 2` 作为单次清理量（批量50%），留出缓冲区间减少高频小量DELETE
- `ops.go` 同步适配新字段的读写与校验

**前端**
- 日志设置卡片新增「按天 / 按条」切换开关，两种模式互斥显示对应输入框
- 条数模式下描述文案明确标注「每次清理50%」，避免用户误解为精确截断
- API endpoint 同步更新参数传递

**国际化**
- 补全 en / zh_hans / zh_hant 三语缺失 key，统一描述文案

### 兼容性

- 新增字段有默认值，升级后自动回退到原有按天数模式，无需手动迁移
- 前端旧版忽略未知字段，不影响已有部署