### PR TITLE
feat(planprovider): MiMo passToken 自动刷新 serviceToken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ nul
 _patch2.cjs
 patch_channel_import.cjs
 web/_patch2.mjs
+octopus

--- a/internal/model/plan_provider.go
+++ b/internal/model/plan_provider.go
@@ -159,7 +159,7 @@ var PlanProviderCategories = []PlanProviderCategoryInfo{
 		Type:        PlanProviderTypeTokenPlan,
 		BaseURL:     "https://platform.xiaomimimo.com",
 		Models:      "MiMo-V2-Pro,MiMo-V2-Flash,MiMo-V2-Edge",
-		Description: "小米 MiMo Token Plan 套餐用量查询（Cookie 鉴权，有效期未知，疑似长期有效）。在浏览器登录 platform.xiaomimimo.com 后，按 F12 打开开发者工具 → Network → 刷新页面 → 任意请求的 Cookie 字段，复制完整内容（需包含 api-platform_serviceToken、userId、api-platform_slh、api-platform_ph 四个字段）",
+		Description: "小米 MiMo Token Plan 套餐用量查询。支持两种鉴权方式：① passToken（小米账号 SSO Token，可自动刷新 serviceToken，但安全风险极高——passToken 可能可以换取小米云、小米社区、MiMo 等任何接入小米账号体系的服务的 Token（未验证），请自行判断是否需要使用）；② serviceToken（仅 MiMo 平台 Token，有效期约 1 天，过期需手动更新）。在浏览器登录 platform.xiaomimimo.com 后，按 F12 → Application → Cookies 复制。",
 		HelpURL:     "https://platform.xiaomimimo.com/console/plan-manage",
 	},
 }

--- a/internal/model/plan_provider.go
+++ b/internal/model/plan_provider.go
@@ -159,7 +159,7 @@ var PlanProviderCategories = []PlanProviderCategoryInfo{
 		Type:        PlanProviderTypeTokenPlan,
 		BaseURL:     "https://platform.xiaomimimo.com",
 		Models:      "MiMo-V2-Pro,MiMo-V2-Flash,MiMo-V2-Edge",
-		Description: "小米 MiMo Token Plan 套餐用量查询。支持两种鉴权方式：① passToken（小米账号 SSO Token，可自动刷新 serviceToken，但安全风险极高——passToken 可能可以换取小米云、小米社区、MiMo 等任何接入小米账号体系的服务的 Token（未验证），请自行判断是否需要使用）；② serviceToken（仅 MiMo 平台 Token，有效期约 1 天，过期需手动更新）。在浏览器登录 platform.xiaomimimo.com 后，按 F12 → Application → Cookies 复制。",
+		Description: "小米 MiMo Token Plan 套餐用量查询。支持两种鉴权方式：① passToken（小米账号 SSO Token，有效期 30 天滚动刷新，可自动刷新 serviceToken，但安全风险——passToken 可能存在横向移动风险，未进行全方面测试，请自行判断是否需要使用）；② serviceToken（仅 MiMo 平台 Token，有效期约 1 天，过期需手动更新）。在浏览器登录 platform.xiaomimimo.com 后，按 F12 → Application → Cookies 复制。",
 		HelpURL:     "https://platform.xiaomimimo.com/console/plan-manage",
 	},
 }

--- a/internal/planprovider/query.go
+++ b/internal/planprovider/query.go
@@ -623,30 +623,43 @@ func decodeSenseNovaAccountID(token string) string {
 
 // --- MiMo Token Plan (小米 MiMo Coding Plan) ---
 //
-// 使用浏览器 Cookie 鉴权查询小米 MiMo 套餐用量。
-// 鉴权信息：Cookie 中的 api-platform_serviceToken + userId + api-platform_slh + api-platform_ph。
-// Cookie 有效期较长（实测数天到数周），过期后需用户重新从浏览器获取。
+// 支持两种鉴权模式：
+//   - serviceToken 模式：用户提供完整浏览器 Cookie（含 api-platform_serviceToken），有效期约 1 天
+//   - passToken 模式：用户提供小米账号 SSO Cookie（含 passToken=），系统通过 SSO 自动刷新 serviceToken，可长期有效
 //
 // API 端点：
 //   - 用量：GET https://platform.xiaomimimo.com/api/v1/tokenPlan/usage
 //   - 详情：GET https://platform.xiaomimimo.com/api/v1/tokenPlan/detail
-//
-// apiKey 参数传入完整的 Cookie 字符串。
 var mimoPlanUsageURL = "https://platform.xiaomimimo.com/api/v1/tokenPlan/usage"
 var mimoPlanDetailURL = "https://platform.xiaomimimo.com/api/v1/tokenPlan/detail"
+var mimoGenLoginURL = "https://platform.xiaomimimo.com/api/v1/genLoginUrl?currentPath=%2Fconsole%2Fplan-manage"
 
 func queryMiMoPlanTokenPlan(ctx context.Context, cookie string) (*TokenPlanResult, error) {
 	if cookie == "" {
-		return nil, fmt.Errorf("mimo_plan: cookie 不能为空，请在浏览器登录 platform.xiaomimimo.com 后从开发者工具复制 Cookie")
+		return nil, fmt.Errorf("mimo_plan: cookie 不能为空")
 	}
 
-	// 验证 cookie 中包含必要的字段
-	if !strings.Contains(cookie, "api-platform_serviceToken") {
-		return nil, fmt.Errorf("mimo_plan: Cookie 缺少 api-platform_serviceToken 字段，请确保复制了完整的 Cookie（需包含 api-platform_serviceToken、userId、api-platform_slh、api-platform_ph）")
+	isPassToken := strings.Contains(cookie, "passToken=")
+	isServiceToken := strings.Contains(cookie, "api-platform_serviceToken")
+
+	if !isPassToken && !isServiceToken {
+		return nil, fmt.Errorf("mimo_plan: Cookie 缺少有效的鉴权字段，需包含 passToken= 或 api-platform_serviceToken")
 	}
 
-	// 1. 查询用量
-	usageBody, err := doMiMoGet(ctx, mimoPlanUsageURL, cookie)
+	// passToken 模式：先通过 SSO 刷新获取 serviceToken
+	var serviceCookie string
+	if isPassToken {
+		var err error
+		serviceCookie, err = refreshMiMoServiceToken(ctx, cookie)
+		if err != nil {
+			return nil, fmt.Errorf("mimo_plan: passToken 刷新 serviceToken 失败: %w", err)
+		}
+	} else {
+		serviceCookie = cookie
+	}
+
+	// 查询用量
+	usageBody, err := doMiMoGet(ctx, mimoPlanUsageURL, serviceCookie)
 	if err != nil {
 		return nil, fmt.Errorf("mimo_plan: query usage: %w", err)
 	}
@@ -682,8 +695,8 @@ func queryMiMoPlanTokenPlan(ctx context.Context, cookie string) (*TokenPlanResul
 		return nil, fmt.Errorf("mimo_plan: API error code=%d msg=%s", usageResp.Code, usageResp.Message)
 	}
 
-	// 2. 查询套餐详情（获取到期时间）
-	detailBody, err := doMiMoGet(ctx, mimoPlanDetailURL, cookie)
+	// 查询套餐详情（获取到期时间）
+	detailBody, err := doMiMoGet(ctx, mimoPlanDetailURL, serviceCookie)
 	if err != nil {
 		return nil, fmt.Errorf("mimo_plan: query detail: %w", err)
 	}
@@ -706,7 +719,7 @@ func queryMiMoPlanTokenPlan(ctx context.Context, cookie string) (*TokenPlanResul
 		return nil, fmt.Errorf("mimo_plan: detail API error code=%d msg=%s", detailResp.Code, detailResp.Message)
 	}
 
-	// 3. 组装结果。MiMo 会把订阅额度、补偿额度等拆成多个 item，展示层需要总量。
+	// 组装结果。MiMo 会把订阅额度、补偿额度等拆成多个 item，展示层需要总量。
 	result := &TokenPlanResult{}
 	for _, item := range usageResp.Data.Usage.Items {
 		result.QuotaTotal += item.Limit
@@ -719,7 +732,6 @@ func queryMiMoPlanTokenPlan(ctx context.Context, cookie string) (*TokenPlanResul
 
 	// 到期时间
 	if detailResp.Data.CurrentPeriodEnd != "" {
-		// 格式: "2006-01-02 15:04:05"
 		if t, err := time.ParseInLocation("2006-01-02 15:04:05", detailResp.Data.CurrentPeriodEnd, time.Local); err == nil {
 			result.QuotaResetAt = &t
 		}
@@ -735,6 +747,138 @@ func queryMiMoPlanTokenPlan(ctx context.Context, cookie string) (*TokenPlanResul
 	}
 
 	return result, nil
+}
+
+// refreshMiMoServiceToken 通过小米 SSO 流程用 passToken 获取新的 serviceToken Cookie。
+//
+// 流程：
+//  1. GET genLoginUrl → 302 重定向到 account.xiaomi.com/pass/serviceLogin
+//  2. 带 passToken Cookie 访问 SSO → 302 重定向到 /sts?auth=...
+//  3. 访问 /sts → Set-Cookie 返回 api-platform_serviceToken 等
+func refreshMiMoServiceToken(ctx context.Context, passTokenCookie string) (string, error) {
+	// Step 1: 获取 SSO 登录 URL
+	ssoURL, err := mimoFollowRedirect(ctx, mimoGenLoginURL, "")
+	if err != nil {
+		return "", fmt.Errorf("genLoginUrl: %w", err)
+	}
+
+	// Step 2: 带 passToken 访问 SSO，获取 /sts 回调 URL
+	stsURL, err := mimoFollowRedirect(ctx, ssoURL, passTokenCookie)
+	if err != nil {
+		return "", fmt.Errorf("SSO authentication: %w", err)
+	}
+
+	// Step 3: 访问 /sts，从 Set-Cookie 提取 serviceToken
+	serviceCookie, err := mimoGetServiceCookie(ctx, stsURL, passTokenCookie)
+	if err != nil {
+		return "", fmt.Errorf("/sts callback: %w", err)
+	}
+
+	return serviceCookie, nil
+}
+
+// mimoFollowRedirect 发送 GET 请求并返回 Location 头（不自动跟随重定向）。
+func mimoFollowRedirect(ctx context.Context, reqURL, cookie string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return "", err
+	}
+	if cookie != "" {
+		req.Header.Set("Cookie", cookie)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36")
+	req.Header.Set("Referer", "https://platform.xiaomimimo.com/")
+
+	client := &http.Client{
+		Timeout: requestTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if loc := resp.Header.Get("Location"); loc != "" {
+		return loc, nil
+	}
+	// 有些情况下 302 可能没有 Location 但有 JSON body
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return "", fmt.Errorf("redirect without Location header (status %d)", resp.StatusCode)
+	}
+	return "", fmt.Errorf("expected redirect but got status %d", resp.StatusCode)
+}
+
+// mimoGetServiceCookie 访问 /sts 回调并从 Set-Cookie 提取 serviceToken 构造完整 Cookie 字符串。
+func mimoGetServiceCookie(ctx context.Context, stsURL, passTokenCookie string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, stsURL, nil)
+	if err != nil {
+		return "", err
+	}
+	if passTokenCookie != "" {
+		req.Header.Set("Cookie", passTokenCookie)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36")
+
+	client := &http.Client{
+		Timeout: requestTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var serviceToken, userId, slh, ph string
+	for _, sc := range resp.Header.Values("Set-Cookie") {
+		if v := extractMiMoCookieValue(sc, "api-platform_serviceToken"); v != "" {
+			serviceToken = v
+		}
+		if v := extractMiMoCookieValue(sc, "userId"); v != "" {
+			userId = v
+		}
+		if v := extractMiMoCookieValue(sc, "api-platform_slh"); v != "" {
+			slh = v
+		}
+		if v := extractMiMoCookieValue(sc, "api-platform_ph"); v != "" {
+			ph = v
+		}
+	}
+
+	if serviceToken == "" {
+		return "", fmt.Errorf("Set-Cookie 中未找到 api-platform_serviceToken (status %d)", resp.StatusCode)
+	}
+
+	var parts []string
+	parts = append(parts, fmt.Sprintf(`api-platform_serviceToken="%s"`, serviceToken))
+	if userId != "" {
+		parts = append(parts, "userId="+userId)
+	}
+	if slh != "" {
+		parts = append(parts, fmt.Sprintf(`api-platform_slh="%s"`, slh))
+	}
+	if ph != "" {
+		parts = append(parts, fmt.Sprintf(`api-platform_ph="%s"`, ph))
+	}
+	return strings.Join(parts, "; "), nil
+}
+
+// extractMiMoCookieValue 从 Set-Cookie 头中提取指定 Cookie 的值。
+func extractMiMoCookieValue(setCookie, name string) string {
+	prefix := name + "="
+	for _, part := range strings.Split(setCookie, ";") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, prefix) {
+			val := strings.TrimPrefix(part, prefix)
+			return strings.Trim(val, `"`)
+		}
+	}
+	return ""
 }
 
 // doMiMoGet 执行 MiMo 平台的 GET 请求，使用 Cookie 鉴权。

--- a/internal/planprovider/query.go
+++ b/internal/planprovider/query.go
@@ -646,6 +646,9 @@ func queryMiMoPlanTokenPlan(ctx context.Context, cookie string) (*TokenPlanResul
 		return nil, fmt.Errorf("mimo_plan: Cookie 缺少有效的鉴权字段，需包含 passToken= 或 api-platform_serviceToken")
 	}
 
+	// 清理 cookie 末尾多余分号/空格
+	cookie = strings.TrimRight(strings.TrimSpace(cookie), "; ")
+
 	// passToken 模式：先通过 SSO 刷新获取 serviceToken
 	var serviceCookie string
 	if isPassToken {

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -158,10 +158,10 @@
       "sensenovaTokenPlaceholder": "Paste console Bearer Token value",
       "sensenovaTokenHint": "Log in to platform.sensenova.cn console, copy the Bearer Token from request headers. Valid for ~3 hours; re-obtain after expiry.",
       "cookieLabel": "Cookie",
-      "mimoPassTokenPlaceholder": "Paste full Cookie from account.xiaomi.com (must include passToken=, userId=, cUserId= fields)",
-      "mimoServiceTokenPlaceholder": "Paste full Cookie from platform.xiaomimimo.com (must include api-platform_serviceToken=, userId=, api-platform_slh=, api-platform_ph= fields)",
-      "mimoPassTokenHint": "⚠️ High security risk: passToken is a long-lived Xiaomi account session token that may grant access to Xiaomi Cloud, MiMo Community, MiMo and any service using Xiaomi account SSO (unverified). System auto-refreshes serviceToken via SSO.",
-      "mimoServiceTokenHint": "Login platform.xiaomimimo.com → F12 → Application → Cookies, copy all cookies under api-platform domain. Valid ~1 day, manual update required on expiry."
+      "mimoPassTokenPlaceholder": "Paste full Cookie from account.xiaomi.com",
+      "mimoServiceTokenPlaceholder": "Paste full Cookie from platform.xiaomimimo.com",
+      "mimoPassTokenHint": "Required fields: passToken=, userId=, cUserId=. ⚠️ High risk: passToken is a long-lived Xiaomi account token that may grant access to Xiaomi Cloud, MiMo Community, MiMo etc. (unverified). System auto-refreshes serviceToken via SSO.",
+      "mimoServiceTokenHint": "Required fields: api-platform_serviceToken=, userId=, api-platform_slh=, api-platform_ph=. Login platform.xiaomimimo.com → F12 → Application → Cookies, copy all cookies under api-platform. Valid ~1 day."
     },
     "title": "Remote Sites",
     "addSite": "Add Site",

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -160,8 +160,8 @@
       "cookieLabel": "Cookie",
       "mimoPassTokenPlaceholder": "Paste full Cookie from account.xiaomi.com",
       "mimoServiceTokenPlaceholder": "Paste full Cookie from platform.xiaomimimo.com",
-      "mimoPassTokenHint": "Required fields: passToken=, userId=, cUserId=. ⚠️ High risk: passToken is a long-lived Xiaomi account token that may grant access to Xiaomi Cloud, MiMo Community, MiMo etc. (unverified). System auto-refreshes serviceToken via SSO.",
-      "mimoServiceTokenHint": "Required fields: api-platform_serviceToken=, userId=, api-platform_slh=, api-platform_ph=. Login platform.xiaomimimo.com → F12 → Application → Cookies, copy all cookies under api-platform. Valid ~1 day."
+      "mimoPassTokenHint": "Required fields: passToken=, userId=, cUserId=. Valid 30 days (auto-renewed on each use). ⚠️ Security risk: passToken is a long-lived Xiaomi account session token, may have lateral movement risk, not fully tested. System auto-refreshes serviceToken via SSO.",
+      "mimoServiceTokenHint": "Required fields: api-platform_serviceToken=, userId=, api-platform_slh=, api-platform_ph=. Valid ~1 day (server-controlled), manual update required. Login platform.xiaomimimo.com → F12 → Application → Cookies, copy all cookies under api-platform domain."
     },
     "title": "Remote Sites",
     "addSite": "Add Site",

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -158,8 +158,10 @@
       "sensenovaTokenPlaceholder": "Paste console Bearer Token value",
       "sensenovaTokenHint": "Log in to platform.sensenova.cn console, copy the Bearer Token from request headers. Valid for ~3 hours; re-obtain after expiry.",
       "cookieLabel": "Cookie",
-      "mimoCookiePlaceholder": "Paste browser Cookie (must include api-platform_serviceToken)",
-      "mimoCookieHint": "Login to platform.xiaomimimo.com, press F12 → Network → refresh page → copy full Cookie from any request. Validity unknown, appears long-lived."
+      "mimoPassTokenPlaceholder": "Paste full Cookie from account.xiaomi.com (must include passToken=, userId=, cUserId= fields)",
+      "mimoServiceTokenPlaceholder": "Paste full Cookie from platform.xiaomimimo.com (must include api-platform_serviceToken=, userId=, api-platform_slh=, api-platform_ph= fields)",
+      "mimoPassTokenHint": "⚠️ High security risk: passToken is a long-lived Xiaomi account session token that may grant access to Xiaomi Cloud, MiMo Community, MiMo and any service using Xiaomi account SSO (unverified). System auto-refreshes serviceToken via SSO.",
+      "mimoServiceTokenHint": "Login platform.xiaomimimo.com → F12 → Application → Cookies, copy all cookies under api-platform domain. Valid ~1 day, manual update required on expiry."
     },
     "title": "Remote Sites",
     "addSite": "Add Site",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -158,8 +158,10 @@
       "sensenovaTokenPlaceholder": "粘贴控制台 Bearer Token 值",
       "sensenovaTokenHint": "需登录 platform.sensenova.cn 控制台，从请求头复制 Bearer Token 值。有效期约 3 小时，过期后需重新获取。",
       "cookieLabel": "Cookie",
-      "mimoCookiePlaceholder": "粘贴浏览器 Cookie（需包含 api-platform_serviceToken）",
-      "mimoCookieHint": "需登录 platform.xiaomimimo.com，按 F12 打开开发者工具 → Network → 刷新页面 → 任意请求的 Cookie 字段，复制完整内容。有效期未知，疑似长期有效。"
+      "mimoPassTokenPlaceholder": "粘贴 account.xiaomi.com 的完整 Cookie（需包含 passToken=、userId=、cUserId= 字段）",
+      "mimoServiceTokenPlaceholder": "粘贴 platform.xiaomimimo.com 的完整 Cookie（需包含 api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph= 字段）",
+      "mimoPassTokenHint": "⚠️ 安全风险极高：passToken 是小米账号长期会话凭证，可能可以换取小米云、小米社区、MiMo 等任何接入小米账号体系的服务的 Token（未验证）。填入后系统自动通过 SSO 刷新 serviceToken，无需手动更新。",
+      "mimoServiceTokenHint": "登录 platform.xiaomimimo.com → F12 → Application → Cookies，复制 api-platform 域下所有 Cookie。有效期约 1 天，过期后需手动更新。"
     },
     "title": "远程站点",
     "addSite": "添加站点",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -160,8 +160,8 @@
       "cookieLabel": "Cookie",
       "mimoPassTokenPlaceholder": "粘贴 account.xiaomi.com 的完整 Cookie",
       "mimoServiceTokenPlaceholder": "粘贴 platform.xiaomimimo.com 的完整 Cookie",
-      "mimoPassTokenHint": "需包含字段：passToken=、userId=、cUserId=。⚠️ 安全风险极高：passToken 是小米账号长期会话凭证，可能换取小米云、小米社区、MiMo 等服务的 Token（未验证）。填入后系统自动通过 SSO 刷新 serviceToken，无需手动更新。",
-      "mimoServiceTokenHint": "需包含字段：api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph=。登录 platform.xiaomimimo.com → F12 → Application → Cookies，复制 api-platform 域下所有 Cookie。有效期约 1 天，过期需手动更新。"
+      "mimoPassTokenHint": "需包含字段：passToken=、userId=、cUserId=。有效期 30 天（每次使用自动续期）。⚠️ 安全风险：passToken 是小米账号长期会话凭证，可能存在横向移动风险，未进行全方面测试。填入后系统自动通过 SSO 刷新 serviceToken，无需手动更新。",
+      "mimoServiceTokenHint": "需包含字段：api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph=。有效期约 1 天（服务端控制），过期需手动更新。登录 platform.xiaomimimo.com → F12 → Application → Cookies，复制 api-platform 域下所有 Cookie。"
     },
     "title": "远程站点",
     "addSite": "添加站点",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -158,10 +158,10 @@
       "sensenovaTokenPlaceholder": "粘贴控制台 Bearer Token 值",
       "sensenovaTokenHint": "需登录 platform.sensenova.cn 控制台，从请求头复制 Bearer Token 值。有效期约 3 小时，过期后需重新获取。",
       "cookieLabel": "Cookie",
-      "mimoPassTokenPlaceholder": "粘贴 account.xiaomi.com 的完整 Cookie（需包含 passToken=、userId=、cUserId= 字段）",
-      "mimoServiceTokenPlaceholder": "粘贴 platform.xiaomimimo.com 的完整 Cookie（需包含 api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph= 字段）",
-      "mimoPassTokenHint": "⚠️ 安全风险极高：passToken 是小米账号长期会话凭证，可能可以换取小米云、小米社区、MiMo 等任何接入小米账号体系的服务的 Token（未验证）。填入后系统自动通过 SSO 刷新 serviceToken，无需手动更新。",
-      "mimoServiceTokenHint": "登录 platform.xiaomimimo.com → F12 → Application → Cookies，复制 api-platform 域下所有 Cookie。有效期约 1 天，过期后需手动更新。"
+      "mimoPassTokenPlaceholder": "粘贴 account.xiaomi.com 的完整 Cookie",
+      "mimoServiceTokenPlaceholder": "粘贴 platform.xiaomimimo.com 的完整 Cookie",
+      "mimoPassTokenHint": "需包含字段：passToken=、userId=、cUserId=。⚠️ 安全风险极高：passToken 是小米账号长期会话凭证，可能换取小米云、小米社区、MiMo 等服务的 Token（未验证）。填入后系统自动通过 SSO 刷新 serviceToken，无需手动更新。",
+      "mimoServiceTokenHint": "需包含字段：api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph=。登录 platform.xiaomimimo.com → F12 → Application → Cookies，复制 api-platform 域下所有 Cookie。有效期约 1 天，过期需手动更新。"
     },
     "title": "远程站点",
     "addSite": "添加站点",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -160,8 +160,8 @@
       "cookieLabel": "Cookie",
       "mimoPassTokenPlaceholder": "貼上 account.xiaomi.com 的完整 Cookie",
       "mimoServiceTokenPlaceholder": "貼上 platform.xiaomimimo.com 的完整 Cookie",
-      "mimoPassTokenHint": "需包含欄位：passToken=、userId=、cUserId=。⚠️ 安全風險極高：passToken 是小米帳號長期會話憑證，可能換取小米雲、小米社區、MiMo 等服務的 Token（未驗證）。填入後系統自動透過 SSO 刷新 serviceToken，無需手動更新。",
-      "mimoServiceTokenHint": "需包含欄位：api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph=。登入 platform.xiaomimimo.com → F12 → Application → Cookies，複製 api-platform 域下所有 Cookie。有效期約 1 天，過期需手動更新。"
+      "mimoPassTokenHint": "需包含欄位：passToken=、userId=、cUserId=。有效期 30 天（每次使用自動續期）。⚠️ 安全風險：passToken 是小米帳號長期會話憑證，可能存在橫向移動風險，未進行全方面測試。填入後系統自動透過 SSO 刷新 serviceToken，無需手動更新。",
+      "mimoServiceTokenHint": "需包含欄位：api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph=。有效期約 1 天（服務端控制），過期需手動更新。登入 platform.xiaomimimo.com → F12 → Application → Cookies，複製 api-platform 域下所有 Cookie。"
     },
     "title": "遠端站點",
     "addSite": "新增站點",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -158,10 +158,10 @@
       "sensenovaTokenPlaceholder": "貼上控制台 Bearer Token 值",
       "sensenovaTokenHint": "需登入 platform.sensenova.cn 控制台，從請求頭複製 Bearer Token 值。有效期約 3 小時，過期後需重新取得。",
       "cookieLabel": "Cookie",
-      "mimoPassTokenPlaceholder": "貼上 account.xiaomi.com 的完整 Cookie（需包含 passToken=、userId=、cUserId= 欄位）",
-      "mimoServiceTokenPlaceholder": "貼上 platform.xiaomimimo.com 的完整 Cookie（需包含 api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph= 欄位）",
-      "mimoPassTokenHint": "⚠️ 安全風險極高：passToken 是小米帳號長期會話憑證，可能可以換取小米雲、小米社區、MiMo 等任何接入小米帳號體系的服務的 Token（未驗證）。填入後系統自動透過 SSO 刷新 serviceToken，無需手動更新。",
-      "mimoServiceTokenHint": "登入 platform.xiaomimimo.com → F12 → Application → Cookies，複製 api-platform 域下所有 Cookie。有效期約 1 天，過期後需手動更新。"
+      "mimoPassTokenPlaceholder": "貼上 account.xiaomi.com 的完整 Cookie",
+      "mimoServiceTokenPlaceholder": "貼上 platform.xiaomimimo.com 的完整 Cookie",
+      "mimoPassTokenHint": "需包含欄位：passToken=、userId=、cUserId=。⚠️ 安全風險極高：passToken 是小米帳號長期會話憑證，可能換取小米雲、小米社區、MiMo 等服務的 Token（未驗證）。填入後系統自動透過 SSO 刷新 serviceToken，無需手動更新。",
+      "mimoServiceTokenHint": "需包含欄位：api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph=。登入 platform.xiaomimimo.com → F12 → Application → Cookies，複製 api-platform 域下所有 Cookie。有效期約 1 天，過期需手動更新。"
     },
     "title": "遠端站點",
     "addSite": "新增站點",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -158,8 +158,10 @@
       "sensenovaTokenPlaceholder": "貼上控制台 Bearer Token 值",
       "sensenovaTokenHint": "需登入 platform.sensenova.cn 控制台，從請求頭複製 Bearer Token 值。有效期約 3 小時，過期後需重新取得。",
       "cookieLabel": "Cookie",
-      "mimoCookiePlaceholder": "貼上瀏覽器 Cookie（需包含 api-platform_serviceToken）",
-      "mimoCookieHint": "需登入 platform.xiaomimimo.com，按 F12 開發者工具 → Network → 重新整理頁面 → 任意請求的 Cookie 欄位，複製完整內容。有效期未知，疑似長期有效。"
+      "mimoPassTokenPlaceholder": "貼上 account.xiaomi.com 的完整 Cookie（需包含 passToken=、userId=、cUserId= 欄位）",
+      "mimoServiceTokenPlaceholder": "貼上 platform.xiaomimimo.com 的完整 Cookie（需包含 api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph= 欄位）",
+      "mimoPassTokenHint": "⚠️ 安全風險極高：passToken 是小米帳號長期會話憑證，可能可以換取小米雲、小米社區、MiMo 等任何接入小米帳號體系的服務的 Token（未驗證）。填入後系統自動透過 SSO 刷新 serviceToken，無需手動更新。",
+      "mimoServiceTokenHint": "登入 platform.xiaomimimo.com → F12 → Application → Cookies，複製 api-platform 域下所有 Cookie。有效期約 1 天，過期後需手動更新。"
     },
     "title": "遠端站點",
     "addSite": "新增站點",

--- a/web/src/components/modules/plan-provider/PlanProviderSection.tsx
+++ b/web/src/components/modules/plan-provider/PlanProviderSection.tsx
@@ -226,8 +226,8 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
                                     type="password"
                                     placeholder={isMiMoPlan
                                         ? (mimoAuthMode === 'passToken'
-                                            ? (t('plan.mimoPassTokenPlaceholder') || '粘贴小米账号 Cookie（需包含 passToken= 字段）')
-                                            : (t('plan.mimoServiceTokenPlaceholder') || '粘贴 MiMo 平台 Cookie（需包含 api-platform_serviceToken 字段）'))
+                                            ? (t('plan.mimoPassTokenPlaceholder') || '粘贴 account.xiaomi.com 的完整 Cookie（需包含 passToken=、userId=、cUserId= 字段）')
+                                            : (t('plan.mimoServiceTokenPlaceholder') || '粘贴 platform.xiaomimimo.com 的完整 Cookie（需包含 api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph= 字段）'))
                                         : isConsoleTokenPlan
                                             ? (selectedInfo?.category === 'sensenova_plan'
                                                 ? (t('plan.sensenovaTokenPlaceholder') || '粘贴控制台 Bearer Token 值')
@@ -237,17 +237,17 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
                                     onChange={(e) => setApiKey(e.target.value)}
                                 />
                                 {isMiMoPlan && mimoAuthMode === 'passToken' && (
-                                    <p className="text-xs text-red-500">
-                                        ⚠️ 安全警告：passToken 是小米账号的长期会话凭证，<strong>安全风险极高</strong>。passToken 可能可以换取小米云、小米社区、MiMo 等任何接入小米账号体系的服务的 Token（未验证）。请自行判断是否需要使用。填入后系统将自动通过 SSO 刷新 serviceToken。
+                                    <p className="text-[11px] leading-tight text-red-500">
+                                        {t('plan.mimoPassTokenHint') || '⚠️ 安全风险极高：passToken 是小米账号长期会话凭证，可能可以换取小米云、小米社区、MiMo 等任何接入小米账号体系的服务的 Token（未验证）。填入后系统自动通过 SSO 刷新 serviceToken，无需手动更新。'}
                                     </p>
                                 )}
                                 {isMiMoPlan && mimoAuthMode === 'serviceToken' && (
-                                    <p className="text-xs text-amber-500">
-                                        需登录 platform.xiaomimimo.com，按 F12 → Application → Cookies 复制。有效期约 1 天，过期后需手动更新。
+                                    <p className="text-[11px] leading-tight text-amber-500">
+                                        {t('plan.mimoServiceTokenHint') || '登录 platform.xiaomimimo.com → F12 → Application → Cookies，复制 api-platform 域下所有 Cookie。有效期约 1 天，过期后需手动更新。'}
                                     </p>
                                 )}
                                 {isConsoleTokenPlan && !isMiMoPlan && (
-                                    <p className="text-xs text-amber-500">
+                                    <p className="text-[11px] leading-tight text-amber-500">
                                         {selectedInfo?.category === 'sensenova_plan'
                                             ? (t('plan.sensenovaTokenHint') || '需登录 platform.sensenova.cn 控制台，从请求头复制 Bearer Token 值。有效期约 3 小时，过期后需重新获取。')
                                             : (t('plan.oasisTokenHint') || '需登录 platform.stepfun.com 控制台，从浏览器 Cookie 复制 Oasis-Token 值（格式：access...refresh）。该 Token 有效期约 30 分钟，过期后需重新获取。')}

--- a/web/src/components/modules/plan-provider/PlanProviderSection.tsx
+++ b/web/src/components/modules/plan-provider/PlanProviderSection.tsx
@@ -99,6 +99,7 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
     const [apiKey, setApiKey] = useState('');
     const [forwardApiKey, setForwardApiKey] = useState('');
     const [customName, setCustomName] = useState('');
+    const [mimoAuthMode, setMimoAuthMode] = useState<'passToken' | 'serviceToken'>('serviceToken');
 
     const isConsoleTokenPlan = selectedCategory === 'stepfun_plan' || selectedCategory === 'sensenova_plan' || selectedCategory === 'mimo_plan';
     const isMiMoPlan = selectedCategory === 'mimo_plan';
@@ -119,6 +120,7 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
             setApiKey('');
             setForwardApiKey('');
             setCustomName('');
+            setMimoAuthMode('serviceToken');
         } catch (e: unknown) {
             const msg = e instanceof Error ? e.message : '添加失败';
             toast.error(msg);
@@ -152,7 +154,7 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
             {/* Header */}
             <div className="flex items-center justify-between">
                 <h2 className="text-lg font-semibold">{title}</h2>
-                <Dialog open={addOpen} onOpenChange={setAddOpen}>
+                <Dialog open={addOpen} onOpenChange={(open) => { setAddOpen(open); if (!open) { setMimoAuthMode('serviceToken'); setApiKey(''); } }}>
                     <DialogTrigger asChild>
                         <Button size="sm" className="rounded-xl gap-1.5">
                             <Plus className="size-4" />
@@ -207,10 +209,40 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
                                             ? (t('plan.consoleTokenLabel') || '控制台 Token')
                                             : (t('plan.apiKeyLabel') || 'API Key')}
                                 </label>
+                                {isMiMoPlan && (
+                                    <div className="flex gap-4 text-sm">
+                                        <label className="flex items-center gap-1.5 cursor-pointer">
+                                            <input
+                                                type="radio"
+                                                name="mimoAuthMode"
+                                                value="passToken"
+                                                checked={mimoAuthMode === 'passToken'}
+                                                onChange={() => { setMimoAuthMode('passToken'); setApiKey(''); }}
+                                                className="accent-primary"
+                                            />
+                                            <span className="text-foreground">passToken</span>
+                                            <span className="text-xs text-muted-foreground">（自动刷新，安全风险高）</span>
+                                        </label>
+                                        <label className="flex items-center gap-1.5 cursor-pointer">
+                                            <input
+                                                type="radio"
+                                                name="mimoAuthMode"
+                                                value="serviceToken"
+                                                checked={mimoAuthMode === 'serviceToken'}
+                                                onChange={() => { setMimoAuthMode('serviceToken'); setApiKey(''); }}
+                                                className="accent-primary"
+                                            />
+                                            <span className="text-foreground">serviceToken</span>
+                                            <span className="text-xs text-muted-foreground">（有效期 1 天）</span>
+                                        </label>
+                                    </div>
+                                )}
                                 <Input
                                     type="password"
                                     placeholder={isMiMoPlan
-                                        ? (t('plan.mimoCookiePlaceholder') || '粘贴浏览器 Cookie（需包含 api-platform_serviceToken）')
+                                        ? (mimoAuthMode === 'passToken'
+                                            ? (t('plan.mimoPassTokenPlaceholder') || '粘贴小米账号 Cookie（需包含 passToken= 字段）')
+                                            : (t('plan.mimoServiceTokenPlaceholder') || '粘贴 MiMo 平台 Cookie（需包含 api-platform_serviceToken 字段）'))
                                         : isConsoleTokenPlan
                                             ? (selectedInfo?.category === 'sensenova_plan'
                                                 ? (t('plan.sensenovaTokenPlaceholder') || '粘贴控制台 Bearer Token 值')
@@ -219,13 +251,21 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
                                     value={apiKey}
                                     onChange={(e) => setApiKey(e.target.value)}
                                 />
-                                {isConsoleTokenPlan && (
+                                {isMiMoPlan && mimoAuthMode === 'passToken' && (
+                                    <p className="text-xs text-red-500">
+                                        ⚠️ 安全警告：passToken 是小米账号的长期会话凭证，<strong>安全风险极高</strong>。passToken 可能可以换取小米云、小米社区、MiMo 等任何接入小米账号体系的服务的 Token（未验证）。请自行判断是否需要使用。填入后系统将自动通过 SSO 刷新 serviceToken。
+                                    </p>
+                                )}
+                                {isMiMoPlan && mimoAuthMode === 'serviceToken' && (
                                     <p className="text-xs text-amber-500">
-                                        {isMiMoPlan
-                                            ? (t('plan.mimoCookieHint') || '需登录 platform.xiaomimimo.com，按 F12 打开开发者工具 → Network → 刷新页面 → 任意请求的 Cookie 字段，复制完整内容。有效期未知，疑似长期有效。')
-                                            : selectedInfo?.category === 'sensenova_plan'
-                                                ? (t('plan.sensenovaTokenHint') || '需登录 platform.sensenova.cn 控制台，从请求头复制 Bearer Token 值。有效期约 3 小时，过期后需重新获取。')
-                                                : (t('plan.oasisTokenHint') || '需登录 platform.stepfun.com 控制台，从浏览器 Cookie 复制 Oasis-Token 值（格式：access...refresh）。该 Token 有效期约 30 分钟，过期后需重新获取。')}
+                                        需登录 platform.xiaomimimo.com，按 F12 → Application → Cookies 复制。有效期约 1 天，过期后需手动更新。
+                                    </p>
+                                )}
+                                {isConsoleTokenPlan && !isMiMoPlan && (
+                                    <p className="text-xs text-amber-500">
+                                        {selectedInfo?.category === 'sensenova_plan'
+                                            ? (t('plan.sensenovaTokenHint') || '需登录 platform.sensenova.cn 控制台，从请求头复制 Bearer Token 值。有效期约 3 小时，过期后需重新获取。')
+                                            : (t('plan.oasisTokenHint') || '需登录 platform.stepfun.com 控制台，从浏览器 Cookie 复制 Oasis-Token 值（格式：access...refresh）。该 Token 有效期约 30 分钟，过期后需重新获取。')}
                                     </p>
                                 )}
                             </div>

--- a/web/src/components/modules/plan-provider/PlanProviderSection.tsx
+++ b/web/src/components/modules/plan-provider/PlanProviderSection.tsx
@@ -216,8 +216,8 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
                                                 <SelectValue />
                                             </SelectTrigger>
                                             <SelectContent>
-                                                <SelectItem value="serviceToken">serviceToken — 有效期 1 天，手动更新</SelectItem>
-                                                <SelectItem value="passToken">passToken — 自动刷新，⚠️ 安全风险高</SelectItem>
+                                                <SelectItem value="serviceToken">serviceToken — 1 天有效</SelectItem>
+                                                <SelectItem value="passToken">passToken — 30 天，自动刷新</SelectItem>
                                             </SelectContent>
                                         </Select>
                                     </div>

--- a/web/src/components/modules/plan-provider/PlanProviderSection.tsx
+++ b/web/src/components/modules/plan-provider/PlanProviderSection.tsx
@@ -210,31 +210,16 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
                                             : (t('plan.apiKeyLabel') || 'API Key')}
                                 </label>
                                 {isMiMoPlan && (
-                                    <div className="flex gap-4 text-sm">
-                                        <label className="flex items-center gap-1.5 cursor-pointer">
-                                            <input
-                                                type="radio"
-                                                name="mimoAuthMode"
-                                                value="passToken"
-                                                checked={mimoAuthMode === 'passToken'}
-                                                onChange={() => { setMimoAuthMode('passToken'); setApiKey(''); }}
-                                                className="accent-primary"
-                                            />
-                                            <span className="text-foreground">passToken</span>
-                                            <span className="text-xs text-muted-foreground">（自动刷新，安全风险高）</span>
-                                        </label>
-                                        <label className="flex items-center gap-1.5 cursor-pointer">
-                                            <input
-                                                type="radio"
-                                                name="mimoAuthMode"
-                                                value="serviceToken"
-                                                checked={mimoAuthMode === 'serviceToken'}
-                                                onChange={() => { setMimoAuthMode('serviceToken'); setApiKey(''); }}
-                                                className="accent-primary"
-                                            />
-                                            <span className="text-foreground">serviceToken</span>
-                                            <span className="text-xs text-muted-foreground">（有效期 1 天）</span>
-                                        </label>
+                                    <div className="space-y-1">
+                                        <Select value={mimoAuthMode} onValueChange={(v: string) => { setMimoAuthMode(v as 'passToken' | 'serviceToken'); setApiKey(''); }}>
+                                            <SelectTrigger className="h-9 text-sm">
+                                                <SelectValue />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value="serviceToken">serviceToken — 有效期 1 天，手动更新</SelectItem>
+                                                <SelectItem value="passToken">passToken — 自动刷新，⚠️ 安全风险高</SelectItem>
+                                            </SelectContent>
+                                        </Select>
                                     </div>
                                 )}
                                 <Input


### PR DESCRIPTION
## 背景

MiMo Token Plan 监控功能已实现，但 `api-platform_serviceToken` 经使用测试发现仅 1 天有效期（上一个PR错误的描述为长期有效），用户需频繁手动更新 Cookie。经分析小米 SSO 流程，发现 `passToken`（小米账号 SSO Token，30 天滚动刷新，使用时自动续期，等同于长期有效）可通过 SSO 自动换取新的 `serviceToken`。

## 改动

### 后端（`internal/planprovider/query.go`）
- 新增 `refreshMiMoServiceToken()` — 通过 SSO 流程用 passToken 获取新 serviceToken
- 新增 `mimoFollowRedirect()` / `mimoGetServiceCookie()` / `extractMiMoCookieValue()` — SSO 重定向链处理

### 前端（`web/src/components/modules/plan-provider/PlanProviderSection.tsx`）
- MiMo 表单新增下拉选择框切换鉴权模式
- passToken 模式显示有效期 + 字段说明
- serviceToken 模式显示有效期提示 + 字段说明

### i18n（`zh_hans.json` / `en.json` / `zh_hant.json`）
- 新增 4 个 key：`mimoPassTokenPlaceholder` / `mimoServiceTokenPlaceholder` / `mimoPassTokenHint` / `mimoServiceTokenHint`

### Model（`internal/model/plan_provider.go`）
- 更新 MiMo 描述：passToken 有效期 30 天滚动刷新，及安全风险说明

## 安全说明
- passToken 可能存在横向移动风险，未进行全方面测试
- 已验证仅限 `sid=api-platform`（MiMo 平台），不能横向到小米云`sid=i.mi.com`/小米社区`sid=vip_community_pc`

## 验证
- ✅ `go vet` 通过
- ✅ 13 个 planprovider 测试全部通过
- ✅ 前端无新增 TypeScript 错误
- ✅ 实测 passToken SSO 流程可成功获取新 serviceToken
<img width="1440" height="2788" alt="Screenshot_2026-07-08-18-59-35-570_com android chrome-edit" src="https://github.com/user-attachments/assets/2c235ecc-250f-41ea-b4dd-292c064e5e2d" />
