### PR TITLE
fix: MiMo TTS Accept header 覆盖 + 不支持音频格式回退

### DIFF
--- a/internal/relay/media_relay.go
+++ b/internal/relay/media_relay.go
@@ -524,6 +524,13 @@ func forwardMediaRequestJSON(
 
 	copyMediaForwardHeaders(req, c, channel, key, "application/json", streamRequested)
 
+	// MiMo Chat Completions API only accepts application/json, but the
+	// upstream TTS client (e.g. OpenAI SDK) sends Accept: audio/mpeg.
+	// Override after copyMediaForwardHeaders to prevent 406 responses.
+	if strings.EqualFold(strings.TrimSpace(group.EndpointProvider), "mimo") && cfg.UpstreamPath == "/v1/chat/completions" {
+		req.Header.Set("Accept", "application/json")
+	}
+
 	// Send request
 	httpClient, err := helper.ChannelHttpClient(channel)
 	if err != nil {

--- a/internal/relay/media_relay.go
+++ b/internal/relay/media_relay.go
@@ -552,7 +552,7 @@ func forwardMediaRequestJSON(
 	if cfg.BinaryResponse {
 		provider := strings.ToLower(strings.TrimSpace(group.EndpointProvider))
 		if provider == "mimo" && cfg.UpstreamPath == "/v1/chat/completions" {
-			return handleMimoTTSResponse(c, response)
+			return handleMimoTTSResponse(c, response, cfg.AudioFormat)
 		}
 		return handleBinaryResponse(c, response)
 	}
@@ -890,6 +890,12 @@ func rewriteAudioSpeechRequestByProvider(group dbmodel.Group, cfg mediaEndpointC
 	if format == "" {
 		format = "wav"
 	}
+	// MiMo TTS only supports wav, mp3, pcm, pcm16.
+	// Map unsupported formats (opus, flac, aac, etc.) to mp3.
+	if format != "wav" && format != "mp3" && format != "pcm" && format != "pcm16" {
+		format = "mp3"
+	}
+	cfg.AudioFormat = format
 	if voice == "" {
 		voice = "mimo_default"
 	}
@@ -926,7 +932,7 @@ type mimoTTSChatResponse struct {
 
 // handleMimoTTSResponse extracts the base64-encoded audio from a MiMo chat
 // completion JSON response and sends it as binary audio to the client.
-func handleMimoTTSResponse(c *gin.Context, response *http.Response) (int, error) {
+func handleMimoTTSResponse(c *gin.Context, response *http.Response, audioFormat string) (int, error) {
 	respBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return 0, fmt.Errorf("failed to read MiMo TTS response: %w", err)
@@ -946,8 +952,15 @@ func handleMimoTTSResponse(c *gin.Context, response *http.Response) (int, error)
 		return response.StatusCode, fmt.Errorf("failed to decode MiMo TTS audio: %w", err)
 	}
 
-	// Determine audio content type from the response format
-	c.Header("Content-Type", "audio/wav")
+	// Set Content-Type based on the resolved audio format.
+	contentType := "audio/wav"
+	switch audioFormat {
+	case "mp3":
+		contentType = "audio/mpeg"
+	case "pcm", "pcm16":
+		contentType = "audio/pcm"
+	}
+	c.Header("Content-Type", contentType)
 	_, err = c.Writer.Write(audioData)
 	if err != nil {
 		return 0, fmt.Errorf("failed to write MiMo TTS audio: %w", err)

--- a/internal/relay/media_type.go
+++ b/internal/relay/media_type.go
@@ -24,6 +24,8 @@ type mediaEndpointConfig struct {
 	BinaryResponse bool
 	// MultipartInput indicates the inbound request uses multipart/form-data.
 	MultipartInput bool
+	// AudioFormat carries the resolved audio format for MiMo TTS responses.
+	AudioFormat string
 }
 
 // mediaEndpointConfigs maps each media endpoint type to its configuration.

--- a/internal/relay/request_body_test.go
+++ b/internal/relay/request_body_test.go
@@ -399,3 +399,26 @@ func TestRewriteAudioSpeechRequestByProvider_Defaults(t *testing.T) {
 		t.Fatalf("audio.voice = %v, want default mimo_default", audio["voice"])
 	}
 }
+
+func TestRewriteAudioSpeechRequestByProvider_OpusClampedToMp3(t *testing.T) {
+	group := dbmodel.Group{EndpointProvider: "mimo"}
+	body := []byte(`{"model":"mimo-v2.5-tts","input":"Hello","voice":"Chloe","response_format":"opus"}`)
+	cfg := mediaEndpointConfig{UpstreamPath: "/v1/audio/speech", BinaryResponse: true}
+
+	gotBody, gotCfg := rewriteAudioSpeechRequestByProvider(group, cfg, body)
+	if gotCfg.UpstreamPath != "/v1/chat/completions" {
+		t.Fatalf("UpstreamPath = %q, want %q", gotCfg.UpstreamPath, "/v1/chat/completions")
+	}
+	if gotCfg.AudioFormat != "mp3" {
+		t.Fatalf("AudioFormat = %q, want mp3", gotCfg.AudioFormat)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(gotBody, &raw); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	audio := raw["audio"].(map[string]any)
+	if audio["format"] != "mp3" {
+		t.Fatalf("audio.format = %v, want mp3", audio["format"])
+	}
+}


### PR DESCRIPTION
## fix: MiMo TTS Accept header 覆盖 + 不支持音频格式回退

### 问题
1. OpenAI TTS SDK 发送 `Accept: audio/mpeg`，但 MiMo Chat Completions API 只接受 `application/json`，导致 406。
2. `response_format` 传入 `opus`/`flac`/`aac` 等 MiMo 不支持的格式时，会直接报错。

### 修改
- **Accept header 覆盖**：当 provider=mimo 且路径为 `/v1/chat/completions` 时，强制将 Accept 设为 `application/json`（在 `copyMediaForwardHeaders` 之后）。
- **音频格式回退**：`rewriteAudioSpeechRequestByProvider` 中，将 wav/mp3/pcm/pcm16 以外的格式（opus、flac、aac 等）统一回退为 mp3。
- **Content-Type 响应头**：`handleMimoTTSResponse` 根据实际解析的音频格式返回正确的 Content-Type（audio/mpeg / audio/pcm / audio/wav）。
- 新增 `AudioFormat` 字段到 `mediaEndpointConfig`，贯穿请求改写到响应处理流程。
- 新增单元测试 `TestRewriteAudioSpeechRequestByProvider_OpusClampedToMp3`。

### 测试
仅在 hermes-agent 环境中通过测试（hermes-agent 通过）。