### PR TITLE
优化 relay 异常重试、流会话和日志写入稳定性

### DIFF
--- a/internal/op/relaylog/relaylog.go
+++ b/internal/op/relaylog/relaylog.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lingyuins/octopus/internal/utils/log"
 	"github.com/lingyuins/octopus/internal/utils/snowflake"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const relayLogMaxSize = 200
@@ -158,7 +159,7 @@ func relayLogFlushToDB(ctx context.Context) error {
 	lastFlushedID := batch[len(batch)-1].ID
 	relayLogCacheLock.Unlock()
 
-	result := db.GetDB().WithContext(ctx).Create(&batch)
+	result := db.GetDB().WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&batch)
 	if result.Error != nil {
 		return result.Error
 	}

--- a/internal/op/relaylog/relaylog_test.go
+++ b/internal/op/relaylog/relaylog_test.go
@@ -1,0 +1,58 @@
+package relaylog
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/lingyuins/octopus/internal/db"
+	"github.com/lingyuins/octopus/internal/model"
+)
+
+func TestRelayLogFlushToDBSkipsDuplicateIDsAndTruncatesCache(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "relaylog.db")
+	if err := db.InitDB("sqlite", dsn, false); err != nil {
+		t.Fatalf("InitDB failed: %v", err)
+	}
+
+	existing := model.RelayLog{ID: 101, Time: 1, RequestModelName: "existing"}
+	if err := db.GetDB().Create(&existing).Error; err != nil {
+		t.Fatalf("seed relay log failed: %v", err)
+	}
+
+	relayLogCacheLock.Lock()
+	relayLogCache = []model.RelayLog{
+		{ID: 101, Time: 2, RequestModelName: "duplicate"},
+		{ID: 102, Time: 3, RequestModelName: "new"},
+	}
+	relayLogCacheLock.Unlock()
+	t.Cleanup(func() {
+		relayLogCacheLock.Lock()
+		relayLogCache = make([]model.RelayLog, 0, relayLogMaxSize)
+		relayLogCacheLock.Unlock()
+	})
+
+	if err := relayLogFlushToDB(context.Background()); err != nil {
+		t.Fatalf("relayLogFlushToDB returned error: %v", err)
+	}
+
+	var count int64
+	if err := db.GetDB().Model(&model.RelayLog{}).Count(&count).Error; err != nil {
+		t.Fatalf("count relay logs failed: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("relay log count = %d, want 2", count)
+	}
+
+	var inserted model.RelayLog
+	if err := db.GetDB().First(&inserted, "id = ?", 102).Error; err != nil {
+		t.Fatalf("new relay log was not inserted: %v", err)
+	}
+
+	relayLogCacheLock.Lock()
+	cacheLen := len(relayLogCache)
+	relayLogCacheLock.Unlock()
+	if cacheLen != 0 {
+		t.Fatalf("relay log cache len = %d, want 0", cacheLen)
+	}
+}

--- a/internal/relay/chat_responses_fallback_test.go
+++ b/internal/relay/chat_responses_fallback_test.go
@@ -118,3 +118,27 @@ func TestOutboundAttemptTypesResponsesFormatPrefersResponseFirst(t *testing.T) {
 		}
 	}
 }
+
+func TestShouldTryAdapterFallbackSkipsSameChannelFailures(t *testing.T) {
+	result := attemptResult{
+		Success:  false,
+		Written:  false,
+		Decision: RetryDecision{Scope: ScopeSameChannel, Reason: "unauthorized", Code: 401, IsError: true},
+	}
+
+	if shouldTryAdapterFallback(result, 0, 2) {
+		t.Fatal("expected key-scoped failure to skip adapter fallback")
+	}
+}
+
+func TestShouldTryAdapterFallbackAllowsNextChannelFailures(t *testing.T) {
+	result := attemptResult{
+		Success:  false,
+		Written:  false,
+		Decision: RetryDecision{Scope: ScopeNextChannel, Reason: "gateway error", Code: 503, IsError: true},
+	}
+
+	if !shouldTryAdapterFallback(result, 0, 2) {
+		t.Fatal("expected route-scoped failure to allow adapter fallback")
+	}
+}

--- a/internal/relay/metrics.go
+++ b/internal/relay/metrics.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/lingyuins/octopus/internal/model"
 	"github.com/lingyuins/octopus/internal/op/apikey"
@@ -16,6 +18,10 @@ import (
 	"github.com/lingyuins/octopus/internal/utils/log"
 	"github.com/lingyuins/octopus/internal/utils/telemetry"
 )
+
+const relayLogTextFieldMaxBytes = 4096
+
+const relayLogJSONFieldMaxBytes = 16384
 
 // RelayMetrics 负责最终的日志收集与持久化
 type RelayMetrics struct {
@@ -359,11 +365,36 @@ func filterMessageForLog(msg *transformerModel.Message) *transformerModel.Messag
 		return nil
 	}
 	c := *msg
+	if c.Content.Content != nil {
+		content := truncateRelayLogString(*c.Content.Content, relayLogTextFieldMaxBytes)
+		c.Content.Content = &content
+	}
+	if c.ReasoningContent != nil {
+		reasoningContent := truncateRelayLogString(*c.ReasoningContent, relayLogTextFieldMaxBytes)
+		c.ReasoningContent = &reasoningContent
+	}
+	if c.Reasoning != nil {
+		reasoning := truncateRelayLogString(*c.Reasoning, relayLogTextFieldMaxBytes)
+		c.Reasoning = &reasoning
+	}
+	if len(c.ToolCalls) > 0 {
+		c.ToolCalls = make([]transformerModel.ToolCall, len(msg.ToolCalls))
+		for i, toolCall := range msg.ToolCalls {
+			c.ToolCalls[i] = toolCall
+			c.ToolCalls[i].Function.Arguments = truncateRelayLogString(toolCall.Function.Arguments, relayLogTextFieldMaxBytes)
+		}
+	}
 	c.Images = nil
 	if len(c.Content.MultipleContent) > 0 {
 		parts := make([]transformerModel.MessageContentPart, 0, len(c.Content.MultipleContent))
 		for _, p := range c.Content.MultipleContent {
 			switch {
+			case p.Type == "text" && p.Text != nil:
+				text := truncateRelayLogString(*p.Text, relayLogTextFieldMaxBytes)
+				parts = append(parts, transformerModel.MessageContentPart{
+					Type: p.Type,
+					Text: &text,
+				})
 			case p.Type == "image_url" && p.ImageURL != nil:
 				parts = append(parts, transformerModel.MessageContentPart{
 					Type:     "image_url",
@@ -397,21 +428,50 @@ func filterMessageForLog(msg *transformerModel.Message) *transformerModel.Messag
 	return &c
 }
 
+func truncateRelayLogString(value string, maxBytes int) string {
+	if maxBytes <= 0 || len(value) <= maxBytes {
+		return value
+	}
+
+	truncated := value[:maxBytes]
+	for !utf8.ValidString(truncated) && len(truncated) > 0 {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return fmt.Sprintf("%s...[truncated %d bytes for storage]", truncated, len(value)-len(truncated))
+}
+
 func filterEmbeddingInputForLog(input *transformerModel.EmbeddingInput) *transformerModel.EmbeddingInput {
 	if input == nil {
 		return nil
 	}
 	cloned := *input
-	for i, value := range cloned.Multiple {
-		if len(value) > 4096 {
-			cloned.Multiple[i] = value[:4096] + "...[truncated for storage]"
-		}
+	if len(input.Multiple) > 0 {
+		cloned.Multiple = make([]string, len(input.Multiple))
+		copy(cloned.Multiple, input.Multiple)
 	}
-	if cloned.Single != nil && len(*cloned.Single) > 4096 {
-		truncated := (*cloned.Single)[:4096] + "...[truncated for storage]"
+	for i, value := range cloned.Multiple {
+		cloned.Multiple[i] = truncateRelayLogString(value, relayLogTextFieldMaxBytes)
+	}
+	if cloned.Single != nil {
+		truncated := truncateRelayLogString(*cloned.Single, relayLogTextFieldMaxBytes)
 		cloned.Single = &truncated
 	}
 	return &cloned
+}
+
+func filterToolsForLog(tools []transformerModel.Tool) []transformerModel.Tool {
+	if len(tools) == 0 {
+		return nil
+	}
+	filtered := make([]transformerModel.Tool, len(tools))
+	for i, tool := range tools {
+		filtered[i] = tool
+		filtered[i].Function.Description = truncateRelayLogString(tool.Function.Description, relayLogTextFieldMaxBytes)
+		if len(tool.Function.Parameters) > relayLogJSONFieldMaxBytes {
+			filtered[i].Function.Parameters = json.RawMessage(strconv.Quote(truncateRelayLogString(string(tool.Function.Parameters), relayLogJSONFieldMaxBytes)))
+		}
+	}
+	return filtered
 }
 
 func (m *RelayMetrics) filterRequestForLog(req *transformerModel.InternalLLMRequest) *transformerModel.InternalLLMRequest {
@@ -430,6 +490,9 @@ func (m *RelayMetrics) filterRequestForLog(req *transformerModel.InternalLLMRequ
 		}
 	}
 	filtered.EmbeddingInput = filterEmbeddingInputForLog(req.EmbeddingInput)
+	filtered.Tools = filterToolsForLog(req.Tools)
+	filtered.ExtraBody = nil
+	filtered.RawRequest = nil
 	return &filtered
 }
 

--- a/internal/relay/metrics_test.go
+++ b/internal/relay/metrics_test.go
@@ -1,10 +1,14 @@
 package relay
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/lingyuins/octopus/internal/model"
 	"github.com/lingyuins/octopus/internal/relay/balancer"
+	transmodel "github.com/lingyuins/octopus/internal/transformer/model"
 )
 
 func TestFinalChannelFallsBackToSkippedAttempt(t *testing.T) {
@@ -62,5 +66,88 @@ func TestInflightRelayResultCarriesAttemptsSnapshot(t *testing.T) {
 	channelID, channelName := finalChannel(result.attempts)
 	if channelID != 23 || channelName != "mimo-channel" {
 		t.Fatalf("finalChannel(result.attempts) = (%d, %q), want (%d, %q)", channelID, channelName, 23, "mimo-channel")
+	}
+}
+
+func TestTruncateRelayLogStringPreservesUTF8(t *testing.T) {
+	value := strings.Repeat("界", relayLogTextFieldMaxBytes)
+	got := truncateRelayLogString(value, relayLogTextFieldMaxBytes)
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncateRelayLogString() returned invalid UTF-8")
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Fatalf("truncateRelayLogString() = %q, want truncation marker", got)
+	}
+}
+
+func TestFilterRequestForLogTruncatesLargeTextFields(t *testing.T) {
+	longText := strings.Repeat("x", relayLogTextFieldMaxBytes+100)
+	longReasoning := strings.Repeat("r", relayLogTextFieldMaxBytes+100)
+	longArgs := strings.Repeat("a", relayLogTextFieldMaxBytes+100)
+	longPart := strings.Repeat("p", relayLogTextFieldMaxBytes+100)
+	longEmbedding := strings.Repeat("e", relayLogTextFieldMaxBytes+100)
+	longToolDescription := strings.Repeat("d", relayLogTextFieldMaxBytes+100)
+	longToolParams := json.RawMessage(`{"type":"object","description":"` + strings.Repeat("s", relayLogJSONFieldMaxBytes+100) + `"}`)
+	stream := true
+	req := &transmodel.InternalLLMRequest{
+		Model:  "gpt-4o",
+		Stream: &stream,
+		Messages: []transmodel.Message{{
+			Role:             "assistant",
+			Content:          transmodel.MessageContent{Content: &longText, MultipleContent: []transmodel.MessageContentPart{{Type: "text", Text: &longPart}}},
+			ReasoningContent: &longReasoning,
+			ToolCalls: []transmodel.ToolCall{{
+				ID:       "call-1",
+				Type:     "function",
+				Function: transmodel.FunctionCall{Name: "search", Arguments: longArgs},
+			}},
+		}},
+		EmbeddingInput: &transmodel.EmbeddingInput{Single: &longEmbedding, Multiple: []string{longEmbedding}},
+		Tools: []transmodel.Tool{{
+			Type: "function",
+			Function: transmodel.Function{
+				Name:        "search",
+				Description: longToolDescription,
+				Parameters:  longToolParams,
+			},
+		}},
+		ExtraBody:  json.RawMessage(`{"large":"body"}`),
+		RawRequest: []byte(`{"raw":"request"}`),
+	}
+
+	filtered := (&RelayMetrics{}).filterRequestForLog(req)
+
+	if got := *filtered.Messages[0].Content.Content; len(got) <= relayLogTextFieldMaxBytes || !strings.Contains(got, "truncated") {
+		t.Fatalf("message content was not truncated: len=%d value=%q", len(got), got)
+	}
+	if got := *filtered.Messages[0].ReasoningContent; len(got) <= relayLogTextFieldMaxBytes || !strings.Contains(got, "truncated") {
+		t.Fatalf("reasoning content was not truncated: len=%d value=%q", len(got), got)
+	}
+	if got := filtered.Messages[0].ToolCalls[0].Function.Arguments; len(got) <= relayLogTextFieldMaxBytes || !strings.Contains(got, "truncated") {
+		t.Fatalf("tool call arguments were not truncated: len=%d value=%q", len(got), got)
+	}
+	if got := *filtered.Messages[0].Content.MultipleContent[0].Text; len(got) <= relayLogTextFieldMaxBytes || !strings.Contains(got, "truncated") {
+		t.Fatalf("content part text was not truncated: len=%d value=%q", len(got), got)
+	}
+	if got := *filtered.EmbeddingInput.Single; len(got) <= relayLogTextFieldMaxBytes || !strings.Contains(got, "truncated") {
+		t.Fatalf("embedding single was not truncated: len=%d value=%q", len(got), got)
+	}
+	if got := filtered.EmbeddingInput.Multiple[0]; len(got) <= relayLogTextFieldMaxBytes || !strings.Contains(got, "truncated") {
+		t.Fatalf("embedding multiple was not truncated: len=%d value=%q", len(got), got)
+	}
+	if got := filtered.Tools[0].Function.Description; len(got) <= relayLogTextFieldMaxBytes || !strings.Contains(got, "truncated") {
+		t.Fatalf("tool description was not truncated: len=%d value=%q", len(got), got)
+	}
+	if len(filtered.Tools[0].Function.Parameters) > relayLogJSONFieldMaxBytes+128 {
+		t.Fatalf("tool parameters were not bounded: len=%d", len(filtered.Tools[0].Function.Parameters))
+	}
+	if len(filtered.ExtraBody) != 0 || len(filtered.RawRequest) != 0 {
+		t.Fatalf("log filter should clear ExtraBody and RawRequest")
+	}
+	if *req.Messages[0].Content.Content != longText || req.Messages[0].ToolCalls[0].Function.Arguments != longArgs {
+		t.Fatalf("filterRequestForLog mutated original request")
+	}
+	if req.EmbeddingInput.Multiple[0] != longEmbedding {
+		t.Fatalf("filterRequestForLog mutated original embedding input")
 	}
 }

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -116,6 +116,18 @@ func isLLMRequestFormat(request *model.InternalLLMRequest) bool {
 		return false
 	}
 }
+
+func shouldTryAdapterFallback(result attemptResult, adapterIndex, attemptCount int) bool {
+	if result.Success || result.Written || result.Decision.Scope == ScopeAbortAll || adapterIndex >= attemptCount-1 {
+		return false
+	}
+	// Key-scoped failures use the same credential across adapter formats, so
+	// trying another adapter only adds latency before the normal key retry path.
+	if result.Decision.Scope == ScopeSameChannel {
+		return false
+	}
+	return true
+}
 func isZenCandidateChannelAllowed(requestModel string, channelType outbound.OutboundType, isEmbeddingRequest bool) bool {
 	preferred := detectZenPreferredChannelTypes(requestModel, isEmbeddingRequest)
 	if len(preferred) == 0 {
@@ -1176,7 +1188,7 @@ func executeRelay(req *relayRequest, group dbmodel.Group, requestModel string, m
 						}
 						break
 					}
-					if result.Written || result.Decision.Scope == ScopeAbortAll || adapterIndex == len(attemptTypes)-1 {
+					if !shouldTryAdapterFallback(result, adapterIndex, len(attemptTypes)) {
 						break
 					}
 					log.Infof("[%s] %s adapter failed on channel %s, falling back to %s: %v",

--- a/internal/relay/request_session.go
+++ b/internal/relay/request_session.go
@@ -93,7 +93,7 @@ func shouldUseRelayStreamSession(req *transmodel.InternalLLMRequest) bool {
 	if req == nil || req.Stream == nil || !*req.Stream {
 		return false
 	}
-	return true
+	return strings.TrimSpace(req.ConversationID) != ""
 }
 
 func resolveRelayStreamSessionIdentity(endpointType string, inboundType int, apiKeyID int, req *transmodel.InternalLLMRequest) (string, uint64, bool) {
@@ -107,11 +107,6 @@ func resolveRelayStreamSessionIdentity(endpointType string, inboundType int, api
 	}
 
 	conversationID := strings.TrimSpace(req.ConversationID)
-	if conversationID == "" {
-		conversationID = "implicit:" + strconv.FormatUint(requestHash, 16)
-		req.ConversationID = conversationID
-	}
-
 	return conversationID, requestHash, true
 }
 

--- a/internal/relay/stream_session_test.go
+++ b/internal/relay/stream_session_test.go
@@ -132,7 +132,7 @@ func TestBuildRelayStreamSessionHash_IgnoresResumeControlFields(t *testing.T) {
 	}
 }
 
-func TestResolveRelayStreamSessionIdentity_GeneratesImplicitConversationID(t *testing.T) {
+func TestResolveRelayStreamSessionIdentityRequiresExplicitConversationID(t *testing.T) {
 	stream := true
 	req := &transmodel.InternalLLMRequest{
 		Model:      "gpt-4o",
@@ -141,23 +141,36 @@ func TestResolveRelayStreamSessionIdentity_GeneratesImplicitConversationID(t *te
 	}
 
 	conversationID, requestHash, ok := resolveRelayStreamSessionIdentity("chat", 0, 7, req)
-	if !ok {
-		t.Fatal("resolveRelayStreamSessionIdentity() should enable stream session for stream requests without conversation_id")
+	if ok || conversationID != "" || requestHash != 0 {
+		t.Fatalf("resolveRelayStreamSessionIdentity() = (%q, %d, %t), want disabled", conversationID, requestHash, ok)
 	}
-	if !strings.HasPrefix(conversationID, "implicit:") {
-		t.Fatalf("conversationID = %q, want implicit prefix", conversationID)
+}
+
+func TestResolveRelayStreamSessionIdentityUsesExplicitConversationID(t *testing.T) {
+	stream := true
+	req := &transmodel.InternalLLMRequest{
+		Model:          "gpt-4o",
+		Stream:         &stream,
+		ConversationID: "conv-1",
+		RawRequest:     []byte(`{"conversation_id":"conv-1","model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hello"}]}`),
+	}
+
+	conversationID, requestHash, ok := resolveRelayStreamSessionIdentity("chat", 0, 7, req)
+	if !ok {
+		t.Fatal("resolveRelayStreamSessionIdentity() should enable explicit stream session")
+	}
+	if conversationID != "conv-1" {
+		t.Fatalf("conversationID = %q, want conv-1", conversationID)
 	}
 	if requestHash == 0 {
 		t.Fatal("requestHash should be non-zero")
 	}
-	if req.ConversationID != conversationID {
-		t.Fatalf("req.ConversationID = %q, want %q", req.ConversationID, conversationID)
-	}
 
 	retry := &transmodel.InternalLLMRequest{
-		Model:      "gpt-4o",
-		Stream:     &stream,
-		RawRequest: []byte(`{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hello"}],"last_event_id":2}`),
+		Model:          "gpt-4o",
+		Stream:         &stream,
+		ConversationID: "conv-1",
+		RawRequest:     []byte(`{"conversation_id":"conv-1","model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hello"}],"last_event_id":2}`),
 	}
 	retryConversationID, retryHash, ok := resolveRelayStreamSessionIdentity("chat", 0, 7, retry)
 	if !ok {


### PR DESCRIPTION
## 变更说明

这个 PR 主要改善 relay 在异常渠道、大请求和日志写入场景下的响应速度与稳定性：

1. relay log 批量写入时对重复 ID 使用 `ON CONFLICT DO NOTHING`，避免单条重复日志导致整批保存失败。
2. 对 401/403/429 等同密钥/同渠道错误跳过 Chat/Responses 适配器 fallback，减少无意义的重复上游请求。
3. 普通 `stream=true` 请求不再隐式创建可恢复流会话，仅在显式传入 `conversation_id` / `X-Conversation-ID` 时启用；同时对 relay log 中的长文本、reasoning、tool call 参数、embedding 输入和 tool schema 做日志副本截断，降低大上下文请求带来的内存和 SQLite 写入压力。

## 测试

```bash
go test ./internal/relay ./internal/op/relaylog -run 'Metrics|TruncateRelayLog|FilterRequestForLog|StreamSession|RelayStreamSession|ResolveRelayStreamSession|OutboundAttemptTypes|ShouldTryAdapterFallback|RelayLog|Classify|Retry|FailureHint'
```