### PR TITLE
feat(channel): 新增紧凑布局模式

### DIFF
--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -937,6 +937,7 @@
       "sort": "Sort",
       "grid": "Grid",
       "list": "List",
+      "compact": "Compact",
       "nameAsc": "Name Asc",
       "nameDesc": "Name Desc",
       "createdAsc": "Time Asc",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -937,6 +937,7 @@
       "sort": "排序",
       "grid": "网格",
       "list": "列表",
+      "compact": "紧凑",
       "nameAsc": "名称正序",
       "nameDesc": "名称倒序",
       "createdAsc": "时间正序",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -937,6 +937,7 @@
       "sort": "排序",
       "grid": "網格",
       "list": "清單",
+      "compact": "緊湊",
       "nameAsc": "名稱正序",
       "nameDesc": "名稱倒序",
       "createdAsc": "時間正序",

--- a/web/src/components/common/VirtualizedGrid.tsx
+++ b/web/src/components/common/VirtualizedGrid.tsx
@@ -25,7 +25,7 @@ type ColumnConfig = ResponsiveColumns | ((width: number) => number);
 
 interface VirtualizedGridProps<T> {
     items: T[];
-    layout?: 'grid' | 'list';
+    layout?: 'grid' | 'list' | 'compact';
     columns: ColumnConfig;
     estimateItemHeight: number;
     gap?: number;
@@ -96,7 +96,7 @@ export function VirtualizedGrid<T>({
     }, []);
 
     const columnCount = useMemo(() => {
-        if (layout === 'list') return 1;
+        if (layout === 'list' || layout === 'compact') return 1;
         return Math.max(1, getColumnsForWidth(containerWidth, columns));
     }, [layout, containerWidth, columns]);
     const effectiveOverscan = containerWidth < BREAKPOINTS.md ? Math.min(overscan, 2) : overscan;

--- a/web/src/components/modules/channel/Card.tsx
+++ b/web/src/components/modules/channel/Card.tsx
@@ -15,13 +15,14 @@ import { toast } from '@/components/common/Toast';
 import { Badge } from '@/components/ui/badge';
 import { getChannelMetricDisplayParts } from './metric-format';
 
-export function Card({ channel, stats, layout = 'grid' }: { channel: Channel; stats: StatsMetricsFormatted; layout?: 'grid' | 'list' }) {
+export function Card({ channel, stats, layout = 'grid' }: { channel: Channel; stats: StatsMetricsFormatted; layout?: 'grid' | 'list' | 'compact' }) {
     const t = useTranslations('channel.card');
     const tForm = useTranslations('channel.form');
     const tSections = useTranslations('channel.detail.sections');
     const tMetrics = useTranslations('channel.detail.metrics');
     const enableChannel = useEnableChannel();
     const isListLayout = layout === 'list';
+    const isCompactLayout = layout === 'compact';
 
     const splitModels = (models: string) =>
         models
@@ -52,6 +53,73 @@ export function Card({ channel, stats, layout = 'grid' }: { channel: Channel; st
         );
     };
 
+    // ── Compact layout: single-line row ──────────────────────────────────
+    if (isCompactLayout) {
+        const successRaw = stats.request_success.raw;
+        const failedRaw = stats.request_failed.raw;
+        const totalRaw = successRaw + failedRaw;
+        const successRate = totalRaw > 0 ? ((successRaw / totalRaw) * 100).toFixed(1) : '0.0';
+        const failRate = totalRaw > 0 ? ((failedRaw / totalRaw) * 100).toFixed(1) : '0.0';
+
+        return (
+            <MorphingDialog>
+                <MorphingDialogTrigger
+                    className="group w-full rounded-lg border border-border bg-card px-3 py-2 text-card-foreground transition-all duration-150 hover:border-border/80 hover:bg-muted/20 active:scale-[0.998]"
+                >
+                    {/* Line 1: status dot + name + key badge + toggle */}
+                    <div className="flex items-center gap-2">
+                        <span className={`h-2 w-2 shrink-0 rounded-full ${channel.enabled ? 'bg-emerald-500' : 'bg-destructive'}`} />
+                        <div className="min-w-0 flex-1">
+                            <Tooltip side="top" sideOffset={8}>
+                                <TooltipTrigger asChild>
+                                    <span className="truncate text-sm font-medium">{channel.name}</span>
+                                </TooltipTrigger>
+                                <TooltipContent key={channel.name}>{channel.name}</TooltipContent>
+                            </Tooltip>
+                        </div>
+                        <Badge variant="secondary" className="shrink-0 rounded-md border border-border bg-muted px-1.5 py-0 text-[0.6rem] tabular-nums">
+                            #{channel.id} · {enabledKeyCount}/{channel.keys.length}
+                        </Badge>
+                        <Switch
+                            checked={channel.enabled}
+                            onCheckedChange={handleEnableChange}
+                            disabled={enableChannel.isPending}
+                            onClick={(e) => e.stopPropagation()}
+                            onKeyDown={(e) => e.stopPropagation()}
+                            className="shrink-0"
+                        />
+                    </div>
+
+                    {/* Line 2: metrics row */}
+                    <div className="mt-1.5 flex items-center gap-3 pl-4 text-xs text-muted-foreground">
+                        <span className="tabular-nums">
+                            <MessageSquare className="mr-1 inline-block size-3 text-primary/60" strokeWidth={1.5} />
+                            {stats.request_count.formatted.value}
+                            {stats.request_count.formatted.unit ? <span className="ml-0.5 text-[0.6rem]">{stats.request_count.formatted.unit}</span> : null}
+                        </span>
+                        <span className="tabular-nums">
+                            <span className="text-emerald-500">{successRate}%</span>
+                            <span className="mx-0.5">/</span>
+                            <span className="text-destructive">{failRate}%</span>
+                        </span>
+                        <span className="tabular-nums font-medium text-foreground/80">
+                            <DollarSign className="mr-0.5 inline-block size-3 text-primary/60" strokeWidth={1.5} />
+                            {stats.total_cost.formatted.value}
+                            {stats.total_cost.formatted.unit ? <span className="ml-0.5 text-[0.6rem] text-muted-foreground">{stats.total_cost.formatted.unit}</span> : null}
+                        </span>
+                    </div>
+                </MorphingDialogTrigger>
+
+                <MorphingDialogContainer>
+                    <MorphingDialogContent className="relative flex max-h-[calc(100dvh-2rem)] min-h-0 w-[min(100vw-1rem,56rem)] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-card px-4 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom,0px))] text-card-foreground md:px-6 md:py-5">
+                        <CardContent channel={channel} stats={stats} />
+                    </MorphingDialogContent>
+                </MorphingDialogContainer>
+            </MorphingDialog>
+        );
+    }
+
+    // ── Grid / List layout ────────────────────────────────────────────────
     return (
         <MorphingDialog>
             <MorphingDialogTrigger

--- a/web/src/components/modules/channel/Card.tsx
+++ b/web/src/components/modules/channel/Card.tsx
@@ -66,47 +66,53 @@ export function Card({ channel, stats, layout = 'grid' }: { channel: Channel; st
                 <MorphingDialogTrigger
                     className="group w-full rounded-lg border border-border bg-card px-3 py-2 text-card-foreground transition-all duration-150 hover:border-border/80 hover:bg-muted/20 active:scale-[0.998]"
                 >
-                    {/* Line 1: status dot + name + key badge + toggle */}
                     <div className="flex items-center gap-2">
-                        <span className={`h-2 w-2 shrink-0 rounded-full ${channel.enabled ? 'bg-emerald-500' : 'bg-destructive'}`} />
+                        {/* Status dot - vertically centered across both lines */}
+                        <span className={`h-2 w-2 shrink-0 self-center rounded-full ${channel.enabled ? 'bg-emerald-500' : 'bg-destructive'}`} />
+
                         <div className="min-w-0 flex-1">
-                            <Tooltip side="top" sideOffset={8}>
-                                <TooltipTrigger asChild>
-                                    <span className="truncate text-sm font-medium">{channel.name}</span>
-                                </TooltipTrigger>
-                                <TooltipContent key={channel.name}>{channel.name}</TooltipContent>
-                            </Tooltip>
+                            {/* Line 1: name + key badge */}
+                            <div className="flex items-center gap-1.5">
+                                <Tooltip side="top" sideOffset={8}>
+                                    <TooltipTrigger asChild>
+                                        <span className="truncate text-sm font-medium">{channel.name}</span>
+                                    </TooltipTrigger>
+                                    <TooltipContent key={channel.name}>{channel.name}</TooltipContent>
+                                </Tooltip>
+                                <Badge variant="secondary" className="shrink-0 rounded-md border border-border bg-muted px-1.5 py-0 text-[0.6rem] tabular-nums">
+                                    #{channel.id} · {enabledKeyCount}/{channel.keys.length}
+                                </Badge>
+                            </div>
+
+                            {/* Line 2: metrics row */}
+                            <div className="mt-0.5 flex items-center gap-3 text-xs text-muted-foreground">
+                                <span className="tabular-nums">
+                                    <MessageSquare className="mr-1 inline-block size-3 text-primary/60" strokeWidth={1.5} />
+                                    {stats.request_count.formatted.value}
+                                    {stats.request_count.formatted.unit ? <span className="ml-0.5 text-[0.6rem]">{stats.request_count.formatted.unit}</span> : null}
+                                </span>
+                                <span className="tabular-nums">
+                                    <span className="text-emerald-500">{successRate}%</span>
+                                    <span className="mx-0.5">/</span>
+                                    <span className="text-destructive">{failRate}%</span>
+                                </span>
+                                <span className="tabular-nums font-medium text-foreground/80">
+                                    <DollarSign className="mr-0.5 inline-block size-3 text-primary/60" strokeWidth={1.5} />
+                                    {stats.total_cost.formatted.value}
+                                    {stats.total_cost.formatted.unit ? <span className="ml-0.5 text-[0.6rem] text-muted-foreground">{stats.total_cost.formatted.unit}</span> : null}
+                                </span>
+                            </div>
                         </div>
-                        <Badge variant="secondary" className="shrink-0 rounded-md border border-border bg-muted px-1.5 py-0 text-[0.6rem] tabular-nums">
-                            #{channel.id} · {enabledKeyCount}/{channel.keys.length}
-                        </Badge>
+
+                        {/* Toggle - vertically centered across both lines */}
                         <Switch
                             checked={channel.enabled}
                             onCheckedChange={handleEnableChange}
                             disabled={enableChannel.isPending}
                             onClick={(e) => e.stopPropagation()}
                             onKeyDown={(e) => e.stopPropagation()}
-                            className="shrink-0"
+                            className="shrink-0 self-center"
                         />
-                    </div>
-
-                    {/* Line 2: metrics row */}
-                    <div className="mt-1.5 flex items-center gap-3 pl-4 text-xs text-muted-foreground">
-                        <span className="tabular-nums">
-                            <MessageSquare className="mr-1 inline-block size-3 text-primary/60" strokeWidth={1.5} />
-                            {stats.request_count.formatted.value}
-                            {stats.request_count.formatted.unit ? <span className="ml-0.5 text-[0.6rem]">{stats.request_count.formatted.unit}</span> : null}
-                        </span>
-                        <span className="tabular-nums">
-                            <span className="text-emerald-500">{successRate}%</span>
-                            <span className="mx-0.5">/</span>
-                            <span className="text-destructive">{failRate}%</span>
-                        </span>
-                        <span className="tabular-nums font-medium text-foreground/80">
-                            <DollarSign className="mr-0.5 inline-block size-3 text-primary/60" strokeWidth={1.5} />
-                            {stats.total_cost.formatted.value}
-                            {stats.total_cost.formatted.unit ? <span className="ml-0.5 text-[0.6rem] text-muted-foreground">{stats.total_cost.formatted.unit}</span> : null}
-                        </span>
                     </div>
                 </MorphingDialogTrigger>
 

--- a/web/src/components/modules/channel/index.tsx
+++ b/web/src/components/modules/channel/index.tsx
@@ -109,9 +109,11 @@ export function Channel() {
         filterPredicate: (item, f) => createChannelFilterPredicate(f as 'all' | 'enabled' | 'disabled')(item.raw),
     });
 
-    const channelGridClassName = layout === 'list'
-        ? 'grid grid-cols-1 gap-4'
-        : 'grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3';
+    const channelGridClassName = layout === 'compact'
+        ? 'flex flex-col gap-1'
+        : layout === 'list'
+            ? 'grid grid-cols-1 gap-4'
+            : 'grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3';
 
     return (
         <section className="relative flex h-full min-h-0 flex-col overflow-y-auto overscroll-contain rounded-t-xl pb-3 md:pb-4" aria-label={pageKey}>

--- a/web/src/components/modules/model/Item.tsx
+++ b/web/src/components/modules/model/Item.tsx
@@ -17,7 +17,7 @@ import { useSettingStore } from '@/stores/setting';
 
 interface ModelItemProps {
     model: ModelMarketItem;
-    layout?: 'grid' | 'list';
+    layout?: 'grid' | 'list' | 'compact';
     latencyUnit?: LatencyUnitMode;
 }
 

--- a/web/src/components/modules/toolbar/index.tsx
+++ b/web/src/components/modules/toolbar/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ArrowUpAZ, Clock3, LayoutGrid, List, Plus, Search, SlidersHorizontal, X } from 'lucide-react';
+import { ArrowUpAZ, Clock3, LayoutGrid, List, Rows3, Plus, Search, SlidersHorizontal, X } from 'lucide-react';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import {
     MorphingDialog,
@@ -318,7 +318,7 @@ export function Toolbar() {
                                 {showLayoutOptions && (
                                     <div className="grid gap-2 rounded-lg border border-border bg-muted/20 p-2.5">
                                         <p className="text-xs font-semibold text-muted-foreground">{t('popover.layout')}</p>
-                                        <div className="grid grid-cols-2 gap-2">
+                                        <div className="grid grid-cols-3 gap-2">
                                             <button
                                                 type="button"
                                                 onClick={() => setLayout(toolbarItem, 'grid')}
@@ -342,6 +342,18 @@ export function Toolbar() {
                                             >
                                                 <List className="size-3.5" />
                                                 {t('popover.list')}
+                                            </button>
+                                            <button
+                                                type="button"
+                                                onClick={() => setLayout(toolbarItem, 'compact')}
+                                                className={cn(
+                                                    OPTION_BUTTON_CLASS,
+                                                    'inline-flex items-center justify-center gap-1.5',
+                                                    layout === 'compact' ? ACTIVE_OPTION_CLASS : INACTIVE_OPTION_CLASS
+                                                )}
+                                            >
+                                                <Rows3 className="size-3.5" />
+                                                {t('popover.compact')}
                                             </button>
                                         </div>
                                     </div>

--- a/web/src/components/modules/toolbar/view-options-store.ts
+++ b/web/src/components/modules/toolbar/view-options-store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-export type ToolbarLayout = 'grid' | 'list';
+export type ToolbarLayout = 'grid' | 'list' | 'compact';
 export type ToolbarSortOrder = 'asc' | 'desc';
 export type ToolbarSortField = 'name' | 'created';
 export type SiteToolbarSortField = 'default' | 'name' | 'created' | 'balance';


### PR DESCRIPTION
### 概述

渠道页面新增第三种布局选项——紧凑模式（Compact），在现有的网格（Grid）和列表（List）之外，提供更高信息密度的双行卡片视图。

### ⚠️ 仅前端改动

不涉及后端代码变更。

### 改动内容

**ToolbarLayout 类型（view-options-store.ts）**
- `'grid' | 'list'` → `'grid' | 'list' | 'compact'`

**工具栏布局切换（toolbar/index.tsx）**
- 布局切换区由 `grid-cols-2` 改为 `grid-cols-3`，新增紧凑按钮（Rows3 图标）

**渠道卡片（channel/Card.tsx）**
- 紧凑模式渲染为双行单行卡片：
  - 第一行：状态圆点 + 渠道名 + `#ID · Key比率` Badge + Switch 开关
  - 第二行（缩进对齐）：请求数 + 成功率/失败率（绿/红色）+ 总成本
- 点击行展开详情弹窗（与 grid/list 共用 MorphingDialog）

**渠道页布局类（channel/index.tsx）**
- compact 时使用 `flex flex-col gap-1` 替代 grid 布局

**类型兼容（VirtualizedGrid.tsx、model/Item.tsx）**
- layout prop 类型同步新增 `'compact'`，compact 时强制单列

**翻译（en/zh_hans/zh_hant）**
- 新增 `compact` 键：Compact / 紧凑 / 緊湊

### 效果预览

| 布局 | 特点 |
|------|------|
| Grid | 网格卡片，含 Base URL、各项指标分区展示 |
| List | 单列卡片，Base URL + 指标并排，4 列统计 |
| **Compact** | **双行紧凑行，名称一行，指标一行** | 

效果预览
<img width="1080" height="2400" alt="Screenshot_2026-06-17-08-24-45-599_com android chrome" src="https://github.com/user-attachments/assets/1920014b-1628-4538-b5ce-3b0c22f54bf1" />

