### PR TITLE
perf: 日志列表查询不再读取并重解析 response_content 大字段 (#52)

### DIFF
--- a/internal/model/log.go
+++ b/internal/model/log.go
@@ -37,16 +37,16 @@ type RelayLog struct {
 	ActualModelName   string           `json:"actual_model_name" gorm:"column:actual_model_name"`       // 实际使用模型名称
 	InputTokens       int              `json:"input_tokens" gorm:"column:input_tokens"`                 // 输入Token
 	OutputTokens      int              `json:"output_tokens" gorm:"column:output_tokens"`               // 输出 Token
-	SemanticCacheHit  bool             `json:"semantic_cache_hit" gorm:"-"`
-	CacheReadTokens   int              `json:"cache_read_tokens" gorm:"-"`                      // 提供方提示缓存命中 Token
-	Ftut              int              `json:"ftut" gorm:"column:ftut"`                         // 首字时间(毫秒)
-	UseTime           int              `json:"use_time" gorm:"column:use_time"`                 // 总用时(毫秒)
-	Cost              float64          `json:"cost" gorm:"column:cost"`                         // 消耗费用
-	RequestContent    string           `json:"request_content" gorm:"column:request_content"`   // 请求内容
-	ResponseContent   string           `json:"response_content" gorm:"column:response_content"` // 响应内容
-	Error             string           `json:"error" gorm:"column:error"`                       // 错误信息
-	Attempts          []ChannelAttempt `json:"attempts" gorm:"column:attempts;serializer:json"` // 所有尝试记录
-	TotalAttempts     int              `json:"total_attempts" gorm:"column:total_attempts"`     // 总尝试次数
+	SemanticCacheHit  bool             `json:"semantic_cache_hit" gorm:"column:semantic_cache_hit"`     // 语义缓存命中（写入时落库，避免列表查询重解析大字段）
+	CacheReadTokens   int              `json:"cache_read_tokens" gorm:"column:cache_read_tokens"`       // 提供方提示缓存命中 Token（写入时落库）
+	Ftut              int              `json:"ftut" gorm:"column:ftut"`                                 // 首字时间(毫秒)
+	UseTime           int              `json:"use_time" gorm:"column:use_time"`                         // 总用时(毫秒)
+	Cost              float64          `json:"cost" gorm:"column:cost"`                                 // 消耗费用
+	RequestContent    string           `json:"request_content" gorm:"column:request_content"`           // 请求内容
+	ResponseContent   string           `json:"response_content" gorm:"column:response_content"`         // 响应内容
+	Error             string           `json:"error" gorm:"column:error"`                               // 错误信息
+	Attempts          []ChannelAttempt `json:"attempts" gorm:"column:attempts;serializer:json"`         // 所有尝试记录
+	TotalAttempts     int              `json:"total_attempts" gorm:"column:total_attempts"`             // 总尝试次数
 }
 
 // RelayLogListItem 日志列表轻量条目，排除了 RequestContent 和 ResponseContent 大字段
@@ -63,15 +63,14 @@ type RelayLogListItem struct {
 	ActualModelName   string           `json:"actual_model_name" gorm:"column:actual_model_name"`
 	InputTokens       int              `json:"input_tokens" gorm:"column:input_tokens"`
 	OutputTokens      int              `json:"output_tokens" gorm:"column:output_tokens"`
-	SemanticCacheHit  bool             `json:"semantic_cache_hit" gorm:"-"`
-	CacheReadTokens   int              `json:"cache_read_tokens" gorm:"-"`
+	SemanticCacheHit  bool             `json:"semantic_cache_hit" gorm:"column:semantic_cache_hit"`
+	CacheReadTokens   int              `json:"cache_read_tokens" gorm:"column:cache_read_tokens"`
 	Ftut              int              `json:"ftut" gorm:"column:ftut"`
 	UseTime           int              `json:"use_time" gorm:"column:use_time"`
 	Cost              float64          `json:"cost" gorm:"column:cost"`
 	Error             string           `json:"error" gorm:"column:error"`
 	Attempts          []ChannelAttempt `json:"attempts" gorm:"column:attempts;serializer:json"`
 	TotalAttempts     int              `json:"total_attempts" gorm:"column:total_attempts"`
-	ResponseContent   string           `json:"-" gorm:"column:response_content"`
 }
 
 // TableName explicitly returns "-" for DTO structs to prevent GORM auto-mapping.
@@ -103,6 +102,5 @@ func (r *RelayLog) ToListItem() RelayLogListItem {
 		Error:             r.Error,
 		Attempts:          r.Attempts,
 		TotalAttempts:     r.TotalAttempts,
-		ResponseContent:   r.ResponseContent,
 	}
 }

--- a/internal/op/relaylog/relaylog.go
+++ b/internal/op/relaylog/relaylog.go
@@ -482,7 +482,7 @@ func RelayLogList(ctx context.Context, startTime, endTime *int, page, pageSize i
 			if idx < 0 {
 				break
 			}
-			result = append(result, enrichRelayLogListItem(cachedLogs[idx].ToListItem(), cachedLogs[idx].ResponseContent))
+			result = append(result, cachedLogs[idx].ToListItem())
 		}
 	}
 
@@ -501,7 +501,8 @@ func RelayLogList(ctx context.Context, startTime, endTime *int, page, pageSize i
 				Select("id", "time", "request_model_name", "request_api_key_id", "request_api_key_name",
 					"client_ip",
 					"endpoint_type", "channel_id", "channel_name", "actual_model_name",
-					"input_tokens", "output_tokens", "response_content", "ftut", "use_time",
+					"input_tokens", "output_tokens", "semantic_cache_hit", "cache_read_tokens",
+					"ftut", "use_time",
 					"cost", "error", "attempts", "total_attempts")
 			if startTime != nil {
 				query = query.Where("time >= ?", *startTime)
@@ -521,9 +522,9 @@ func RelayLogList(ctx context.Context, startTime, endTime *int, page, pageSize i
 			if err := query.Order("id DESC").Offset(dbOffset).Limit(remaining).Find(&dbLogs).Error; err != nil {
 				return nil, err
 			}
-			for _, dbLog := range dbLogs {
-				result = append(result, enrichRelayLogListItem(dbLog, dbLog.ResponseContent))
-			}
+			// semantic_cache_hit / cache_read_tokens 已在写入时落库，直接返回，
+			// 无需读取并重新解析 response_content 大字段。
+			result = append(result, dbLogs...)
 		}
 	}
 
@@ -551,16 +552,6 @@ func RelayLogCacheReadTokens(responseContent string) int {
 		return 0
 	}
 	return int(usage.CachedTokens)
-}
-
-func enrichRelayLogListItem(item model.RelayLogListItem, responseContent string) model.RelayLogListItem {
-	if usage, ok := cacheusage.ParseProviderPromptCacheUsageSignals(responseContent); ok {
-		item.SemanticCacheHit = usage.SemanticCacheHit
-		if !usage.SemanticCacheHit {
-			item.CacheReadTokens = int(usage.CachedTokens)
-		}
-	}
-	return item
 }
 
 func RelayLogClear(ctx context.Context) error {

--- a/internal/op/relaylog/relaylog_test.go
+++ b/internal/op/relaylog/relaylog_test.go
@@ -281,3 +281,56 @@ func TestRelayLogApplyKeepEnabledClosesAndReopensLogDB(t *testing.T) {
 		t.Fatalf("GetLogDB() should be non-nil after re-enabling logs")
 	}
 }
+
+// TestRelayLogListReadsPersistedCacheColumns 验证列表查询直接返回落库的
+// semantic_cache_hit / cache_read_tokens 列，而不再读取并解析 response_content
+// 大字段——这是日志列表加载缓慢问题的核心修复点。
+func TestRelayLogListReadsPersistedCacheColumns(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "relaylog-cachecols.db")
+	if err := db.InitDB("sqlite", dsn, false); err != nil {
+		t.Fatalf("InitDB failed: %v", err)
+	}
+	// 显式声明共用主库模式，清除可能被前序「独立日志库」测试残留的全局
+	// logDBType 状态（CloseLogDB 在关闭后仍保留 logDBType 供 Reopen 使用），
+	// 否则 GetLogDB 会走独立库分支返回 nil，跳过本测试需要的 DB 查询。
+	if err := db.InitLogDB("", "", false); err != nil {
+		t.Fatalf("InitLogDB(shared) failed: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := setting.RefreshCache(context.Background()); err != nil {
+		t.Fatalf("RefreshCache failed: %v", err)
+	}
+	// 启用日志保存，让列表查询走 DB 分支。
+	if err := setting.SetString(model.SettingKeyRelayLogKeepEnabled, "true"); err != nil {
+		t.Fatalf("enable relay log keep failed: %v", err)
+	}
+
+	// 落库时大字段是一个无法解析出缓存信号的占位串：若查询仍依赖解析
+	// response_content，下面对 cache 列的断言就会失败。
+	seed := []model.RelayLog{
+		{ID: 1, Time: 1, RequestModelName: "gpt-4", SemanticCacheHit: true, CacheReadTokens: 0, ResponseContent: "not-json"},
+		{ID: 2, Time: 2, RequestModelName: "claude", SemanticCacheHit: false, CacheReadTokens: 123, ResponseContent: "not-json"},
+	}
+	if err := db.GetDB().Create(&seed).Error; err != nil {
+		t.Fatalf("seed relay logs failed: %v", err)
+	}
+
+	logs, err := RelayLogList(context.Background(), nil, nil, 1, 50)
+	if err != nil {
+		t.Fatalf("RelayLogList returned error: %v", err)
+	}
+	if len(logs) != 2 {
+		t.Fatalf("RelayLogList returned %d logs, want 2", len(logs))
+	}
+
+	byID := make(map[int64]model.RelayLogListItem, len(logs))
+	for _, l := range logs {
+		byID[l.ID] = l
+	}
+	if !byID[1].SemanticCacheHit {
+		t.Fatalf("log 1 SemanticCacheHit = false, want true (should come from persisted column)")
+	}
+	if byID[2].CacheReadTokens != 123 {
+		t.Fatalf("log 2 CacheReadTokens = %d, want 123 (should come from persisted column)", byID[2].CacheReadTokens)
+	}
+}

--- a/internal/server/handlers/log.go
+++ b/internal/server/handlers/log.go
@@ -139,7 +139,9 @@ func streamLog(c *gin.Context) {
 			if relaylog.RelayLogStreamExcluded(log.RequestModelName) {
 				continue
 			}
-			data, err := json.Marshal(log)
+			// 仅推送列表所需的轻量字段，剥离 request_content / response_content
+			// 大字段（详情按需单独拉取），避免高 QPS 下用大 payload 拖慢前端。
+			data, err := json.Marshal(log.ToListItem())
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
## 问题

修复 #52— 前端日志列表加载时间超长。

## 根因

日志列表查询和实时推送都在反复处理 `response_content` 大字段：

1. **列表查询拉取并逐条重解析大字段** — `RelayLogList` 的 DB 分支为计算「语义缓存命中」「缓存读取 token」两个值，把 `response_content`（每条可达数十~数百 KB）一并 `Select` 出来并逐条重新解析 JSON，造成大表下的 IO + CPU 双重瓶颈。而这两个值在写入时（`metrics.go`）其实早已算好却被丢弃。
2. **SSE 实时推送整条日志** — `streamLog` 把含 `request_content` + `response_content` 的完整 `RelayLog` 推给前端，但前端列表卡片并不使用这两个字段（详情点开时按需单独拉取）。高 QPS 下前端被大 payload 拖慢。

## 改动

- `SemanticCacheHit` / `CacheReadTokens` 由 `gorm:"-"` 改为持久化列，写入时落库（AutoMigrate 自动加列）。
- 列表查询不再 `Select` `response_content`，直接读两个轻量列，移除逐条 JSON 重解析（删除废弃的 `enrichRelayLogListItem`）。
- SSE 改为推送 `ToListItem()`，剥离两个大字段。

## 关于旧数据

历史记录的这两列为默认值，不做全表 backfill（backfill 需全表解析大字段，正是要避免的开销；日志本身可丢弃）。详情接口仍按 `response_content` 实时重算，旧数据点开详情不受影响。

## 测试

- 新增 `TestRelayLogListReadsPersistedCacheColumns` 锁定「从落库列读取、不再解析大字段」的行为。
- 后端全量 `go test ./...` 通过。
- 前端 `pnpm lint` 0 error。
