### PR TITLE
fix(channel): 修复代理模式未生效导致渠道不走代理

### DIFF
--- a/internal/helper/channel.go
+++ b/internal/helper/channel.go
@@ -8,40 +8,118 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dlclark/regexp2"
 	"github.com/lingyuins/octopus/internal/client"
 	"github.com/lingyuins/octopus/internal/model"
 	ch "github.com/lingyuins/octopus/internal/op/channel"
 	grp "github.com/lingyuins/octopus/internal/op/group"
 	"github.com/lingyuins/octopus/internal/utils/log"
 	"github.com/lingyuins/octopus/internal/utils/xstrings"
-	"github.com/dlclark/regexp2"
 )
 
+// ProxyURLByConfigFunc 由 op 包在启动时注入，用于按代理池配置 ID 解析 URL。
+// helper 不能直接 import op（op/notification 反向依赖 helper，会形成循环）。
+// 未注入时 pool 模式只能依赖 channel.ChannelProxy 自定义 URL。
+var ProxyURLByConfigFunc func(id int, ctx context.Context) (string, error)
+
+// ChannelHttpClient 按渠道代理配置返回转发用 HTTP 客户端。
+// 优先使用 ProxyMode/ProxyConfigID（站点投影与代理池）；
+// 兼容旧字段 Proxy + ChannelProxy。
 func ChannelHttpClient(channel *model.Channel) (*http.Client, error) {
+	return channelHTTPClient(channel, 0)
+}
+
+// ChannelShortTimeoutHttpClient 返回短超时(30s)的 HTTP 客户端。
+// 用于后台任务(延迟探测、模型同步)，避免在 endpoint 不可达时 goroutine 堆积。
+func ChannelShortTimeoutHttpClient(channel *model.Channel) (*http.Client, error) {
+	return channelHTTPClient(channel, 30*time.Second)
+}
+
+func channelHTTPClient(channel *model.Channel, timeout time.Duration) (*http.Client, error) {
 	if channel == nil {
 		return nil, errors.New("channel is nil")
 	}
-	if !channel.Proxy {
+
+	mode, proxyConfigID, customProxyURL := resolveChannelProxy(channel)
+	short := timeout > 0 && timeout <= 30*time.Second
+
+	switch mode {
+	case model.ProxyUsageModeDirect:
+		if short {
+			return client.GetHTTPClientShortTimeout(false)
+		}
 		return client.GetHTTPClientSystemProxy(false)
-	} else if channel.ChannelProxy == nil || strings.TrimSpace(*channel.ChannelProxy) == "" {
+	case model.ProxyUsageModeSystem:
+		if short {
+			return client.GetHTTPClientShortTimeout(true)
+		}
 		return client.GetHTTPClientSystemProxy(true)
-	} else {
-		return client.GetHTTPClientCustomProxy(strings.TrimSpace(*channel.ChannelProxy))
+	case model.ProxyUsageModePool:
+		proxyURL := strings.TrimSpace(customProxyURL)
+		if proxyURL == "" {
+			if proxyConfigID == nil || *proxyConfigID <= 0 {
+				return nil, fmt.Errorf("proxy config id is required when proxy mode is pool")
+			}
+			if ProxyURLByConfigFunc == nil {
+				return nil, fmt.Errorf("proxy configuration resolver is not initialized")
+			}
+			resolved, err := ProxyURLByConfigFunc(*proxyConfigID, context.Background())
+			if err != nil {
+				return nil, err
+			}
+			proxyURL = resolved
+		}
+		if short {
+			return client.GetHTTPClientCustomProxyWithTimeout(proxyURL, 30*time.Second)
+		}
+		return client.GetHTTPClientCustomProxy(proxyURL)
+	default:
+		return nil, fmt.Errorf("unsupported proxy mode: %s", mode)
 	}
 }
 
-// ChannelShortTimeoutHttpClient 返回一个短超时(30s)的 HTTP 客户端
-// 用于后台任务(延迟探测、模型同步)，避免在 endpoint 不可达时 goroutine 堆积
-func ChannelShortTimeoutHttpClient(channel *model.Channel) (*http.Client, error) {
+// resolveChannelProxy 解析渠道实际代理模式。
+// 兼容路径：
+// 1) 新模型 ProxyMode=system/pool（含 ProxyConfigID）
+// 2) 旧模型仅 Proxy + ChannelProxy
+// 3) 迁移后 ProxyMode 默认 direct，但 Proxy 仍为 true 的历史数据
+func resolveChannelProxy(channel *model.Channel) (model.ProxyUsageMode, *int, string) {
 	if channel == nil {
-		return nil, errors.New("channel is nil")
+		return model.ProxyUsageModeDirect, nil, ""
 	}
-	if !channel.Proxy {
-		return client.GetHTTPClientShortTimeout(false)
-	} else if channel.ChannelProxy == nil || strings.TrimSpace(*channel.ChannelProxy) == "" {
-		return client.GetHTTPClientShortTimeout(true)
-	} else {
-		return client.GetHTTPClientCustomProxyWithTimeout(strings.TrimSpace(*channel.ChannelProxy), 30*time.Second)
+
+	customProxyURL := ""
+	if channel.ChannelProxy != nil {
+		customProxyURL = strings.TrimSpace(*channel.ChannelProxy)
+	}
+
+	mode := channel.ProxyMode
+	// 历史数据：GORM 给 proxy_mode 默认值 direct，但旧 proxy 布尔可能仍为 true。
+	// 此时必须回退到 legacy 字段，否则系统代理/自定义代理会静默失效。
+	if mode == "" || mode == model.ProxyUsageModeDirect {
+		if !channel.Proxy {
+			return model.ProxyUsageModeDirect, nil, ""
+		}
+		if customProxyURL != "" {
+			return model.ProxyUsageModePool, nil, customProxyURL
+		}
+		return model.ProxyUsageModeSystem, nil, ""
+	}
+
+	switch mode {
+	case model.ProxyUsageModeSystem:
+		// 系统代理模式下若仍残留 channel_proxy，优先走自定义 URL（兼容迁移中途数据）
+		if customProxyURL != "" {
+			return model.ProxyUsageModePool, nil, customProxyURL
+		}
+		return model.ProxyUsageModeSystem, nil, ""
+	case model.ProxyUsageModePool:
+		if customProxyURL != "" && (channel.ProxyConfigID == nil || *channel.ProxyConfigID <= 0) {
+			return model.ProxyUsageModePool, nil, customProxyURL
+		}
+		return model.ProxyUsageModePool, channel.ProxyConfigID, ""
+	default:
+		return mode, channel.ProxyConfigID, customProxyURL
 	}
 }
 

--- a/internal/helper/channel_proxy_test.go
+++ b/internal/helper/channel_proxy_test.go
@@ -1,0 +1,226 @@
+package helper
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/lingyuins/octopus/internal/model"
+	"github.com/lingyuins/octopus/internal/op/setting"
+)
+
+func TestResolveChannelProxyUsesProxyModePool(t *testing.T) {
+	configID := 42
+	channel := &model.Channel{
+		ProxyMode:     model.ProxyUsageModePool,
+		ProxyConfigID: &configID,
+		Proxy:         true,
+	}
+
+	mode, gotID, customURL := resolveChannelProxy(channel)
+	if mode != model.ProxyUsageModePool {
+		t.Fatalf("mode = %q, want pool", mode)
+	}
+	if gotID == nil || *gotID != configID {
+		t.Fatalf("proxy config id = %#v, want %d", gotID, configID)
+	}
+	if customURL != "" {
+		t.Fatalf("custom url = %q, want empty", customURL)
+	}
+}
+
+func TestResolveChannelProxyUsesSystemMode(t *testing.T) {
+	channel := &model.Channel{
+		ProxyMode: model.ProxyUsageModeSystem,
+		Proxy:     true,
+	}
+
+	mode, gotID, customURL := resolveChannelProxy(channel)
+	if mode != model.ProxyUsageModeSystem {
+		t.Fatalf("mode = %q, want system", mode)
+	}
+	if gotID != nil {
+		t.Fatalf("proxy config id = %#v, want nil", gotID)
+	}
+	if customURL != "" {
+		t.Fatalf("custom url = %q, want empty", customURL)
+	}
+}
+
+func TestResolveChannelProxyLegacyCustomURL(t *testing.T) {
+	proxyURL := "socks5://127.0.0.1:1080"
+	channel := &model.Channel{
+		Proxy:        true,
+		ChannelProxy: &proxyURL,
+	}
+
+	mode, gotID, customURL := resolveChannelProxy(channel)
+	if mode != model.ProxyUsageModePool {
+		t.Fatalf("mode = %q, want pool", mode)
+	}
+	if gotID != nil {
+		t.Fatalf("proxy config id = %#v, want nil", gotID)
+	}
+	if customURL != proxyURL {
+		t.Fatalf("custom url = %q, want %q", customURL, proxyURL)
+	}
+}
+
+func TestResolveChannelProxyLegacySystemToggle(t *testing.T) {
+	channel := &model.Channel{Proxy: true}
+
+	mode, gotID, customURL := resolveChannelProxy(channel)
+	if mode != model.ProxyUsageModeSystem {
+		t.Fatalf("mode = %q, want system", mode)
+	}
+	if gotID != nil || customURL != "" {
+		t.Fatalf("unexpected pool fields id=%#v url=%q", gotID, customURL)
+	}
+}
+
+func TestResolveChannelProxyDirect(t *testing.T) {
+	// 显式 direct：ProxyMode=direct 且 Proxy=false（或未开旧开关）
+	channel := &model.Channel{ProxyMode: model.ProxyUsageModeDirect, Proxy: false}
+
+	mode, gotID, customURL := resolveChannelProxy(channel)
+	if mode != model.ProxyUsageModeDirect {
+		t.Fatalf("mode = %q, want direct", mode)
+	}
+	if gotID != nil || customURL != "" {
+		t.Fatalf("unexpected proxy fields id=%#v url=%q", gotID, customURL)
+	}
+}
+
+func TestResolveChannelProxyLegacyProxyTrueWithDefaultDirectMode(t *testing.T) {
+	// 迁移后常见状态：proxy_mode 默认 direct，但旧 proxy 开关仍为 true
+	channel := &model.Channel{
+		ProxyMode: model.ProxyUsageModeDirect,
+		Proxy:     true,
+	}
+	mode, gotID, customURL := resolveChannelProxy(channel)
+	if mode != model.ProxyUsageModeSystem {
+		t.Fatalf("mode = %q, want system (legacy proxy flag)", mode)
+	}
+	if gotID != nil || customURL != "" {
+		t.Fatalf("unexpected pool fields id=%#v url=%q", gotID, customURL)
+	}
+}
+
+func TestResolveChannelProxyLegacyCustomURLWithDefaultDirectMode(t *testing.T) {
+	proxyURL := "http://legacy-proxy:8080"
+	channel := &model.Channel{
+		ProxyMode:    model.ProxyUsageModeDirect,
+		Proxy:        true,
+		ChannelProxy: &proxyURL,
+	}
+	mode, gotID, customURL := resolveChannelProxy(channel)
+	if mode != model.ProxyUsageModePool {
+		t.Fatalf("mode = %q, want pool", mode)
+	}
+	if gotID != nil {
+		t.Fatalf("proxy config id = %#v, want nil", gotID)
+	}
+	if customURL != proxyURL {
+		t.Fatalf("custom url = %q, want %q", customURL, proxyURL)
+	}
+}
+
+func TestChannelHttpClientPoolUsesCustomProxyURL(t *testing.T) {
+	proxyURL := "http://127.0.0.1:18080"
+	channel := &model.Channel{
+		ProxyMode:    model.ProxyUsageModePool,
+		Proxy:        true,
+		ChannelProxy: &proxyURL,
+	}
+
+	httpClient, err := ChannelHttpClient(channel)
+	if err != nil {
+		t.Fatalf("ChannelHttpClient: %v", err)
+	}
+	transport, ok := httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", httpClient.Transport)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("expected transport.Proxy to be set")
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	got, err := transport.Proxy(req)
+	if err != nil {
+		t.Fatalf("Proxy(req): %v", err)
+	}
+	if got == nil || got.String() != proxyURL {
+		t.Fatalf("proxy url = %v, want %s", got, proxyURL)
+	}
+}
+
+func TestChannelHttpClientPoolUsesConfigResolver(t *testing.T) {
+	configID := 7
+	resolvedURL := "http://proxy-pool.example:8080"
+	oldResolver := ProxyURLByConfigFunc
+	ProxyURLByConfigFunc = func(id int, _ context.Context) (string, error) {
+		if id != configID {
+			t.Fatalf("resolver id = %d, want %d", id, configID)
+		}
+		return resolvedURL, nil
+	}
+	t.Cleanup(func() { ProxyURLByConfigFunc = oldResolver })
+
+	channel := &model.Channel{
+		ProxyMode:     model.ProxyUsageModePool,
+		ProxyConfigID: &configID,
+		Proxy:         true,
+	}
+
+	httpClient, err := ChannelHttpClient(channel)
+	if err != nil {
+		t.Fatalf("ChannelHttpClient: %v", err)
+	}
+	transport, ok := httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", httpClient.Transport)
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	got, err := transport.Proxy(req)
+	if err != nil {
+		t.Fatalf("Proxy(req): %v", err)
+	}
+	if got == nil || got.String() != resolvedURL {
+		t.Fatalf("proxy url = %v, want %s", got, resolvedURL)
+	}
+}
+
+func TestChannelHttpClientSystemUsesSettingProxy(t *testing.T) {
+	proxyURL := "http://system-proxy.example:9090"
+	setting.GetCache().Set(model.SettingKeyProxyURL, proxyURL)
+
+	channel := &model.Channel{
+		ProxyMode: model.ProxyUsageModeSystem,
+		Proxy:     true,
+	}
+	httpClient, err := ChannelHttpClient(channel)
+	if err != nil {
+		t.Fatalf("ChannelHttpClient: %v", err)
+	}
+	transport, ok := httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", httpClient.Transport)
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	got, err := transport.Proxy(req)
+	if err != nil {
+		t.Fatalf("Proxy(req): %v", err)
+	}
+	if got == nil || got.String() != proxyURL {
+		t.Fatalf("proxy url = %v, want %s", got, proxyURL)
+	}
+}

--- a/internal/op/channel.go
+++ b/internal/op/channel.go
@@ -3,6 +3,7 @@ package op
 import (
 	"context"
 
+	"github.com/lingyuins/octopus/internal/helper"
 	"github.com/lingyuins/octopus/internal/model"
 	"github.com/lingyuins/octopus/internal/op/channel"
 	"github.com/lingyuins/octopus/internal/op/stats"
@@ -24,6 +25,8 @@ func init() {
 	channel.GroupGet = func(id int, ctx context.Context) (*model.ChannelGroup, error) {
 		return ChannelGroupGet(id, ctx)
 	}
+	// 注入代理池 URL 解析器，避免 helper 反向 import op 造成循环依赖。
+	helper.ProxyURLByConfigFunc = ProxyURLForConfig
 }
 
 // Deprecated: Use channel.List from internal/op/channel instead.

--- a/internal/op/channel/channel.go
+++ b/internal/op/channel/channel.go
@@ -3,6 +3,7 @@ package channel
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/lingyuins/octopus/internal/db"
@@ -46,6 +47,9 @@ func Create(ch *model.Channel, ctx context.Context) error {
 		if err := ch.RequestRewrite.Validate(ch.Type); err != nil {
 			return err
 		}
+		if err := normalizeChannelProxyFields(ch); err != nil {
+			return err
+		}
 		if ch.GroupID == 0 {
 			defaultGroupID, err := GroupDefaultID(ctx)
 			if err != nil {
@@ -68,6 +72,72 @@ func Create(ch *model.Channel, ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// normalizeChannelProxyFields 把 ProxyMode / ProxyConfigID / 旧 Proxy+ChannelProxy
+// 统一成可持久化的一致状态：
+// - ProxyMode 为空时从旧字段推导
+// - pool 模式必须带 ProxyConfigID 或 ChannelProxy
+// - 非 pool 模式清空 ProxyConfigID
+// - Proxy 布尔值与 ProxyMode 同步
+func normalizeChannelProxyFields(ch *model.Channel) error {
+	if ch == nil {
+		return nil
+	}
+
+	customProxy := ""
+	if ch.ChannelProxy != nil {
+		customProxy = strings.TrimSpace(*ch.ChannelProxy)
+		if customProxy == "" {
+			ch.ChannelProxy = nil
+		} else {
+			ch.ChannelProxy = &customProxy
+		}
+	}
+
+	mode := ch.ProxyMode
+	if strings.TrimSpace(string(mode)) == "" {
+		mode, ch.ProxyConfigID = deriveProxyModeFromLegacy(ch.Proxy, ch.ChannelProxy)
+	}
+	if err := mode.Validate(false); err != nil {
+		return err
+	}
+
+	switch mode {
+	case model.ProxyUsageModeDirect:
+		ch.ProxyMode = model.ProxyUsageModeDirect
+		ch.ProxyConfigID = nil
+		ch.Proxy = false
+		// direct 模式下运行时不会使用 ChannelProxy，但仍允许 UI 暂存自定义地址。
+	case model.ProxyUsageModeSystem:
+		ch.ProxyMode = model.ProxyUsageModeSystem
+		ch.ProxyConfigID = nil
+		ch.Proxy = true
+	case model.ProxyUsageModePool:
+		ch.ProxyMode = model.ProxyUsageModePool
+		ch.Proxy = true
+		if ch.ProxyConfigID != nil && *ch.ProxyConfigID <= 0 {
+			ch.ProxyConfigID = nil
+		}
+		// 投影渠道/代理池：必须有 config id；旧自定义 URL 可无 config id
+		if (ch.ProxyConfigID == nil || *ch.ProxyConfigID <= 0) && customProxy == "" {
+			return fmt.Errorf("proxy config id is required when proxy mode is pool")
+		}
+	default:
+		return fmt.Errorf("unsupported proxy mode: %s", mode)
+	}
+	return nil
+}
+
+func deriveProxyModeFromLegacy(proxy bool, channelProxy *string) (model.ProxyUsageMode, *int) {
+	if !proxy {
+		return model.ProxyUsageModeDirect, nil
+	}
+	if channelProxy != nil && strings.TrimSpace(*channelProxy) != "" {
+		// 旧自定义代理 URL：没有 proxy_config_id，运行时直接使用 ChannelProxy
+		return model.ProxyUsageModePool, nil
+	}
+	return model.ProxyUsageModeSystem, nil
 }
 
 func KeyUpdate(key model.ChannelKey) error {
@@ -249,45 +319,46 @@ func Update(req *model.ChannelUpdateRequest, ctx context.Context) (*model.Channe
 		selectFields = append(selectFields, "custom_model")
 		updates.CustomModel = *req.CustomModel
 	}
-	if req.Proxy != nil {
-		selectFields = append(selectFields, "proxy")
-		updates.Proxy = *req.Proxy
-	}
-	if req.AutoSync != nil {
-		selectFields = append(selectFields, "auto_sync")
-		updates.AutoSync = *req.AutoSync
-	}
-	if req.SkipModelTest != nil {
-		selectFields = append(selectFields, "skip_model_test")
-		updates.SkipModelTest = *req.SkipModelTest
-	}
-	if req.Disposable != nil {
-		selectFields = append(selectFields, "disposable")
-		updates.Disposable = *req.Disposable
-	}
-	if req.ExpireAt != nil {
-		selectFields = append(selectFields, "expire_at")
-		updates.ExpireAt = req.ExpireAt
-	}
-	if req.NotifChannelID != nil {
-		selectFields = append(selectFields, "notif_channel_id")
-		updates.NotifChannelID = req.NotifChannelID
-	}
-	if req.KeySelectionStrategy != nil {
-		selectFields = append(selectFields, "key_selection_strategy")
-		updates.KeySelectionStrategy = *req.KeySelectionStrategy
-	}
-	if req.AutoGroup != nil {
-		selectFields = append(selectFields, "auto_group")
-		updates.AutoGroup = *req.AutoGroup
-	}
-	if req.CustomHeader != nil {
-		selectFields = append(selectFields, "custom_header")
-		updates.CustomHeader = *req.CustomHeader
-	}
-	if req.ChannelProxy != nil {
-		selectFields = append(selectFields, "channel_proxy")
-		updates.ChannelProxy = req.ChannelProxy
+	if req.ProxyMode != nil || req.ProxyConfigID != nil || req.Proxy != nil || req.ChannelProxy != nil {
+		mode := current.ProxyMode
+		configID := current.ProxyConfigID
+		legacyProxy := current.Proxy
+		legacyChannelProxy := current.ChannelProxy
+
+		if req.ProxyMode != nil {
+			mode = *req.ProxyMode
+		}
+		if req.ProxyConfigID != nil {
+			configID = req.ProxyConfigID
+		}
+		if req.Proxy != nil {
+			legacyProxy = *req.Proxy
+		}
+		if req.ChannelProxy != nil {
+			legacyChannelProxy = req.ChannelProxy
+		}
+
+		// 仅传旧字段时，从 legacy 推导新模式
+		if req.ProxyMode == nil && (req.Proxy != nil || req.ChannelProxy != nil) {
+			mode, configID = deriveProxyModeFromLegacy(legacyProxy, legacyChannelProxy)
+		}
+
+		tmp := model.Channel{
+			ProxyMode:     mode,
+			ProxyConfigID: configID,
+			Proxy:         legacyProxy,
+			ChannelProxy:  legacyChannelProxy,
+		}
+		if err := normalizeChannelProxyFields(&tmp); err != nil {
+			tx.Rollback()
+			return nil, err
+		}
+
+		selectFields = append(selectFields, "proxy_mode", "proxy_config_id", "proxy", "channel_proxy")
+		updates.ProxyMode = tmp.ProxyMode
+		updates.ProxyConfigID = tmp.ProxyConfigID
+		updates.Proxy = tmp.Proxy
+		updates.ChannelProxy = tmp.ChannelProxy
 	}
 	if req.ParamOverride != nil {
 		selectFields = append(selectFields, "param_override")

--- a/internal/op/channel/proxy_test.go
+++ b/internal/op/channel/proxy_test.go
@@ -1,0 +1,83 @@
+package channel
+
+import (
+	"testing"
+
+	"github.com/lingyuins/octopus/internal/model"
+)
+
+func TestNormalizeChannelProxyFieldsFromLegacySystem(t *testing.T) {
+	ch := &model.Channel{Proxy: true}
+	if err := normalizeChannelProxyFields(ch); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if ch.ProxyMode != model.ProxyUsageModeSystem {
+		t.Fatalf("ProxyMode = %q, want system", ch.ProxyMode)
+	}
+	if !ch.Proxy {
+		t.Fatal("Proxy should remain true for system mode")
+	}
+	if ch.ProxyConfigID != nil {
+		t.Fatalf("ProxyConfigID = %#v, want nil", ch.ProxyConfigID)
+	}
+}
+
+func TestNormalizeChannelProxyFieldsPoolRequiresConfigOrURL(t *testing.T) {
+	ch := &model.Channel{ProxyMode: model.ProxyUsageModePool}
+	if err := normalizeChannelProxyFields(ch); err == nil {
+		t.Fatal("expected error when pool mode has neither config id nor channel proxy")
+	}
+}
+
+func TestNormalizeChannelProxyFieldsPoolWithConfig(t *testing.T) {
+	configID := 9
+	ch := &model.Channel{
+		ProxyMode:     model.ProxyUsageModePool,
+		ProxyConfigID: &configID,
+	}
+	if err := normalizeChannelProxyFields(ch); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if !ch.Proxy {
+		t.Fatal("Proxy should be true for pool mode")
+	}
+	if ch.ProxyConfigID == nil || *ch.ProxyConfigID != configID {
+		t.Fatalf("ProxyConfigID = %#v, want %d", ch.ProxyConfigID, configID)
+	}
+}
+
+func TestNormalizeChannelProxyFieldsDirectClearsConfig(t *testing.T) {
+	configID := 3
+	ch := &model.Channel{
+		ProxyMode:     model.ProxyUsageModeDirect,
+		ProxyConfigID: &configID,
+		Proxy:         true,
+	}
+	if err := normalizeChannelProxyFields(ch); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if ch.Proxy {
+		t.Fatal("Proxy should be false for direct mode")
+	}
+	if ch.ProxyConfigID != nil {
+		t.Fatalf("ProxyConfigID = %#v, want nil", ch.ProxyConfigID)
+	}
+}
+
+func TestDeriveProxyModeFromLegacy(t *testing.T) {
+	mode, id := deriveProxyModeFromLegacy(false, nil)
+	if mode != model.ProxyUsageModeDirect || id != nil {
+		t.Fatalf("direct: mode=%q id=%#v", mode, id)
+	}
+
+	mode, id = deriveProxyModeFromLegacy(true, nil)
+	if mode != model.ProxyUsageModeSystem || id != nil {
+		t.Fatalf("system: mode=%q id=%#v", mode, id)
+	}
+
+	proxyURL := "http://127.0.0.1:1"
+	mode, id = deriveProxyModeFromLegacy(true, &proxyURL)
+	if mode != model.ProxyUsageModePool || id != nil {
+		t.Fatalf("custom: mode=%q id=%#v", mode, id)
+	}
+}

--- a/internal/server/handlers/channel.go
+++ b/internal/server/handlers/channel.go
@@ -412,6 +412,17 @@ func (p channelRequestPayload) toChannel() model.Channel {
 			Remark:     key.Remark,
 		})
 	}
+
+	// 兼容旧前端：proxy + channel_proxy；新前端可直接传 proxy_mode/proxy_config_id。
+	// 这里先写入旧字段，Create 内 normalizeChannelProxyFields 会推导 ProxyMode。
+	var channelProxy *string
+	if p.ChannelProxy != nil {
+		trimmed := strings.TrimSpace(*p.ChannelProxy)
+		if trimmed != "" {
+			channelProxy = &trimmed
+		}
+	}
+
 	return model.Channel{
 		Name:                 p.Name,
 		GroupID:              p.GroupID,
@@ -431,7 +442,7 @@ func (p channelRequestPayload) toChannel() model.Channel {
 		AutoGroup:            p.AutoGroup,
 		CustomHeader:         p.CustomHeader,
 		ParamOverride:        p.ParamOverride,
-		ChannelProxy:         p.ChannelProxy,
+		ChannelProxy:         channelProxy,
 		RequestRewrite:       p.RequestRewrite,
 		MatchRegex:           p.MatchRegex,
 	}

--- a/internal/sitesync/project.go
+++ b/internal/sitesync/project.go
@@ -200,7 +200,8 @@ func ProjectAccount(ctx context.Context, accountID int) ([]int, error) {
 				continue
 			}
 
-			updateReq := &model.ChannelUpdateRequest{ID: existingChannel.ID, Name: &channelPayload.Name, Type: &channelPayload.Type, Enabled: &channelPayload.Enabled, BaseUrls: &channelPayload.BaseUrls, Model: &channelPayload.Model, CustomModel: &channelPayload.CustomModel, ProxyMode: &channelPayload.ProxyMode, ProxyConfigID: channelPayload.ProxyConfigID, AutoSync: &channelPayload.AutoSync, CustomHeader: &channelPayload.CustomHeader, BypassManagedCheck: true}
+			proxyEnabled := channelPayload.Proxy
+			updateReq := &model.ChannelUpdateRequest{ID: existingChannel.ID, Name: &channelPayload.Name, Type: &channelPayload.Type, Enabled: &channelPayload.Enabled, BaseUrls: &channelPayload.BaseUrls, Model: &channelPayload.Model, CustomModel: &channelPayload.CustomModel, ProxyMode: &channelPayload.ProxyMode, ProxyConfigID: channelPayload.ProxyConfigID, Proxy: &proxyEnabled, AutoSync: &channelPayload.AutoSync, CustomHeader: &channelPayload.CustomHeader, BypassManagedCheck: true}
 			updateReq.KeysToAdd, updateReq.KeysToUpdate, updateReq.KeysToDelete = diffManagedChannelKeys(existingChannel.Keys, channelPayload.Keys)
 			if _, err := op.ChannelUpdate(updateReq, ctx); err != nil {
 				return nil, fmt.Errorf("failed to update managed channel: %w", err)


### PR DESCRIPTION
## 问题

设置系统代理或代理池后，站点/渠道请求仍不走代理。

根因：

1. `ChannelHttpClient` 仍只读取旧字段 `Proxy` / `ChannelProxy`，未处理 `ProxyMode` / `ProxyConfigID`
2. 渠道 Create/Update 未持久化 `proxy_mode` / `proxy_config_id`
3. 迁移后 `proxy_mode` 默认 `direct`、旧 `proxy=true` 仍存在时会被误判为直连

## 改动

- `ChannelHttpClient` 按 `ProxyMode`/`ProxyConfigID` 选择直连、系统代理或代理池；兼容旧 `Proxy`/`ChannelProxy`
- 通过 `helper.ProxyURLByConfigFunc` 注入 `op.ProxyURLForConfig`，避免 helper/op 循环依赖
- 渠道 Create/Update 归一化并落盘代理相关字段
- 站点投影更新同步 `Proxy` 布尔
- 补充 helper / op/channel 相关测试

## 验证

```bash
go test ./internal/helper/ -run 'Proxy|ChannelHttp' -count=1
go test ./internal/op/channel/ -run 'Proxy|Normalize|Derive' -count=1
go test ./internal/sitesync/ -run 'Proxy|ResolveSite' -count=1
go build ./internal/helper/ ./internal/op/ ./internal/op/channel/ ./internal/sitesync/ ./internal/relay/
```