### PR TITLE
fix: 修复 MorphingDialog 内嵌 Radix Dialog 点击任意位置导致关闭 (#45)

### DIFF
--- a/web/src/components/ui/morphing-dialog.tsx
+++ b/web/src/components/ui/morphing-dialog.tsx
@@ -288,6 +288,12 @@ function MorphingDialogContent({
       if (openPopoverContent) {
         return true;
       }
+      if (target?.closest('[data-slot="dialog-content"]')) {
+        return true;
+      }
+      if (target?.closest('[data-slot="dialog-overlay"]')) {
+        return true;
+      }
       const dialogLayer = target?.closest('[data-slot="morphing-dialog-layer"]') as HTMLElement | null;
       if (dialogLayer && dialogLayer.dataset.dialogId !== uniqueId) {
         return true;


### PR DESCRIPTION
## 问题描述

在投影渠道 Key 管理界面中，点击 Dialog 内任意位置都会导致整个站点管理页面关闭。

## 根本原因

`MorphingDialogContent` 使用 `useClickOutside` 钩子检测外部点击并关闭自身。Radix Dialog 通过 Portal 渲染到 `document.body`，位于 MorphingDialogContent 的 DOM 树之外。当用户点击 Radix Dialog 内容时，`useClickOutside` 将其误判为"外部点击"并触发关闭。

`shouldIgnore` 排除函数已处理 Select 下拉框、Popover 和其他 MorphingDialog 层，但**缺少对 Radix Dialog 元素的排除检查**。

## 修复方案

在 `morphing-dialog.tsx` 的 `useClickOutside` 排除函数中添加对 `[data-slot="dialog-content"]` 和 `[data-slot="dialog-overlay"]` 的检查，与已有的 Select、Popover 排除逻辑保持一致。

## 影响范围

此修复同时解决以下在 MorphingDialog 内嵌套的 Radix Dialog 的同类问题：
- 投影渠道 Key 管理（#45 报告的 Bug）
- 快捷创建站点 Key
- 高级设置
- 手动添加模型

Closes #45