### PR TITLE
fix(web): 趋势图中国化金额与使用概览对齐，去掉二次汇率换算

### DIFF
--- a/web/src/components/modules/home/chart.tsx
+++ b/web/src/components/modules/home/chart.tsx
@@ -9,6 +9,7 @@ import { formatCount, formatMoney } from '@/lib/utils';
 import { formatDateOnly } from '@/lib/time';
 import { AnimatedNumber } from '@/components/common/AnimatedNumber';
 import { useHomeStatsRefreshMs, useHomeViewStore, type ChartMetricType, type ChartPeriod } from '@/components/modules/home/store';
+import { useSettingStore } from '@/stores/setting';
 import { BarChart3, CalendarClock } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -25,6 +26,7 @@ export function StatsChart() {
     const { data: statsDaily } = useStatsDaily({ refetchIntervalMs: statsRefreshMs });
     const { data: statsHourly } = useStatsHourly({ refetchIntervalMs: statsRefreshMs });
     const t = useTranslations('home.chart');
+    const { chinaMode } = useSettingStore();
 
     const chartMetrics = useHomeViewStore((state) => state.chartMetrics);
     const toggleChartMetric = useHomeViewStore((state) => state.toggleChartMetric);
@@ -147,6 +149,29 @@ export function StatsChart() {
         return 'url(#fillMetric3)';
     };
 
+    // total_cost already went through formatMoney() in the stats select mapper,
+    // so in chinaMode stat.total_cost.raw is already CNY (USD x exchangeRate once).
+    // Formatting it again via formatMoney would apply the exchange rate a second
+    // time and desync the chart from Overview. Use formatDisplayCost for any value
+    // that is already in display currency.
+    const formatDisplayCost = (value: number): { value: string; unit: string } => {
+        if (chinaMode) {
+            const v = Number(value);
+            if (v >= 100_000_000) return { value: (v / 100_000_000).toFixed(2), unit: '亿元' };
+            if (v >= 10_000) return { value: (v / 10_000).toFixed(2), unit: '万元' };
+            return { value: v.toFixed(2), unit: '元' };
+        }
+        return formatMoney(value).formatted;
+    };
+
+    const costAxisFormatter = (value: number): string => {
+        const formatted = formatDisplayCost(Number(value));
+        return `${formatted.value}${formatted.unit}`;
+    };
+
+    const costSummary = formatDisplayCost(totals.cost);
+
+
     const summaryMetrics = [
         {
             key: 'requests',
@@ -157,8 +182,8 @@ export function StatsChart() {
         {
             key: 'cost',
             label: t('totalCost'),
-            value: formatMoney(totals.cost).formatted.value,
-            unit: formatMoney(totals.cost).formatted.unit,
+            value: costSummary.value,
+            unit: costSummary.unit,
         },
         {
             key: 'tokens',
@@ -264,8 +289,7 @@ export function StatsChart() {
                         tickFormatter={(value) => {
                             const primary = chartMetrics[0] ?? 'cost';
                             if (primary === 'cost') {
-                                const formatted = formatMoney(value);
-                                return `${formatted.formatted.value}${formatted.formatted.unit}`;
+                                return costAxisFormatter(Number(value));
                             } else if (primary === 'success-rate') {
                                 return `${value.toFixed(0)}%`;
                             } else if (primary === 'count' || primary === 'tokens') {
@@ -275,7 +299,21 @@ export function StatsChart() {
                             return value.toString();
                         }}
                     />
-                    <ChartTooltip cursor={false} content={<ChartTooltipContent indicator="line" />} />
+                    <ChartTooltip
+                        cursor={false}
+                        content={
+                            <ChartTooltipContent
+                                indicator="line"
+                                formatter={(value) => {
+                                    const primary = chartMetrics[0] ?? 'cost';
+                                    if (primary === 'cost') return costAxisFormatter(Number(value));
+                                    if (primary === 'success-rate') return `${Number(value).toFixed(2)}%`;
+                                    const f = formatCount(Number(value));
+                                    return `${f.formatted.value}${f.formatted.unit}`;
+                                }}
+                            />
+                        }
+                    />
                     <Area
                         type="monotone"
                         dataKey={METRIC_DATA_KEYS[chartMetrics[0]]}


### PR DESCRIPTION
## 问题
中国化模式（chinaMode）下，首页趋势图显示的金额约为「使用概览」的 7.2 倍，两者对不上。使用概览是正确的。

## 根因
`web/src/api/endpoints/stats.ts` 的 `select` 映射已对 `item.input_cost + item.output_cost`（USD）调用 `formatMoney()`。在 chinaMode 下 `formatMoney` 会 `raw = usd * exchangeRate`，因此 `stat.total_cost.raw` **已经是 CNY**。

但 `web/src/components/modules/home/chart.tsx` 的：
- 顶部成本汇总卡片 `summaryMetrics`：`formatMoney(totals.cost)` —— totals.cost 已是 CNY，再 ×exchangeRate → 二次换算
- Y 轴 `tickFormatter`：`formatMoney(value)` —— 同理

导致趋势金额被放大 exchangeRate 倍，与使用概览（仅换算一次）脱节。

## 修复
在 `chart.tsx` 内新增 `formatDisplayCost`：
- chinaMode：直接格式化**已换算**的 CNY（元 / 万元 / 亿元，沿用上游 `ad743f3` 的后缀单位顺序），不再调用会二次 ×exchangeRate 的 `formatMoney`
- 非 chinaMode：仍走 `formatMoney` 显示 $

折线几何值、成本汇总卡片、Y 轴、tooltip 共用同一口径。tooltip 同时补上了成本 / 成功率 / 计数格式化（此前为裸数字无单位）。

修改隔离在 `chart.tsx`，不动 `formatMoney` 全局，不影响依赖该换算的其它页面。

## 验证
- `totals.cost` 与 `stat.total_cost.raw` 求和口径统一，趋势总成本 = 使用概览总成本（同数据源、同换算次数）
- `tsc --noEmit` 通过
- 部署测试通过