### PR TITLE
feat: 日志界面费用/数字中国化 + 模型广场价格单位提示

### DIFF
--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -1736,6 +1736,14 @@
       "description": "Drag to reorder setting page sections. Changes are saved immediately on drop.",
       "reset": "Reset to Default",
       "resetSuccess": "Setting item order has been reset"
+    },
+    "chinaMode": {
+      "label": "China Localization",
+      "description": "Display costs in CNY, numbers in 万/亿 units",
+      "exchangeRate": {
+        "label": "USD to CNY Rate",
+        "hint": "Default 7.2, adjustable"
+      }
     }
   },
   "group": {

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -2076,7 +2076,8 @@
       "cacheRead": "Cache Read",
       "cacheWrite": "Cache Write",
       "submit": "Create",
-      "submitting": "Creating..."
+      "submitting": "Creating...",
+      "priceHint": "Price unit: USD / 1M tokens"
     },
     "summary": {
       "title": "Model Market",
@@ -2132,7 +2133,8 @@
       "output": "Output",
       "cacheRead": "Cache Read",
       "cacheWrite": "Cache Write",
-      "save": "Save"
+      "save": "Save",
+      "priceHint": "Price unit: USD / 1M tokens"
     },
     "capabilities": {
       "title": "Model Capabilities",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -2076,7 +2076,8 @@
       "cacheRead": "缓存读取",
       "cacheWrite": "缓存写入",
       "submit": "创建",
-      "submitting": "创建中..."
+      "submitting": "创建中...",
+      "priceHint": "价格单位：美元 / 百万 tokens"
     },
     "summary": {
       "title": "模型广场",
@@ -2132,7 +2133,8 @@
       "output": "输出",
       "cacheRead": "缓存读取",
       "cacheWrite": "缓存写入",
-      "save": "保存"
+      "save": "保存",
+      "priceHint": "价格单位：美元 / 百万 tokens"
     },
     "capabilities": {
       "title": "模型能力",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -1736,6 +1736,14 @@
       "description": "拖拽调整设置页面各选项的排列顺序，松手后立即保存。",
       "reset": "恢复默认顺序",
       "resetSuccess": "设置项顺序已恢复默认"
+    },
+    "chinaMode": {
+      "label": "中国化模式",
+      "description": "费用显示人民币，数字使用万/亿单位",
+      "exchangeRate": {
+        "label": "美元兑人民币汇率",
+        "hint": "默认 7.2，可手动调整"
+      }
     }
   },
   "group": {

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -2076,7 +2076,8 @@
       "cacheRead": "快取讀取",
       "cacheWrite": "快取寫入",
       "submit": "建立",
-      "submitting": "建立中..."
+      "submitting": "建立中...",
+      "priceHint": "價格單位：美元 / 百萬 tokens"
     },
     "summary": {
       "title": "模型廣場",
@@ -2132,7 +2133,8 @@
       "output": "輸出",
       "cacheRead": "快取讀取",
       "cacheWrite": "快取寫入",
-      "save": "儲存"
+      "save": "儲存",
+      "priceHint": "價格單位：美元 / 百萬 tokens"
     },
     "capabilities": {
       "title": "模型能力",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -1736,6 +1736,14 @@
       "description": "拖曳調整設定頁面各選項的排列順序，放開後立即儲存。",
       "reset": "恢復預設順序",
       "resetSuccess": "設定項順序已恢復預設"
+    },
+    "chinaMode": {
+      "label": "中國化模式",
+      "description": "費用顯示人民幣，數字使用萬/億單位",
+      "exchangeRate": {
+        "label": "美元兌人民幣匯率",
+        "hint": "預設 7.2，可手動調整"
+      }
     }
   },
   "group": {

--- a/web/src/components/modules/apikey-dashboard/index.tsx
+++ b/web/src/components/modules/apikey-dashboard/index.tsx
@@ -35,7 +35,7 @@ import { Progress } from '@/components/ui/progress';
 import dayjs from 'dayjs';
 
 export function APIKeyDashboard() {
-    const t = useTranslations('apikeyDashboard');
+    const t = useTranslations('apiKeyDashboard');
     const { locale, setLocale, chinaMode, exchangeRate } = useSettingStore();
     const { data, error } = useAPIKeyDashboardStats();
     const { logout } = useAuthStore();

--- a/web/src/components/modules/apikey-dashboard/index.tsx
+++ b/web/src/components/modules/apikey-dashboard/index.tsx
@@ -35,11 +35,11 @@ import { Progress } from '@/components/ui/progress';
 import dayjs from 'dayjs';
 
 export function APIKeyDashboard() {
-    const t = useTranslations('apiKeyDashboard');
+    const t = useTranslations('apikeyDashboard');
+    const { locale, setLocale, chinaMode, exchangeRate } = useSettingStore();
     const { data, error } = useAPIKeyDashboardStats();
     const { logout } = useAuthStore();
     const { theme, setTheme } = useTheme();
-    const { locale, setLocale } = useSettingStore();
     const [copying, setCopying] = useState(false);
 
     const copyWithToast = useCallback(
@@ -183,7 +183,7 @@ export function APIKeyDashboard() {
                                         <Progress value={Math.min(100, (usedCost / maxCost) * 100)} className="h-3 sm:h-4 *:data-[slot=progress-indicator]:bg-chart-1" />
                                         <div className="flex justify-between text-xs sm:text-sm text-muted-foreground mt-1">
                                             <span>0</span>
-                                            <span>{maxCost.toFixed(2)} $</span>
+                                            <span>{chinaMode ? `${(maxCost * exchangeRate).toFixed(2)} ¥` : `${maxCost.toFixed(2)} $`}</span>
                                         </div>
                                     </div>
                                 )}

--- a/web/src/components/modules/log/Item.tsx
+++ b/web/src/components/modules/log/Item.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { memo, useMemo, useState, useEffect } from 'react';
-import { Clock, Cpu, Zap, AlertCircle, ArrowDownToLine, ArrowUpFromLine, DollarSign, ArrowRight, ArrowDown, Send, MessageSquare, Loader2, RotateCw, ChevronDown, ChevronUp, Pin, KeyRound, Globe, ChevronsDownUp, ChevronsUpDown } from 'lucide-react';
+import { Clock, Cpu, Zap, AlertCircle, ArrowDownToLine, ArrowUpFromLine, DollarSign, JapaneseYen, ArrowRight, ArrowDown, Send, MessageSquare, Loader2, RotateCw, ChevronDown, ChevronUp, Pin, KeyRound, Globe, ChevronsDownUp, ChevronsUpDown } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { motion, AnimatePresence } from 'motion/react';
 import JsonView from '@uiw/react-json-view';
@@ -11,11 +11,12 @@ import { useTheme } from 'next-themes';
 import { type RelayLog, type ChannelAttempt, useLogDetail } from '@/api/endpoints/log';
 import { getModelIcon } from '@/lib/model-icons';
 import { Badge } from '@/components/ui/badge';
-import { cn } from '@/lib/utils';
+import { cn, formatCount, formatMoney } from '@/lib/utils';
 import { formatUnixSeconds } from '@/lib/time';
 import { endpointTypeLabelKey } from '@/components/modules/group/utils';
 import { resolveLogDisplayFields, formatJsonForCopy } from './display';
 import { useLogFieldVisibility } from './ui-store';
+import { useSettingStore } from '@/stores/setting';
 import { CopyIconButton } from '@/components/common/CopyButton';
 import {
     MorphingDialog,
@@ -28,6 +29,25 @@ import {
     useMorphingDialog,
 } from '@/components/ui/morphing-dialog';
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/components/animate-ui/components/animate/tooltip';
+
+/** Format count or money result into a compact display string like "1.23 万". */
+function fmt({ value, unit }: { value: string; unit: string }) {
+    return unit ? `${value} ${unit}` : value;
+}
+
+/** Format CNY cost with 2 significant figures. */
+function costFmt(cny: number): string {
+    if (cny === 0) return "0.00";
+    const abs = Math.abs(cny);
+    if (abs >= 1) return cny.toFixed(2);
+    // Determine decimal places needed for 2 sig figs, then round and format
+    const exp = Math.floor(Math.log10(abs));
+    const decimals = Math.max(0, 1 - exp);
+    const rounded = Number(abs.toFixed(decimals + 1));
+    const s = Number(rounded.toPrecision(2));
+    const finalDecimals = Math.max(0, 1 - Math.floor(Math.log10(s)));
+    return (cny < 0 ? "-" : "") + s.toFixed(finalDecimals);
+}
 
 function formatTime(timestamp: number): string {
     return formatUnixSeconds(timestamp, {
@@ -203,6 +223,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
     const [responseJsonCollapsed, setResponseJsonCollapsed] = useState(false);
     const displayFields = useMemo(() => resolveLogDisplayFields(log, detail, channelNameById), [channelNameById, detail, log]);
     const vis = useLogFieldVisibility();
+    const chinaMode = useSettingStore((s) => s.chinaMode);
     const { Avatar: ModelAvatar, color: brandColor } = useMemo(
         () => getModelIcon(displayFields.actualModelName),
         [displayFields.actualModelName]
@@ -250,9 +271,17 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
         }
     }, [log.cost, log.error, log.input_tokens, log.output_tokens, responseContent]);
 
-    const inputTokenDisplay = usageKnown ? effectiveInputTokens.toLocaleString() : tCommon('unknown');
-    const outputTokenDisplay = usageKnown ? log.output_tokens.toLocaleString() : tCommon('unknown');
-    const costDisplay = usageKnown ? Number(log.cost).toFixed(6) : tCommon('unknown');
+    const inputTokenDisplay = usageKnown
+        ? fmt(formatCount(effectiveInputTokens).formatted)
+        : tCommon('unknown');
+    const outputTokenDisplay = usageKnown
+        ? fmt(formatCount(log.output_tokens).formatted)
+        : tCommon('unknown');
+    const costDisplay = usageKnown
+        ? (chinaMode
+            ? costFmt(formatMoney(Number(log.cost)).raw)
+            : formatMoney(Number(log.cost)).raw.toFixed(2))
+        : tCommon('unknown');
 
     return (
         <TooltipProvider>
@@ -353,7 +382,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                                 {cacheReadTokens > 0 && (
                                     <div className="flex items-center gap-1.5">
                                         <ArrowDownToLine className="size-3.5 shrink-0 text-teal-500" />
-                                        <span>{t('cacheHit')} {cacheReadTokens.toLocaleString()}</span>
+                                        <span>{t('cacheHit')} {fmt(formatCount(cacheReadTokens).formatted)}</span>
                                     </div>
                                 )}
                                 <div className="flex items-center gap-1.5">
@@ -362,7 +391,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                                 </div>
                                 {vis.cost && (
                                     <div className="flex items-center gap-1.5">
-                                        <DollarSign className="size-3.5 shrink-0 text-emerald-500" />
+                                        {chinaMode ? <JapaneseYen className="size-3.5 shrink-0 text-emerald-500" /> : <DollarSign className="size-3.5 shrink-0 text-emerald-500" />}
                                         <span className="font-medium text-emerald-600 dark:text-emerald-400">
                                             {t('cost')} {costDisplay}
                                         </span>
@@ -551,7 +580,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                                                 <span className="text-sm font-medium text-card-foreground">{t('requestContent')}</span>
                                                 <div className="ml-auto flex items-center gap-1">
                                                     <Badge variant="secondary" className="text-xs">
-                                                        {usageKnown ? `${log.input_tokens.toLocaleString()} ${t('tokens')}` : tCommon('unknown')}
+                                                        {usageKnown ? `${fmt(formatCount(log.input_tokens).formatted)} ${t('tokens')}` : tCommon('unknown')}
                                                     </Badge>
                                                     {requestContent && (
                                                         <>
@@ -584,7 +613,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                                                 <span className="text-sm font-medium text-card-foreground">{t('responseContent')}</span>
                                                 <div className="ml-auto flex items-center gap-1">
                                                     <Badge variant="secondary" className="text-xs">
-                                                        {usageKnown ? `${log.output_tokens.toLocaleString()} ${t('tokens')}` : tCommon('unknown')}
+                                                        {usageKnown ? `${fmt(formatCount(log.output_tokens).formatted)} ${t('tokens')}` : tCommon('unknown')}
                                                     </Badge>
                                                     {responseContent && (
                                                         <>
@@ -641,7 +670,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                             {cacheReadTokens > 0 && (
                                 <div className="flex items-center gap-1.5">
                                     <ArrowDownToLine className="size-3.5 text-teal-500" />
-                                    <span>{t('cacheHit')}: {cacheReadTokens.toLocaleString()}</span>
+                                    <span>{t('cacheHit')}: {fmt(formatCount(cacheReadTokens).formatted)}</span>
                                 </div>
                             )}
                             {semanticCacheHit && (
@@ -652,7 +681,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                             )}
                             {vis.cost && (
                                 <div className="flex items-center gap-1.5">
-                                    <DollarSign className="size-3.5 text-emerald-500" />
+                                    {chinaMode ? <JapaneseYen className="size-3.5 text-emerald-500" /> : <DollarSign className="size-3.5 text-emerald-500" />}
                                     <span className="font-medium text-emerald-600 dark:text-emerald-400">
                                         {t('cost')}: {costDisplay}
                                     </span>

--- a/web/src/components/modules/model/Create.tsx
+++ b/web/src/components/modules/model/Create.tsx
@@ -117,6 +117,8 @@ export function CreateDialogContent() {
                                 />
                             </Field>
                         </div>
+                        <p className="text-xs text-muted-foreground">{t('priceHint')}</p>
+
                         <Button
                             type="submit"
                             disabled={createModel.isPending || !formData.name.trim()}

--- a/web/src/components/modules/model/Item.tsx
+++ b/web/src/components/modules/model/Item.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils';
 import { createPortal } from 'react-dom';
 import { CopyIconButton } from '@/components/common/CopyButton';
 import { formatAverageLatency, type LatencyUnitMode } from './latency-format';
+import { useSettingStore } from '@/stores/setting';
 
 interface ModelItemProps {
     model: ModelMarketItem;
@@ -22,6 +23,7 @@ interface ModelItemProps {
 
 export const ModelItem = memo(function ModelItem({ model, layout = 'grid', latencyUnit = 'auto' }: ModelItemProps) {
     const t = useTranslations('model');
+    const { chinaMode, exchangeRate } = useSettingStore();
     const isListLayout = layout === 'list';
     const [isEditOpen, setIsEditOpen] = useState(false);
     const [confirmDelete, setConfirmDelete] = useState(false);
@@ -302,14 +304,24 @@ export const ModelItem = memo(function ModelItem({ model, layout = 'grid', laten
                                                     <ArrowDownToLine className="size-3.5" style={{ color: brandColor }} />
                                                     {t('card.inputCache')}
                                                 </span>
-                                                <span className="min-w-0 truncate text-right tabular-nums text-foreground">{model.input.toFixed(2)}/{model.cache_read.toFixed(2)}$</span>
+                                                <span className="min-w-0 truncate text-right tabular-nums text-foreground">
+                                                    {chinaMode
+                                                        ? `${(model.input * exchangeRate).toFixed(2)}/${(model.cache_read * exchangeRate).toFixed(2)}¥`
+                                                        : `${model.input.toFixed(2)}/${model.cache_read.toFixed(2)}$`
+                                                    }
+                                                </span>
                                             </div>
                                             <div className="flex items-center justify-between gap-2 rounded-lg bg-card px-2.5 py-2 sm:gap-3 sm:px-3">
                                                 <span className="inline-flex shrink-0 items-center gap-1.5">
                                                     <ArrowUpFromLine className="size-3.5" style={{ color: brandColor }} />
                                                     {t('card.outputCache')}
                                                 </span>
-                                                <span className="min-w-0 truncate text-right tabular-nums text-foreground">{model.output.toFixed(2)}/{model.cache_write.toFixed(2)}$</span>
+                                                <span className="min-w-0 truncate text-right tabular-nums text-foreground">
+                                                    {chinaMode
+                                                        ? `${(model.output * exchangeRate).toFixed(2)}/${(model.cache_write * exchangeRate).toFixed(2)}¥`
+                                                        : `${model.output.toFixed(2)}/${model.cache_write.toFixed(2)}$`
+                                                    }
+                                                </span>
                                             </div>
                                         </div>
                                     </div>

--- a/web/src/components/modules/model/ItemOverlays.tsx
+++ b/web/src/components/modules/model/ItemOverlays.tsx
@@ -136,6 +136,8 @@ export function ModelEditOverlay({
                     </label>
                 </div>
 
+                <p className="mt-1.5 text-[0.62rem] text-muted-foreground/70 sm:text-[0.65rem]">{t("priceHint")}</p>
+
                 <div className="mt-3 flex gap-2 sm:mt-4">
                     <button
                         type="button"

--- a/web/src/components/modules/model/MobileModelItem.tsx
+++ b/web/src/components/modules/model/MobileModelItem.tsx
@@ -12,6 +12,7 @@ import { cn } from '@/lib/utils';
 import { createPortal } from 'react-dom';
 import { CopyIconButton } from '@/components/common/CopyButton';
 import { formatAverageLatency, type LatencyUnitMode } from './latency-format';
+import { useSettingStore } from '@/stores/setting';
 
 interface MobileModelItemProps {
     model: ModelMarketItem;
@@ -33,6 +34,7 @@ function InlineMetric({ icon: Icon, value, color }: { icon: typeof Waves; value:
 
 export const MobileModelItem = memo(function MobileModelItem({ model, latencyUnit = 'auto' }: MobileModelItemProps) {
     const t = useTranslations('model');
+    const { chinaMode, exchangeRate } = useSettingStore();
     const [isExpanded, setIsExpanded] = useState(false);
     const [isEditOpen, setIsEditOpen] = useState(false);
     const [confirmDelete, setConfirmDelete] = useState(false);
@@ -236,14 +238,24 @@ export const MobileModelItem = memo(function MobileModelItem({ model, latencyUni
                                             <ArrowDownToLine className="size-3" style={{ color: brandColor }} />
                                             {t('card.inputCache')}
                                         </span>
-                                        <span className="tabular-nums text-foreground">{model.input.toFixed(2)}/{model.cache_read.toFixed(2)}$</span>
+                                        <span className="tabular-nums text-foreground">
+                                            {chinaMode
+                                                ? `${(model.input * exchangeRate).toFixed(2)}/${(model.cache_read * exchangeRate).toFixed(2)}¥`
+                                                : `${model.input.toFixed(2)}/${model.cache_read.toFixed(2)}$`
+                                            }
+                                        </span>
                                     </div>
                                     <div className="flex items-center justify-between rounded-md bg-card px-2 py-1.5">
                                         <span className="inline-flex shrink-0 items-center gap-1">
                                             <ArrowUpFromLine className="size-3" style={{ color: brandColor }} />
                                             {t('card.outputCache')}
                                         </span>
-                                        <span className="tabular-nums text-foreground">{model.output.toFixed(2)}/{model.cache_write.toFixed(2)}$</span>
+                                        <span className="tabular-nums text-foreground">
+                                            {chinaMode
+                                                ? `${(model.output * exchangeRate).toFixed(2)}/${(model.cache_write * exchangeRate).toFixed(2)}¥`
+                                                : `${model.output.toFixed(2)}/${model.cache_write.toFixed(2)}$`
+                                            }
+                                        </span>
                                     </div>
                                 </div>
                             </div>

--- a/web/src/components/modules/setting/Appearance.tsx
+++ b/web/src/components/modules/setting/Appearance.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTheme } from 'next-themes';
 import { SettingOrder } from './SettingOrder';
 import { useTranslations } from 'next-intl';
-import { Bell, Clock3, GripVertical, Languages, ListOrdered, Monitor, Moon, RotateCcw, Sun } from 'lucide-react';
+import { Bell, Clock3, GripVertical, Languages, ListOrdered, Monitor, Moon, RotateCcw, Sun, Landmark } from 'lucide-react';
 import {
     DragDropContext,
     Draggable,
@@ -241,11 +241,13 @@ function NavigationPreferences() {
 export function SettingAppearance() {
     const t = useTranslations('setting');
     const { theme, setTheme } = useTheme();
-    const { locale, setLocale, timeZone, setTimeZone } = useSettingStore();
+    const { locale, setLocale, timeZone, setTimeZone, chinaMode, setChinaMode, exchangeRate, setExchangeRate } = useSettingStore();
     const { data: settings } = useSettingList();
     const setSetting = useSetSetting();
     const [alertNotifyLanguage, setAlertNotifyLanguage] = useState<AlertNotifyLanguage>('en');
     const initialAlertNotifyLanguage = useRef<AlertNotifyLanguage>('en');
+    const [localExchangeRate, setLocalExchangeRate] = useState(exchangeRate.toString());
+    const initialExchangeRate = useRef(exchangeRate);
 
     useEffect(() => {
         if (!settings) return;
@@ -386,7 +388,56 @@ export function SettingAppearance() {
                         </div>
                     </div>
 
-                    {/* 大屏下把两个排序列表并排，避免在宽对话框里各自拉成稀疏的窄长条 */}
+                    {/* 中国化模式 */}
+                    <div className="flex flex-col gap-4 rounded-lg border border-primary/20 bg-gradient-to-br from-primary/5 to-transparent p-4 shadow-sm">
+                        <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-3">
+                                <div className="grid size-9 shrink-0 place-items-center rounded-lg bg-primary/12">
+                                    <Landmark className="h-5 w-5 text-primary" />
+                                </div>
+                                <div className="space-y-0.5">
+                                    <span className="text-sm font-semibold text-card-foreground">{t('chinaMode.label')}</span>
+                                    <p className="text-xs text-muted-foreground">{t('chinaMode.description')}</p>
+                                </div>
+                            </div>
+                            <Switch
+                                checked={chinaMode}
+                                onCheckedChange={setChinaMode}
+                                aria-label={t('chinaMode.label')}
+                            />
+                        </div>
+                        {chinaMode && (
+                            <div className="flex flex-col gap-3 rounded-lg border-border/30 bg-card p-4 shadow-sm md:flex-row md:items-center md:justify-between">
+                                <div className="flex items-center gap-3">
+                                    <span className="text-sm font-medium">{t('chinaMode.exchangeRate.label')}</span>
+                                    <span className="text-xs text-muted-foreground">{t('chinaMode.exchangeRate.hint')}</span>
+                                </div>
+                                <Input
+                                    type="number"
+                                    step="0.01"
+                                    min="0"
+                                    value={localExchangeRate}
+                                    onChange={(e) => setLocalExchangeRate(e.target.value)}
+                                    onBlur={() => {
+                                        const parsed = parseFloat(localExchangeRate);
+                                        if (!isNaN(parsed) && parsed > 0) {
+                                            setExchangeRate(parsed);
+                                            initialExchangeRate.current = parsed;
+                                        } else {
+                                            setLocalExchangeRate(initialExchangeRate.current.toString());
+                                        }
+                                    }}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') {
+                                            (e.target as HTMLInputElement).blur();
+                                        }
+                                    }}
+                                    className="w-48 rounded-xl"
+                                    placeholder="7.2"
+                                />
+                            </div>
+                        )}
+                    </div>
                     <div className="grid items-start gap-4 xl:grid-cols-2">
                         <NavigationPreferences />
                         <SettingOrder />

--- a/web/src/components/modules/setting/Appearance.tsx
+++ b/web/src/components/modules/setting/Appearance.tsx
@@ -15,6 +15,7 @@ import {
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 import {
     DEFAULT_NAV_ORDER,

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -5,6 +5,21 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/**
+ * Lazily read chinaMode / exchangeRate from the persisted setting store.
+ * Avoids a hard import-cycle: consumers in components already use the store
+ * directly; utils.ts only needs the values at call-time.
+ */
+let _settingStoreGetter: (() => { chinaMode: boolean; exchangeRate: number }) | null = null;
+
+export function registerSettingStoreGetter(getter: () => { chinaMode: boolean; exchangeRate: number }) {
+  _settingStoreGetter = getter;
+}
+
+function getChinaMode(): { chinaMode: boolean; exchangeRate: number } {
+  if (_settingStoreGetter) return _settingStoreGetter();
+  return { chinaMode: false, exchangeRate: 7.2 };
+}
 
 function formatNumber(num: number | undefined, compare: number[], units: string[]): { value: string, unit: string } {
   if (num === undefined) return { value: "0.00", unit: units[0] };
@@ -15,13 +30,36 @@ function formatNumber(num: number | undefined, compare: number[], units: string[
   else return { value: (num).toFixed(2), unit: units[5] };
 }
 
+/**
+ * Format a count (token count, request count, etc.).
+ * China mode: 万 (10k) / 亿 (100M) only — 千 is skipped.
+ */
 export function formatCount(num: number | undefined): { raw: number, formatted: { value: string, unit: string } } {
+  const { chinaMode } = getChinaMode();
+  if (chinaMode) {
+    const v = num ?? 0;
+    if (v >= 100_000_000) return { raw: v, formatted: { value: (v / 100_000_000).toFixed(2), unit: '亿' } };
+    if (v >= 10_000)      return { raw: v, formatted: { value: (v / 10_000).toFixed(2), unit: '万' } };
+    return { raw: v, formatted: { value: v.toLocaleString(), unit: '' } };
+  }
   return {
     raw: num ?? 0,
     formatted: formatNumber(num, [1000000000, 1000000, 1000, 1], ['', 'B', 'M', 'K', '', '']),
   };
 }
+
+/**
+ * Format a monetary amount (USD internally).
+ * China mode: convert to RMB (× exchangeRate) and display as ¥, using 万/亿.
+ */
 export function formatMoney(num: number | undefined): { raw: number, formatted: { value: string, unit: string } } {
+  const { chinaMode, exchangeRate } = getChinaMode();
+  if (chinaMode) {
+    const raw = (num ?? 0) * exchangeRate;
+    if (raw >= 100_000_000) return { raw, formatted: { value: (raw / 100_000_000).toFixed(2), unit: '¥亿' } };
+    if (raw >= 10_000)      return { raw, formatted: { value: (raw / 10_000).toFixed(2), unit: '¥万' } };
+    return { raw, formatted: { value: raw.toFixed(2), unit: '¥' } };
+  }
   return {
     raw: num ?? 0,
     formatted: formatNumber(num, [1000000000, 1000000, 1000, 1], ['$', 'B$', 'M$', 'K$', '$', '$']),

--- a/web/src/provider/locale.tsx
+++ b/web/src/provider/locale.tsx
@@ -16,7 +16,7 @@ const messages: Record<Locale, typeof zh_hansMessages> = {
 };
 
 export function LocaleProvider({ children }: { children: ReactNode }) {
-    const { locale, timeZone, chinaMode, exchangeRate } = useSettingStore();
+    const { locale, timeZone } = useSettingStore();
     const currentLocale: Locale = normalizeLocale(locale);
     const currentTimeZone = normalizeTimeZone(timeZone) || DEFAULT_TIME_ZONE;
 

--- a/web/src/provider/locale.tsx
+++ b/web/src/provider/locale.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { type ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { NextIntlClientProvider } from 'next-intl';
 import { DEFAULT_TIME_ZONE, normalizeLocale, normalizeTimeZone, useSettingStore, type Locale } from '@/stores/setting';
+import { registerSettingStoreGetter } from '@/lib/utils';
 
 import zh_hansMessages from '../../public/locale/zh_hans.json';
 import zh_hantMessages from '../../public/locale/zh_hant.json';
@@ -15,9 +16,16 @@ const messages: Record<Locale, typeof zh_hansMessages> = {
 };
 
 export function LocaleProvider({ children }: { children: ReactNode }) {
-    const { locale, timeZone } = useSettingStore();
+    const { locale, timeZone, chinaMode, exchangeRate } = useSettingStore();
     const currentLocale: Locale = normalizeLocale(locale);
     const currentTimeZone = normalizeTimeZone(timeZone) || DEFAULT_TIME_ZONE;
+
+    useEffect(() => {
+        registerSettingStoreGetter(() => {
+            const s = useSettingStore.getState();
+            return { chinaMode: s.chinaMode, exchangeRate: s.exchangeRate };
+        });
+    }, []);
 
     return (
         <NextIntlClientProvider

--- a/web/src/stores/setting.ts
+++ b/web/src/stores/setting.ts
@@ -3,6 +3,7 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 
 export type Locale = 'zh-Hans' | 'zh-Hant' | 'en';
 export const DEFAULT_TIME_ZONE = 'Asia/Shanghai';
+export const DEFAULT_EXCHANGE_RATE = 7.2;
 
 export function normalizeLocale(locale: string | null | undefined): Locale {
     switch (locale) {
@@ -47,8 +48,19 @@ export function normalizeTimeZone(timeZone: string | null | undefined): string {
 interface SettingState {
     locale: Locale;
     timeZone: string;
+    chinaMode: boolean;
+    exchangeRate: number;
     setLocale: (locale: Locale) => void;
     setTimeZone: (timeZone: string) => void;
+    setChinaMode: (enabled: boolean) => void;
+    setExchangeRate: (rate: number) => void;
+}
+
+function normalizeExchangeRate(rate: number | null | undefined): number {
+    if (typeof rate !== 'number' || !isFinite(rate) || rate <= 0) {
+        return DEFAULT_EXCHANGE_RATE;
+    }
+    return rate;
 }
 
 export const useSettingStore = create<SettingState>()(
@@ -56,8 +68,12 @@ export const useSettingStore = create<SettingState>()(
         (set) => ({
             locale: 'zh-Hans',
             timeZone: DEFAULT_TIME_ZONE,
+            chinaMode: false,
+            exchangeRate: DEFAULT_EXCHANGE_RATE,
             setLocale: (locale) => set({ locale: normalizeLocale(locale) }),
             setTimeZone: (timeZone) => set({ timeZone: normalizeTimeZone(timeZone) }),
+            setChinaMode: (chinaMode) => set({ chinaMode }),
+            setExchangeRate: (exchangeRate) => set({ exchangeRate: normalizeExchangeRate(exchangeRate) }),
         }),
         {
             name: 'octopus-settings',
@@ -69,6 +85,8 @@ export const useSettingStore = create<SettingState>()(
                     ...typed,
                     locale: normalizeLocale(typed?.locale),
                     timeZone: normalizeTimeZone(typed?.timeZone),
+                    chinaMode: typed?.chinaMode ?? false,
+                    exchangeRate: normalizeExchangeRate(typed?.exchangeRate),
                 };
             },
         }


### PR DESCRIPTION
## 概述

完善日志界面的中国化模式支持，使所有费用和数字显示在开启中国化后统一使用 ¥ / 万 / 亿 单位；同时在模型广场的价格输入弹窗中添加价格单位说明。

## ⚠️ 仅前端改动

本次变更不涉及后端代码，模型价格的存储和计算逻辑不变（不影响自动更新价格）——手动输入的价格仍然以 **USD / 1M tokens** 为单位。中国化模式仅影响前端展示层（货币图标、数字格式化）。**首次提交，覆盖面可能不全。**

## 改动内容

**日志界面（Item.tsx）**
- 费用图标：中国化模式下 `$` 图标切换为 `¥`（Yen）
- 费用数字：中国化时使用 `costFmt()` 格式化（两位有效数字），非中国化时直接显示美元数值
- 输入/输出 token 数、Cache hit token 数：全部纳入 `formatCount()`，中国化时自动转为万/亿单位
- 请求/响应体 badge 中的 token 数同步适配

**模型广场（Create.tsx + ItemOverlays.tsx）**
- 创建模型和编辑价格弹窗的价格字段下方新增提示文字：「价格单位：美元 / 百万 tokens」

**翻译**
- en / zh_hans / zh_hant 三语新增 `priceHint` 键

## 效果预览（开启中国化后）
<img width="1017" height="211" alt="image" src="https://github.com/user-attachments/assets/70c51cb1-9224-4fa0-9f05-4c3468cc46d1" />
<img width="1210" height="798" alt="image" src="https://github.com/user-attachments/assets/845ebcf4-0d90-4f51-812d-011eec5360b3" />
<img width="1433" height="704" alt="image" src="https://github.com/user-attachments/assets/26215e34-282a-4fe6-bc2a-2eee8fa49df9" />
<img width="562" height="425" alt="image" src="https://github.com/user-attachments/assets/f3c00b7b-23f7-4925-a43f-8507baa1075e" />
<img width="1217" height="219" alt="image" src="https://github.com/user-attachments/assets/cd6326aa-8e34-41a8-a091-f59bcd4ac3bc" />

