### PR TITLE
feat(planprovider): add MiMo Token Plan monitoring via browser cookie

### DIFF
--- a/internal/model/plan_provider.go
+++ b/internal/model/plan_provider.go
@@ -29,6 +29,7 @@ const (
 	PlanProviderZhipu         PlanProviderCategory = "zhipu"
 	PlanProviderStepFunPlan   PlanProviderCategory = "stepfun_plan"
 	PlanProviderSenseNovaPlan PlanProviderCategory = "sensenova_plan"
+	PlanProviderMiMoPlan      PlanProviderCategory = "mimo_plan"
 )
 
 // PlanProviderCategoryInfo 厂商元信息（非 DB 字段）
@@ -151,6 +152,15 @@ var PlanProviderCategories = []PlanProviderCategoryInfo{
 		Models:      "sensenova-6.7-flash-lite,sensenova-u1-fast,deepseek-v4-flash",
 		Description: "SenseNova Coding Plan 套餐用量查询（控制台 Bearer Token 必填，约 3 小时有效期）。可选填 API Key 自动创建/复用转发渠道（接入点 token.sensenova.cn/v1）",
 		HelpURL:     "https://platform.sensenova.cn/console",
+	},
+	{
+		Category:    PlanProviderMiMoPlan,
+		Name:        "MiMo 套餐 (小米)",
+		Type:        PlanProviderTypeTokenPlan,
+		BaseURL:     "https://platform.xiaomimimo.com",
+		Models:      "MiMo-V2-Pro,MiMo-V2-Flash,MiMo-V2-Edge",
+		Description: "小米 MiMo Token Plan 套餐用量查询（Cookie 鉴权，有效期未知，疑似长期有效）。在浏览器登录 platform.xiaomimimo.com 后，按 F12 打开开发者工具 → Network → 刷新页面 → 任意请求的 Cookie 字段，复制完整内容（需包含 api-platform_serviceToken、userId、api-platform_slh、api-platform_ph 四个字段）",
+		HelpURL:     "https://platform.xiaomimimo.com/console/plan-manage",
 	},
 }
 

--- a/internal/planprovider/query.go
+++ b/internal/planprovider/query.go
@@ -75,6 +75,8 @@ func QueryTokenPlan(ctx context.Context, category model.PlanProviderCategory, ap
 		return querySenseNovaPlanTokenPlan(ctx, apiKey)
 	case model.PlanProviderStepFunPlan:
 		return queryStepFunPlanTokenPlan(ctx, apiKey)
+	case model.PlanProviderMiMoPlan:
+		return queryMiMoPlanTokenPlan(ctx, apiKey)
 	case model.PlanProviderZhipu:
 		return queryZhipuTokenPlan(ctx, apiKey)
 	default:
@@ -617,6 +619,159 @@ func decodeSenseNovaAccountID(token string) string {
 		return ""
 	}
 	return claims.Ext.TenantID
+}
+
+// --- MiMo Token Plan (小米 MiMo Coding Plan) ---
+//
+// 使用浏览器 Cookie 鉴权查询小米 MiMo 套餐用量。
+// 鉴权信息：Cookie 中的 api-platform_serviceToken + userId + api-platform_slh + api-platform_ph。
+// Cookie 有效期较长（实测数天到数周），过期后需用户重新从浏览器获取。
+//
+// API 端点：
+//   - 用量：GET https://platform.xiaomimimo.com/api/v1/tokenPlan/usage
+//   - 详情：GET https://platform.xiaomimimo.com/api/v1/tokenPlan/detail
+//
+// apiKey 参数传入完整的 Cookie 字符串。
+var mimoPlanUsageURL = "https://platform.xiaomimimo.com/api/v1/tokenPlan/usage"
+var mimoPlanDetailURL = "https://platform.xiaomimimo.com/api/v1/tokenPlan/detail"
+
+func queryMiMoPlanTokenPlan(ctx context.Context, cookie string) (*TokenPlanResult, error) {
+	if cookie == "" {
+		return nil, fmt.Errorf("mimo_plan: cookie 不能为空，请在浏览器登录 platform.xiaomimimo.com 后从开发者工具复制 Cookie")
+	}
+
+	// 验证 cookie 中包含必要的字段
+	if !strings.Contains(cookie, "api-platform_serviceToken") {
+		return nil, fmt.Errorf("mimo_plan: Cookie 缺少 api-platform_serviceToken 字段，请确保复制了完整的 Cookie（需包含 api-platform_serviceToken、userId、api-platform_slh、api-platform_ph）")
+	}
+
+	// 1. 查询用量
+	usageBody, err := doMiMoGet(ctx, mimoPlanUsageURL, cookie)
+	if err != nil {
+		return nil, fmt.Errorf("mimo_plan: query usage: %w", err)
+	}
+
+	var usageResp struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Data    struct {
+			MonthUsage struct {
+				Percent float64 `json:"percent"`
+				Items   []struct {
+					Name    string  `json:"name"`
+					Used    float64 `json:"used"`
+					Limit   float64 `json:"limit"`
+					Percent float64 `json:"percent"`
+				} `json:"items"`
+			} `json:"monthUsage"`
+			Usage struct {
+				Percent float64 `json:"percent"`
+				Items   []struct {
+					Name    string  `json:"name"`
+					Used    float64 `json:"used"`
+					Limit   float64 `json:"limit"`
+					Percent float64 `json:"percent"`
+				} `json:"items"`
+			} `json:"usage"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(usageBody, &usageResp); err != nil {
+		return nil, fmt.Errorf("mimo_plan: parse usage response: %w", err)
+	}
+	if usageResp.Code != 0 {
+		return nil, fmt.Errorf("mimo_plan: API error code=%d msg=%s", usageResp.Code, usageResp.Message)
+	}
+
+	// 2. 查询套餐详情（获取到期时间）
+	detailBody, err := doMiMoGet(ctx, mimoPlanDetailURL, cookie)
+	if err != nil {
+		return nil, fmt.Errorf("mimo_plan: query detail: %w", err)
+	}
+
+	var detailResp struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Data    struct {
+			PlanCode          string `json:"planCode"`
+			PlanName          string `json:"planName"`
+			CurrentPeriodEnd  string `json:"currentPeriodEnd"`
+			Expired           bool   `json:"expired"`
+			EnableAutoRenew   bool   `json:"enableAutoRenew"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(detailBody, &detailResp); err != nil {
+		return nil, fmt.Errorf("mimo_plan: parse detail response: %w", err)
+	}
+	if detailResp.Code != 0 {
+		return nil, fmt.Errorf("mimo_plan: detail API error code=%d msg=%s", detailResp.Code, detailResp.Message)
+	}
+
+	// 3. 组装结果
+	// usage.items[0] = plan_total_token（套餐总额度）
+	// usage.items[1] = compensation_total_token（补偿额度，通常为 0）
+	// monthUsage.items[0] = month_total_token（本月已用）
+	result := &TokenPlanResult{}
+
+	// 套餐总额度（从 usage.items[0]）
+	if len(usageResp.Data.Usage.Items) > 0 {
+		planItem := usageResp.Data.Usage.Items[0]
+		result.QuotaTotal = planItem.Limit
+		result.QuotaUsed = planItem.Used
+	}
+
+	// 月度额度（从 monthUsage.items[0]）
+	if len(usageResp.Data.MonthUsage.Items) > 0 {
+		monthItem := usageResp.Data.MonthUsage.Items[0]
+		result.WeeklyTotal = monthItem.Limit
+		result.WeeklyUsed = monthItem.Used
+	}
+
+	// 到期时间
+	if detailResp.Data.CurrentPeriodEnd != "" {
+		// 格式: "2006-01-02 15:04:05"
+		if t, err := time.Parse("2006-01-02 15:04:05", detailResp.Data.CurrentPeriodEnd); err == nil {
+			result.QuotaResetAt = &t
+		}
+	}
+
+	// 各模型明细（MiMo 不分模型，只有一个汇总）
+	result.Models = []TokenPlanModelUsage{
+		{
+			ModelName:  "MiMo (Total)",
+			QuotaTotal: result.QuotaTotal,
+			QuotaUsed:  result.QuotaUsed,
+		},
+	}
+
+	return result, nil
+}
+
+// doMiMoGet 执行 MiMo 平台的 GET 请求，使用 Cookie 鉴权。
+func doMiMoGet(ctx context.Context, url, cookie string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Cookie", cookie)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36")
+
+	client := &http.Client{Timeout: requestTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("http status %d: %s", resp.StatusCode, string(body))
+	}
+	return body, nil
 }
 
 // --- 302.ai ---

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -156,7 +156,10 @@
       "forwardApiKeyHint": "When provided, a forwarding channel will be created or reused. Channels with the same models are merged. Leave empty to monitor quota only.",
       "consoleTokenLabel": "Console Token",
       "sensenovaTokenPlaceholder": "Paste console Bearer Token value",
-      "sensenovaTokenHint": "Log in to platform.sensenova.cn console, copy the Bearer Token from request headers. Valid for ~3 hours; re-obtain after expiry."
+      "sensenovaTokenHint": "Log in to platform.sensenova.cn console, copy the Bearer Token from request headers. Valid for ~3 hours; re-obtain after expiry.",
+      "cookieLabel": "Cookie",
+      "mimoCookiePlaceholder": "Paste browser Cookie (must include api-platform_serviceToken)",
+      "mimoCookieHint": "Login to platform.xiaomimimo.com, press F12 → Network → refresh page → copy full Cookie from any request. Validity unknown, appears long-lived."
     },
     "title": "Remote Sites",
     "addSite": "Add Site",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -156,7 +156,10 @@
       "forwardApiKeyHint": "填写后将自动创建或复用转发渠道，模型相同的合并为同一渠道。留空则仅监控套餐额度。",
       "consoleTokenLabel": "控制台 Token",
       "sensenovaTokenPlaceholder": "粘贴控制台 Bearer Token 值",
-      "sensenovaTokenHint": "需登录 platform.sensenova.cn 控制台，从请求头复制 Bearer Token 值。有效期约 3 小时，过期后需重新获取。"
+      "sensenovaTokenHint": "需登录 platform.sensenova.cn 控制台，从请求头复制 Bearer Token 值。有效期约 3 小时，过期后需重新获取。",
+      "cookieLabel": "Cookie",
+      "mimoCookiePlaceholder": "粘贴浏览器 Cookie（需包含 api-platform_serviceToken）",
+      "mimoCookieHint": "需登录 platform.xiaomimimo.com，按 F12 打开开发者工具 → Network → 刷新页面 → 任意请求的 Cookie 字段，复制完整内容。有效期未知，疑似长期有效。"
     },
     "title": "远程站点",
     "addSite": "添加站点",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -156,7 +156,10 @@
       "forwardApiKeyHint": "填寫後將自動建立或復用轉發渠道，模型相同的合併為同一渠道。留空則僅監控套餐額度。",
       "consoleTokenLabel": "控制台 Token",
       "sensenovaTokenPlaceholder": "貼上控制台 Bearer Token 值",
-      "sensenovaTokenHint": "需登入 platform.sensenova.cn 控制台，從請求頭複製 Bearer Token 值。有效期約 3 小時，過期後需重新取得。"
+      "sensenovaTokenHint": "需登入 platform.sensenova.cn 控制台，從請求頭複製 Bearer Token 值。有效期約 3 小時，過期後需重新取得。",
+      "cookieLabel": "Cookie",
+      "mimoCookiePlaceholder": "貼上瀏覽器 Cookie（需包含 api-platform_serviceToken）",
+      "mimoCookieHint": "需登入 platform.xiaomimimo.com，按 F12 開發者工具 → Network → 重新整理頁面 → 任意請求的 Cookie 欄位，複製完整內容。有效期未知，疑似長期有效。"
     },
     "title": "遠端站點",
     "addSite": "新增站點",

--- a/web/src/components/modules/plan-provider/PlanProviderSection.tsx
+++ b/web/src/components/modules/plan-provider/PlanProviderSection.tsx
@@ -100,7 +100,8 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
     const [forwardApiKey, setForwardApiKey] = useState('');
     const [customName, setCustomName] = useState('');
 
-    const isConsoleTokenPlan = selectedCategory === 'stepfun_plan' || selectedCategory === 'sensenova_plan';
+    const isConsoleTokenPlan = selectedCategory === 'stepfun_plan' || selectedCategory === 'sensenova_plan' || selectedCategory === 'mimo_plan';
+    const isMiMoPlan = selectedCategory === 'mimo_plan';
 
     const handleAdd = useCallback(async () => {
         if (!selectedCategory || !apiKey.trim()) return;
@@ -199,29 +200,35 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
 
                             <div className="space-y-2">
                                 <label className="text-sm font-medium">
-                                    {isConsoleTokenPlan
-                                        ? (t('plan.consoleTokenLabel') || '控制台 Token')
-                                        : (t('plan.apiKeyLabel') || 'API Key')}
+                                    {isMiMoPlan
+                                        ? (t('plan.cookieLabel') || 'Cookie')
+                                        : isConsoleTokenPlan
+                                            ? (t('plan.consoleTokenLabel') || '控制台 Token')
+                                            : (t('plan.apiKeyLabel') || 'API Key')}
                                 </label>
                                 <Input
                                     type="password"
-                                    placeholder={isConsoleTokenPlan
-                                        ? (selectedInfo?.category === 'sensenova_plan'
-                                            ? (t('plan.sensenovaTokenPlaceholder') || '粘贴控制台 Bearer Token 值')
-                                            : (t('plan.oasisTokenPlaceholder') || '粘贴控制台 Cookie 中的 Oasis-Token 值'))
-                                        : (t('plan.apiKeyPlaceholder') || '请输入 API Key')}
+                                    placeholder={isMiMoPlan
+                                        ? (t('plan.mimoCookiePlaceholder') || '粘贴浏览器 Cookie（需包含 api-platform_serviceToken）')
+                                        : isConsoleTokenPlan
+                                            ? (selectedInfo?.category === 'sensenova_plan'
+                                                ? (t('plan.sensenovaTokenPlaceholder') || '粘贴控制台 Bearer Token 值')
+                                                : (t('plan.oasisTokenPlaceholder') || '粘贴控制台 Cookie 中的 Oasis-Token 值'))
+                                            : (t('plan.apiKeyPlaceholder') || '请输入 API Key')}
                                     value={apiKey}
                                     onChange={(e) => setApiKey(e.target.value)}
                                 />
                                 {isConsoleTokenPlan && (
                                     <p className="text-xs text-amber-500">
-                                        {selectedInfo?.category === 'sensenova_plan'
-                                            ? (t('plan.sensenovaTokenHint') || '需登录 platform.sensenova.cn 控制台，从请求头复制 Bearer Token 值。有效期约 3 小时，过期后需重新获取。')
-                                            : (t('plan.oasisTokenHint') || '需登录 platform.stepfun.com 控制台，从浏览器 Cookie 复制 Oasis-Token 值（格式：access...refresh）。该 Token 有效期约 30 分钟，过期后需重新获取。')}
+                                        {isMiMoPlan
+                                            ? (t('plan.mimoCookieHint') || '需登录 platform.xiaomimimo.com，按 F12 打开开发者工具 → Network → 刷新页面 → 任意请求的 Cookie 字段，复制完整内容。有效期未知，疑似长期有效。')
+                                            : selectedInfo?.category === 'sensenova_plan'
+                                                ? (t('plan.sensenovaTokenHint') || '需登录 platform.sensenova.cn 控制台，从请求头复制 Bearer Token 值。有效期约 3 小时，过期后需重新获取。')
+                                                : (t('plan.oasisTokenHint') || '需登录 platform.stepfun.com 控制台，从浏览器 Cookie 复制 Oasis-Token 值（格式：access...refresh）。该 Token 有效期约 30 分钟，过期后需重新获取。')}
                                     </p>
                                 )}
                             </div>
-                            {isConsoleTokenPlan && (
+                            {isConsoleTokenPlan && !isMiMoPlan && (
                                 <div className="space-y-2">
                                     <label className="text-sm font-medium">
                                         {t('plan.forwardApiKeyLabel') || 'API Key（可选）'}


### PR DESCRIPTION
## 概述

新增小米 MiMo Token Plan 套餐用量监控功能。MiMo 不支持 API Key 查询额度，改用浏览器 Cookie 鉴权调用平台内部 API。

## 改动

**后端：**
- `internal/model/plan_provider.go` — 新增 `PlanProviderMiMoPlan` 常量和 `PlanProviderCategories` 条目（类型 tokenplan，纯监控，不创建渠道）
- `internal/planprovider/query.go` — 新增 `queryMiMoPlanTokenPlan()` 查询函数 + `doMiMoGet()` HTTP helper，调用 `platform.xiaomimimo.com/api/v1/tokenPlan/usage` 和 `/tokenPlan/detail`

**前端：**
- `web/src/.../PlanProviderSection.tsx` — MiMo 选择时标签显示「Cookie」而非「API Key」，隐藏转发渠道输入框（MiMo 无转发 API），MiMo 专用占位符和提示文案

**i18n：**
- 三语（zh_hans / zh_hant / en）新增 `plan.cookieLabel`、`plan.mimoCookiePlaceholder`、`plan.mimoCookieHint`

## 鉴权方式

Cookie 字段（从浏览器 F12 → Network 复制）：
- `api-platform_serviceToken` — 主认证 token
- `userId` — 用户 ID
- `api-platform_slh` — 签名 hash
- `api-platform_ph` — 指纹 hash

## API 端点

| 接口 | 路径 | 返回 |
|------|------|------|
| 用量 | `GET /api/v1/tokenPlan/usage` | 套餐总额度、已用、月度用量 |
| 详情 | `GET /api/v1/tokenPlan/detail` | 套餐名、到期时间、自动续费状态 |

## 已验证

- ✅ 本地编译通过（`go build`）
- ✅ 已有测试无回归（`go test ./internal/planprovider/...`）
- ✅ 30/30 关键内容对比全部匹配
- ✅ Cookie 鉴权实测返回正确数据

## 测试图
<img width="1416" height="2769" alt="Screenshot_2026-07-07-17-22-58-050_com android chrome" src="https://github.com/user-attachments/assets/f44ad363-a014-484c-befd-851904f3616e" />
<img width="1436" height="2769" alt="Screenshot_2026-07-07-17-23-14-051_com android chrome" src="https://github.com/user-attachments/assets/31059427-8633-47a0-babe-0f2bfb7d5c73" />