### PR TITLE
fix(relay): inject channel param_override into outbound requests

### DIFF
--- a/internal/relay/rewrite.go
+++ b/internal/relay/rewrite.go
@@ -1,11 +1,13 @@
 package relay
 
 import (
+	"encoding/json"
 	"fmt"
 
 	appmodel "github.com/lingyuins/octopus/internal/model"
 	transmodel "github.com/lingyuins/octopus/internal/transformer/model"
 	"github.com/lingyuins/octopus/internal/transformer/rewrite"
+	"github.com/lingyuins/octopus/internal/utils/log"
 )
 
 func prepareInternalRequestForOutbound(channel *appmodel.Channel, request *transmodel.InternalLLMRequest, groupEndpointType string) (*transmodel.InternalLLMRequest, *rewrite.EffectiveConfig, error) {
@@ -20,18 +22,63 @@ func prepareInternalRequestForOutbound(channel *appmodel.Channel, request *trans
 	if err != nil {
 		return nil, nil, err
 	}
+
+	var target *transmodel.InternalLLMRequest
 	if !enabled {
-		attachRelayGroupEndpointMetadata(request, groupEndpointType)
-		return request, effectiveRewrite, nil
+		target = request
+	} else {
+		rewritten, applyErr := rewrite.Apply(request, effectiveRewrite)
+		if applyErr != nil {
+			return nil, nil, applyErr
+		}
+		target = rewritten
 	}
 
-	rewritten, err := rewrite.Apply(request, effectiveRewrite)
-	if err != nil {
-		return nil, nil, err
+	applyParamOverride(channel, target)
+	attachRelayGroupEndpointMetadata(target, groupEndpointType)
+	return target, effectiveRewrite, nil
+}
+
+// applyParamOverride merges channel-level param_override JSON into the outbound request.
+// Only overrides fields that are not already set by the client request (client takes precedence).
+func applyParamOverride(channel *appmodel.Channel, request *transmodel.InternalLLMRequest) {
+	if channel == nil || channel.ParamOverride == nil || *channel.ParamOverride == "" {
+		return
+	}
+	if request == nil {
+		return
 	}
 
-	attachRelayGroupEndpointMetadata(rewritten, groupEndpointType)
-	return rewritten, effectiveRewrite, nil
+	var overrides map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(*channel.ParamOverride), &overrides); err != nil {
+		log.Warnf("param_override: invalid JSON for channel %d: %v", channel.ID, err)
+		return
+	}
+
+	if v, ok := overrides["max_tokens"]; ok && request.MaxTokens == nil {
+		var val int64
+		if err := json.Unmarshal(v, &val); err == nil {
+			request.MaxTokens = &val
+		}
+	}
+	if v, ok := overrides["max_completion_tokens"]; ok && request.MaxCompletionTokens == nil {
+		var val int64
+		if err := json.Unmarshal(v, &val); err == nil {
+			request.MaxCompletionTokens = &val
+		}
+	}
+	if v, ok := overrides["temperature"]; ok && request.Temperature == nil {
+		var val float64
+		if err := json.Unmarshal(v, &val); err == nil {
+			request.Temperature = &val
+		}
+	}
+	if v, ok := overrides["top_p"]; ok && request.TopP == nil {
+		var val float64
+		if err := json.Unmarshal(v, &val); err == nil {
+			request.TopP = &val
+		}
+	}
 }
 
 func attachRelayGroupEndpointMetadata(request *transmodel.InternalLLMRequest, groupEndpointType string) {


### PR DESCRIPTION
## 问题

Channel 配置中的 `param_override` 字段未被注入到出站请求中，导致无法在渠道级别覆盖模型参数（如 `max_tokens`、`temperature` 等）。

例如 Mimo v2.5 默认输出限制 512 tokens，通过 `param_override` 设置 `{"max_tokens": 128000}` 无效。

## 修复

在 `prepareInternalRequestForOutbound` 中新增 `applyParamOverride()` 调用，将 channel 的 `ParamOverride` JSON 解析后注入到出站请求。

**支持覆盖的参数：**
- `max_tokens`
- `max_completion_tokens`
- `temperature`
- `top_p`

**优先级规则：** 客户端已设置的字段不会被覆盖（client takes precedence）。

## 测试

- ✅ 部署验证：参数注入生效，Mimo v2.5 输出长度正确提升至 128K
- ✅ Fork CI 编译通过