### PR TITLE
fix(relay): 透传上游 400 客户端错误体给下游

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+- **Relay**: 上游 400 类客户端错误（如 `context_length_exceeded`）不再被 adapter 回退链路改写成换渠道，也不再吞成管理端 502；原样把上游状态码与错误体回给下游，便于 omp 等客户端识别溢出并自动压缩上下文。
+
 ## [v2.4.0] - 2026-07-15
 
 ### 🚀 Features

--- a/internal/relay/chat_responses_fallback_test.go
+++ b/internal/relay/chat_responses_fallback_test.go
@@ -240,3 +240,15 @@ func TestShouldTryAdapterFallbackAllowsNextChannelFailures(t *testing.T) {
 		t.Fatal("expected route-scoped failure to allow adapter fallback")
 	}
 }
+
+func TestShouldTryAdapterFallbackSkipsClientErrorScopeNone(t *testing.T) {
+	result := attemptResult{
+		Success:  false,
+		Written:  false,
+		Decision: RetryDecision{Scope: ScopeNone, Reason: "bad request, client error", Code: 400, IsError: true},
+	}
+
+	if shouldTryAdapterFallback(result, 0, 2) {
+		t.Fatal("expected client error ScopeNone to skip adapter fallback so upstream body can be returned immediately")
+	}
+}

--- a/internal/relay/media_relay.go
+++ b/internal/relay/media_relay.go
@@ -315,7 +315,8 @@ func MediaHandler(endpointType MediaEndpointType, c *gin.Context) {
 					lastErr = fwdErr
 					allAttempts = append(allAttempts, routeIter.Attempts()...)
 					recordMediaRelayLog(apiKeyID, requestModel, logEndpointType, bodyBytes, channel.ID, channel.Name, resolvedModel, time.Since(startTime), allAttempts, fwdErr, clientIP)
-					resp.Error(c, http.StatusBadGateway, lastErr.Error())
+					// 与 LLM relay 一致：客户端错误原样回给下游，不吞成 502。
+					writeClientTerminalError(c, decision.Code, fwdErr)
 					return
 				case ScopeAbortAll:
 					lastErr = fwdErr

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -139,15 +139,14 @@ func isLLMRequestFormat(request *model.InternalLLMRequest) bool {
 }
 
 func shouldTryAdapterFallback(result attemptResult, adapterIndex, attemptCount int) bool {
-	if result.Success || result.Written || result.Decision.Scope == ScopeAbortAll || adapterIndex >= attemptCount-1 {
+	if result.Success || result.Written || adapterIndex >= attemptCount-1 {
 		return false
 	}
-	// Key-scoped failures use the same credential across adapter formats, so
-	// trying another adapter only adds latency before the normal key retry path.
-	if result.Decision.Scope == ScopeSameChannel {
-		return false
-	}
-	return true
+	// 只有路由级失败（换候选）才值得尝试另一种出站 adapter 格式。
+	// 客户端错误 ScopeNone（如 context_length_exceeded 的 400）与 Key 级失败
+	// ScopeSameChannel 都不该再换 adapter：前者必须立刻把上游错误体回给下游，
+	// 后者换 adapter 只会用同一把 Key 多打一次，徒增延迟。
+	return result.Decision.Scope == ScopeNextChannel
 }
 func isZenCandidateChannelAllowed(requestModel string, channelType outbound.OutboundType, isEmbeddingRequest bool) bool {
 	preferred := detectZenPreferredChannelTypes(requestModel, isEmbeddingRequest)
@@ -693,16 +692,97 @@ const upstreamErrorDetailPrefix = "upstream error: "
 // 原样展示上游响应，而不是只看到笼统的决策摘要（issue #93）。
 //
 // 错误形如 "upstream error: 429: {\"error\":...}"，这里返回 "429: {\"error\":...}"；
+// 若外层再包了一层 channel/attempt 前缀，也会定位到 "upstream error: " 后截取。
 // 非 HTTP 错误（如网络错误、transformer 错误）则直接返回错误文本本身。
 func extractUpstreamErrorDetail(err error) string {
 	if err == nil {
 		return ""
 	}
 	s := err.Error()
-	if trimmed, ok := strings.CutPrefix(s, upstreamErrorDetailPrefix); ok {
-		return trimmed
+	if idx := strings.Index(s, upstreamErrorDetailPrefix); idx >= 0 {
+		return s[idx+len(upstreamErrorDetailPrefix):]
 	}
 	return s
+}
+
+// clientErrorType 为非 JSON 上游错误体合成 OpenAI 兼容 envelope 时选择 type。
+func clientErrorType(statusCode int) string {
+	switch statusCode {
+	case http.StatusBadRequest:
+		return "invalid_request_error"
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return "authentication_error"
+	case http.StatusTooManyRequests:
+		return "rate_limit_error"
+	default:
+		return "api_error"
+	}
+}
+
+// writeClientTerminalError 在 ScopeNone 等「不再重试」的终态下，把上游错误尽量原样
+// 回给下游客户端，而不是吞成管理端风格的 502 "upstream service unavailable"。
+//
+// 这样下游（如 omp/oh-my-pi）才能识别 context_length_exceeded / prompt is too long
+// 等溢出信号并自动触发上下文压缩，而不是被网关伪装错误挡住。
+//
+// 策略：
+//  1. statusCode>=400 且错误中带有上游 JSON body → 原样 HTTP 状态 + 原样 body；
+//  2. 有上游纯文本 body → 包成 OpenAI 兼容 {"error":{...}}，状态码仍用上游；
+//  3. 没有可用 body → 合成最小 OpenAI 兼容错误；
+//  4. 非 HTTP 错误 / 无效状态 → 回退 BadGateway。
+func writeClientTerminalError(c *gin.Context, statusCode int, err error) {
+	if c == nil || c.Writer.Written() {
+		return
+	}
+	if statusCode < 400 {
+		resp.BadGateway(c)
+		return
+	}
+
+	detail := extractUpstreamErrorDetail(err)
+	bodyText := strings.TrimSpace(detail)
+	if prefix := fmt.Sprintf("%d: ", statusCode); strings.HasPrefix(bodyText, prefix) {
+		bodyText = strings.TrimSpace(bodyText[len(prefix):])
+	}
+
+	if bodyText != "" && bodyText != "response body too large" {
+		body := []byte(bodyText)
+		if jsonAPI.Valid(body) {
+			c.Data(statusCode, "application/json", body)
+			c.Abort()
+			return
+		}
+		if payload, mErr := jsonAPI.Marshal(map[string]any{
+			"error": map[string]any{
+				"message": bodyText,
+				"type":    clientErrorType(statusCode),
+				"code":    "",
+				"param":   "",
+			},
+		}); mErr == nil {
+			c.Data(statusCode, "application/json", payload)
+			c.Abort()
+			return
+		}
+	}
+
+	message := http.StatusText(statusCode)
+	if message == "" {
+		message = "request failed"
+	}
+	if payload, mErr := jsonAPI.Marshal(map[string]any{
+		"error": map[string]any{
+			"message": message,
+			"type":    clientErrorType(statusCode),
+			"code":    "",
+			"param":   "",
+		},
+	}); mErr == nil {
+		c.Data(statusCode, "application/json", payload)
+		c.Abort()
+		return
+	}
+	resp.Error(c, statusCode, message)
 }
 
 // copyHeaders 复制请求头，过滤 hop-by-hop 头
@@ -1356,7 +1436,9 @@ func executeRelay(req *relayRequest, group dbmodel.Group, requestModel string, m
 				case ScopeNone:
 					lastErr = result.Err
 					req.metrics.Save(false, lastErr, currentAttempts)
-					resp.BadGateway(req.c)
+					// 400 类客户端错误不再重试，把上游错误体原样回给下游，
+					// 避免吞成 502 导致客户端无法识别 context_length_exceeded。
+					writeClientTerminalError(req.c, result.Decision.Code, result.Err)
 					return nil, result.Err
 				case ScopeAbortAll:
 					lastErr = result.Err

--- a/internal/relay/retry_test.go
+++ b/internal/relay/retry_test.go
@@ -2,11 +2,15 @@ package relay
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/gin-gonic/gin"
 )
 
 func TestClassifyRelayError_Success(t *testing.T) {
@@ -405,6 +409,84 @@ func TestExtractUpstreamErrorDetail(t *testing.T) {
 				t.Errorf("extractUpstreamErrorDetail() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExtractUpstreamErrorDetailFromWrappedAttemptError(t *testing.T) {
+	// attempt() 会把 forward 错误再包一层 "channel X adapter=Y attempt N/M: ..."
+	// 透传逻辑必须仍能抽出上游 body。
+	err := errors.New(`channel foo adapter=openai-chat attempt 1/4: upstream error: 400: {"error":{"message":"输入内容过长","type":"invalid_request_error","code":"context_length_exceeded"}}`)
+	got := extractUpstreamErrorDetail(err)
+	want := `400: {"error":{"message":"输入内容过长","type":"invalid_request_error","code":"context_length_exceeded"}}`
+	if got != want {
+		t.Fatalf("extractUpstreamErrorDetail() = %q, want %q", got, want)
+	}
+}
+
+func TestWriteClientTerminalErrorPassesUpstreamJSONBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	upstreamBody := `{"error":{"message":"输入内容过长，已超过当前模型的上下文限制，请减少历史消息、文件内容或提示词后重试。","type":"invalid_request_error","param":"","code":"context_length_exceeded"}}`
+	err := fmt.Errorf("channel demo adapter=openai-chat attempt 1/4: upstream error: 400: %s", upstreamBody)
+
+	writeClientTerminalError(c, http.StatusBadRequest, err)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("content-type = %q, want application/json", ct)
+	}
+	if got := strings.TrimSpace(w.Body.String()); got != upstreamBody {
+		t.Fatalf("body = %s, want %s", got, upstreamBody)
+	}
+	if !strings.Contains(w.Body.String(), "context_length_exceeded") {
+		t.Fatalf("body missing context_length_exceeded: %s", w.Body.String())
+	}
+}
+
+func TestWriteClientTerminalErrorWrapsPlainTextBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	err := errors.New("upstream error: 400: prompt is too long")
+	writeClientTerminalError(c, http.StatusBadRequest, err)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	var payload struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		} `json:"error"`
+	}
+	if err := jsonAPI.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal body: %v; body=%s", err, w.Body.String())
+	}
+	if payload.Error.Message != "prompt is too long" {
+		t.Fatalf("message = %q, want prompt is too long", payload.Error.Message)
+	}
+	if payload.Error.Type != "invalid_request_error" {
+		t.Fatalf("type = %q, want invalid_request_error", payload.Error.Type)
+	}
+}
+
+func TestWriteClientTerminalErrorFallsBackToBadGatewayWithoutHTTPStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	writeClientTerminalError(c, 0, errors.New("connection refused"))
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusBadGateway, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- 上游 400 类客户端错误（如 `context_length_exceeded`）在 `ScopeNone` 终态下不再吞成管理端 502 `upstream service unavailable`，改为原样返回上游 HTTP 状态码与错误体
- 禁止对 `ScopeNone` / `ScopeSameChannel` 做 adapter 回退，避免上下文超限时再走 Chat/Responses 回退链路
- media relay 同步使用同一透传路径
- 便于 omp / oh-my-pi 等下游客户端识别 `context_length_exceeded` 并自动触发上下文压缩

## 背景
同一模型不同渠道上下文窗口不同时，上游会返回：

```json
{"error":{"message":"输入内容过长...","type":"invalid_request_error","code":"context_length_exceeded"}}
```

日志虽已记录 `none (bad request, client error)`，但最终响应被 `resp.BadGateway()` 改写，下游拿不到溢出信号，无法自动 compact。

## Test plan
- [x] `go test ./internal/relay/ -count=1`
- [x] 覆盖：上游 JSON body 原样透传、纯文本 body 包 OpenAI envelope、无 HTTP 状态回退 502
- [x] 覆盖：`ScopeNone` 不触发 adapter fallback
- [ ] 实际请求验证：分组内小窗口渠道返回 `context_length_exceeded` 时，客户端直接收到 400 + 原 body，且不再切到下一渠道