### PR TITLE
feat(log,transformer): 日志出站协议/思考指标 + effort 透传修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🚀 Features
+- **Log**: show effective outbound reasoning effort and upstream reasoning tokens on log cards (hidden when empty; field toggles default on).
+
+### 🐛 Bug Fixes
+- **Transformer**: preserve OpenAI `reasoning_effort` values `minimal`/`xhigh`/`max` instead of collapsing them to `high`; Anthropic/Gemini budget mapping now covers `xhigh`/`max`.
+
 ## [v2.4.0] - 2026-07-15
 
 ### 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🚀 Features
 - **Log**: show effective outbound reasoning effort and upstream reasoning tokens on log cards (hidden when empty; field toggles default on).
+- **Log**: when official reasoning tokens are absent, fall back to thinking text character count (UTF-8 runes) and display as “思考 XXt” / “思考 XX字”.
 
 ### 🐛 Bug Fixes
 - **Transformer**: preserve OpenAI `reasoning_effort` values `minimal`/`xhigh`/`max` instead of collapsing them to `high`; Anthropic/Gemini budget mapping now covers `xhigh`/`max`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Log**: when official reasoning tokens are absent, fall back to thinking text character count (UTF-8 runes) and display as “思考 XXt” / “思考 XX字”.
 
 ### 🐛 Bug Fixes
+- **Transformer**: Anthropic streaming now attaches usage on `message_delta` chunks so relay logs keep input/output tokens when `message_stop` is missing.
 - **Transformer**: preserve OpenAI `reasoning_effort` values `minimal`/`xhigh`/`max` instead of collapsing them to `high`; Anthropic/Gemini budget mapping now covers `xhigh`/`max`.
 
 ## [v2.4.0] - 2026-07-15

--- a/internal/db/migrate/035.go
+++ b/internal/db/migrate/035.go
@@ -14,8 +14,10 @@ func init() {
 	})
 }
 
-// 035: 为 relay_logs 增加 reasoning_effort / reasoning_tokens 列。
-// reasoning_effort 记录出站最终思考强度；reasoning_tokens 记录上游 usage 中的思考 token。
+// 035: 为 relay_logs 增加 reasoning_effort / reasoning_tokens / reasoning_chars 列。
+// reasoning_effort 记录出站最终思考强度；
+// reasoning_tokens 记录上游 usage 中的官方思考 token；
+// reasoning_chars 在无官方 token 时记录思考文本字符数（UTF-8 rune）作为展示回退。
 // gorm AutoMigrate 通常也会加列，这里幂等兜底，确保跨方言与运行时切换 DB 类型后列存在。
 func migrateRelayLogReasoningMetrics(db *gorm.DB) error {
 	if db == nil {
@@ -24,7 +26,7 @@ func migrateRelayLogReasoningMetrics(db *gorm.DB) error {
 	if !db.Migrator().HasTable(&model.RelayLog{}) {
 		return nil
 	}
-	for _, col := range []string{"ReasoningEffort", "ReasoningTokens"} {
+	for _, col := range []string{"ReasoningEffort", "ReasoningTokens", "ReasoningChars"} {
 		if db.Migrator().HasColumn(&model.RelayLog{}, col) {
 			continue
 		}

--- a/internal/db/migrate/035.go
+++ b/internal/db/migrate/035.go
@@ -1,0 +1,36 @@
+package migrate
+
+import (
+	"fmt"
+
+	"github.com/lingyuins/octopus/internal/model"
+	"gorm.io/gorm"
+)
+
+func init() {
+	RegisterAfterAutoMigration(Migration{
+		Version: 35,
+		Up:      migrateRelayLogReasoningMetrics,
+	})
+}
+
+// 035: 为 relay_logs 增加 reasoning_effort / reasoning_tokens 列。
+// reasoning_effort 记录出站最终思考强度；reasoning_tokens 记录上游 usage 中的思考 token。
+// gorm AutoMigrate 通常也会加列，这里幂等兜底，确保跨方言与运行时切换 DB 类型后列存在。
+func migrateRelayLogReasoningMetrics(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("db is nil")
+	}
+	if !db.Migrator().HasTable(&model.RelayLog{}) {
+		return nil
+	}
+	for _, col := range []string{"ReasoningEffort", "ReasoningTokens"} {
+		if db.Migrator().HasColumn(&model.RelayLog{}, col) {
+			continue
+		}
+		if err := db.Migrator().AddColumn(&model.RelayLog{}, col); err != nil {
+			return fmt.Errorf("add relay_logs.%s: %w", col, err)
+		}
+	}
+	return nil
+}

--- a/internal/model/log.go
+++ b/internal/model/log.go
@@ -39,6 +39,9 @@ type RelayLog struct {
 	OutputTokens      int              `json:"output_tokens" gorm:"column:output_tokens"`                                                                                                  // 输出 Token
 	SemanticCacheHit  bool             `json:"semantic_cache_hit" gorm:"column:semantic_cache_hit"`                                                                                        // 语义缓存命中（写入时落库，避免列表查询重解析大字段）
 	CacheReadTokens   int              `json:"cache_read_tokens" gorm:"column:cache_read_tokens"`                                                                                          // 提供方提示缓存命中 Token（写入时落库）
+	ReasoningEffort   string           `json:"reasoning_effort" gorm:"column:reasoning_effort"`                                                                                            // 出站最终思考强度（effective）
+	ReasoningTokens   int              `json:"reasoning_tokens" gorm:"column:reasoning_tokens"`                                                                                            // 上游返回的思考 Token（usage）
+
 	Ftut              int              `json:"ftut" gorm:"column:ftut"`                                                                                                                    // 首字时间(毫秒)
 	UseTime           int              `json:"use_time" gorm:"column:use_time"`                                                                                                            // 总用时(毫秒)
 	Cost              float64          `json:"cost" gorm:"column:cost"`                                                                                                                    // 消耗费用
@@ -66,6 +69,8 @@ type RelayLogListItem struct {
 	OutputTokens      int              `json:"output_tokens" gorm:"column:output_tokens"`
 	SemanticCacheHit  bool             `json:"semantic_cache_hit" gorm:"column:semantic_cache_hit"`
 	CacheReadTokens   int              `json:"cache_read_tokens" gorm:"column:cache_read_tokens"`
+	ReasoningEffort   string           `json:"reasoning_effort" gorm:"column:reasoning_effort"`
+	ReasoningTokens   int              `json:"reasoning_tokens" gorm:"column:reasoning_tokens"`
 	Ftut              int              `json:"ftut" gorm:"column:ftut"`
 	UseTime           int              `json:"use_time" gorm:"column:use_time"`
 	Cost              float64          `json:"cost" gorm:"column:cost"`
@@ -115,6 +120,8 @@ func (r *RelayLog) ToListItem() RelayLogListItem {
 		OutputTokens:      r.OutputTokens,
 		SemanticCacheHit:  r.SemanticCacheHit,
 		CacheReadTokens:   r.CacheReadTokens,
+		ReasoningEffort:   r.ReasoningEffort,
+		ReasoningTokens:   r.ReasoningTokens,
 		Ftut:              r.Ftut,
 		UseTime:           r.UseTime,
 		Cost:              r.Cost,

--- a/internal/model/log.go
+++ b/internal/model/log.go
@@ -40,7 +40,8 @@ type RelayLog struct {
 	SemanticCacheHit  bool             `json:"semantic_cache_hit" gorm:"column:semantic_cache_hit"`                                                                                        // 语义缓存命中（写入时落库，避免列表查询重解析大字段）
 	CacheReadTokens   int              `json:"cache_read_tokens" gorm:"column:cache_read_tokens"`                                                                                          // 提供方提示缓存命中 Token（写入时落库）
 	ReasoningEffort   string           `json:"reasoning_effort" gorm:"column:reasoning_effort"`                                                                                            // 出站最终思考强度（effective）
-	ReasoningTokens   int              `json:"reasoning_tokens" gorm:"column:reasoning_tokens"`                                                                                            // 上游返回的思考 Token（usage）
+	ReasoningTokens   int              `json:"reasoning_tokens" gorm:"column:reasoning_tokens"`                                                                                            // 上游返回的思考 Token（usage，确定性）
+	ReasoningChars    int              `json:"reasoning_chars" gorm:"column:reasoning_chars"`                                                                                              // 思考文本字符数（无官方 token 时的估算回退，UTF-8 rune 数）
 
 	Ftut              int              `json:"ftut" gorm:"column:ftut"`                                                                                                                    // 首字时间(毫秒)
 	UseTime           int              `json:"use_time" gorm:"column:use_time"`                                                                                                            // 总用时(毫秒)
@@ -71,6 +72,7 @@ type RelayLogListItem struct {
 	CacheReadTokens   int              `json:"cache_read_tokens" gorm:"column:cache_read_tokens"`
 	ReasoningEffort   string           `json:"reasoning_effort" gorm:"column:reasoning_effort"`
 	ReasoningTokens   int              `json:"reasoning_tokens" gorm:"column:reasoning_tokens"`
+	ReasoningChars    int              `json:"reasoning_chars" gorm:"column:reasoning_chars"`
 	Ftut              int              `json:"ftut" gorm:"column:ftut"`
 	UseTime           int              `json:"use_time" gorm:"column:use_time"`
 	Cost              float64          `json:"cost" gorm:"column:cost"`
@@ -122,6 +124,7 @@ func (r *RelayLog) ToListItem() RelayLogListItem {
 		CacheReadTokens:   r.CacheReadTokens,
 		ReasoningEffort:   r.ReasoningEffort,
 		ReasoningTokens:   r.ReasoningTokens,
+		ReasoningChars:    r.ReasoningChars,
 		Ftut:              r.Ftut,
 		UseTime:           r.UseTime,
 		Cost:              r.Cost,

--- a/internal/op/relaylog/relaylog.go
+++ b/internal/op/relaylog/relaylog.go
@@ -707,6 +707,7 @@ func RelayLogList(ctx context.Context, filter LogFilter, page, pageSize int) ([]
 					"client_ip",
 					"endpoint_type", "channel_id", "channel_name", "actual_model_name",
 					"input_tokens", "output_tokens", "semantic_cache_hit", "cache_read_tokens",
+					"reasoning_effort", "reasoning_tokens",
 					"ftut", "use_time",
 					"cost", "error", "attempts", "total_attempts", "is_test")
 			if filter.StartTime != nil {

--- a/internal/op/relaylog/relaylog.go
+++ b/internal/op/relaylog/relaylog.go
@@ -707,7 +707,7 @@ func RelayLogList(ctx context.Context, filter LogFilter, page, pageSize int) ([]
 					"client_ip",
 					"endpoint_type", "channel_id", "channel_name", "actual_model_name",
 					"input_tokens", "output_tokens", "semantic_cache_hit", "cache_read_tokens",
-					"reasoning_effort", "reasoning_tokens",
+					"reasoning_effort", "reasoning_tokens", "reasoning_chars",
 					"ftut", "use_time",
 					"cost", "error", "attempts", "total_attempts", "is_test")
 			if filter.StartTime != nil {

--- a/internal/relay/metrics.go
+++ b/internal/relay/metrics.go
@@ -306,6 +306,12 @@ func (m *RelayMetrics) saveLog(ctx context.Context, err error, duration time.Dur
 		relayLog.ReasoningEffort = strings.TrimSpace(m.InternalRequest.ReasoningEffort)
 	}
 
+	// 无官方 reasoning_tokens 时，回退统计思考文本字符数（UTF-8 rune，中英等统一按字计）。
+	// 有官方 token 时不写 chars，避免前端同时出现两种口径。
+	if relayLog.ReasoningTokens <= 0 {
+		relayLog.ReasoningChars = reasoningCharsFromResponse(m.InternalResponse)
+	}
+
 	// 大字段（请求/响应内容）记录开关。关闭时跳过 JSON 构造与存储，可大幅
 	// 降低每条日志的写入量与磁盘 IO（高负载日志性能优化的主要杠杆）。
 	// SemanticCacheHit 与 CacheReadTokens 不依赖大字段：前者从请求判断，后者
@@ -390,6 +396,25 @@ func cacheReadTokensFromUsage(resp *transformerModel.InternalLLMResponse) int {
 		return int(resp.Usage.PromptTokensDetails.CachedTokens)
 	}
 	return 0
+}
+
+// reasoningCharsFromResponse 统计响应里思考文本的字符数（UTF-8 rune）。
+// 一个中文/英文/其他字符都计 1，用于 Anthropic 等无官方 reasoning_tokens 的回退展示。
+func reasoningCharsFromResponse(resp *transformerModel.InternalLLMResponse) int {
+	if resp == nil {
+		return 0
+	}
+	total := 0
+	for i := range resp.Choices {
+		choice := &resp.Choices[i]
+		if choice.Message != nil {
+			total += utf8.RuneCountInString(choice.Message.GetReasoningContent())
+		}
+		if choice.Delta != nil {
+			total += utf8.RuneCountInString(choice.Delta.GetReasoningContent())
+		}
+	}
+	return total
 }
 
 func filterMessageForLog(msg *transformerModel.Message) *transformerModel.Message {

--- a/internal/relay/metrics.go
+++ b/internal/relay/metrics.go
@@ -296,6 +296,14 @@ func (m *RelayMetrics) saveLog(ctx context.Context, err error, duration time.Dur
 		relayLog.InputTokens = int(m.InternalResponse.Usage.PromptTokens)
 		relayLog.OutputTokens = int(m.InternalResponse.Usage.CompletionTokens)
 		relayLog.Cost = m.Stats.InputCost + m.Stats.OutputCost
+		if m.InternalResponse.Usage.CompletionTokensDetails != nil {
+			relayLog.ReasoningTokens = int(m.InternalResponse.Usage.CompletionTokensDetails.ReasoningTokens)
+		}
+	}
+
+	// 出站最终思考强度：以 InternalRequest 当前值为准（出站 sanitize/normalize 后写回）。
+	if m.InternalRequest != nil {
+		relayLog.ReasoningEffort = strings.TrimSpace(m.InternalRequest.ReasoningEffort)
 	}
 
 	// 大字段（请求/响应内容）记录开关。关闭时跳过 JSON 构造与存储，可大幅

--- a/internal/relay/metrics_content_test.go
+++ b/internal/relay/metrics_content_test.go
@@ -109,3 +109,54 @@ func TestSaveLogContentEnabledToggle(t *testing.T) {
 		t.Fatalf("content disabled: CacheReadTokens = %d, want %d (from Usage)", last2.CacheReadTokens, cachedTokens)
 	}
 }
+
+func TestSaveLogPersistsReasoningEffortAndTokens(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "metrics-reasoning.db")
+	if err := db.InitDB("sqlite", dsn, false); err != nil {
+		t.Fatalf("InitDB failed: %v", err)
+	}
+	if err := db.InitLogDB("", "", false); err != nil {
+		t.Fatalf("InitLogDB(shared) failed: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := setting.RefreshCache(context.Background()); err != nil {
+		t.Fatalf("RefreshCache failed: %v", err)
+	}
+	t.Cleanup(relaylog.SetCacheForTest(nil))
+
+	resp := &transformerModel.InternalLLMResponse{
+		Usage: &transformerModel.Usage{
+			PromptTokens:     100,
+			CompletionTokens: 50,
+			CompletionTokensDetails: &transformerModel.CompletionTokensDetails{
+				ReasoningTokens: 42,
+			},
+		},
+	}
+	metrics := &RelayMetrics{
+		APIKeyID:     1,
+		RequestModel: "gpt-5.5",
+		EndpointType: "chat",
+		ClientIP:     "127.0.0.1",
+		StartTime:    time.Now().Add(-50 * time.Millisecond),
+		InternalRequest: &transformerModel.InternalLLMRequest{
+			ReasoningEffort: "max",
+		},
+	}
+	metrics.SetInternalResponse(resp, "gpt-5.5")
+	metrics.saveLog(context.Background(), nil, 50*time.Millisecond, []model.ChannelAttempt{
+		{ChannelID: 1, ChannelName: "ch", ModelName: "gpt-5.5", Status: model.AttemptSuccess},
+	}, 1, "ch")
+
+	logs, _ := relaylog.GetCacheAndLock()
+	if len(logs) == 0 {
+		t.Fatal("expected log in cache")
+	}
+	last := logs[len(logs)-1]
+	if last.ReasoningEffort != "max" {
+		t.Fatalf("ReasoningEffort=%q, want max", last.ReasoningEffort)
+	}
+	if last.ReasoningTokens != 42 {
+		t.Fatalf("ReasoningTokens=%d, want 42", last.ReasoningTokens)
+	}
+}

--- a/internal/relay/metrics_content_test.go
+++ b/internal/relay/metrics_content_test.go
@@ -160,3 +160,111 @@ func TestSaveLogPersistsReasoningEffortAndTokens(t *testing.T) {
 		t.Fatalf("ReasoningTokens=%d, want 42", last.ReasoningTokens)
 	}
 }
+
+func TestSaveLogPersistsReasoningCharsWhenNoOfficialTokens(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "metrics-reasoning-chars.db")
+	if err := db.InitDB("sqlite", dsn, false); err != nil {
+		t.Fatalf("InitDB failed: %v", err)
+	}
+	if err := db.InitLogDB("", "", false); err != nil {
+		t.Fatalf("InitLogDB(shared) failed: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := setting.RefreshCache(context.Background()); err != nil {
+		t.Fatalf("RefreshCache failed: %v", err)
+	}
+	t.Cleanup(relaylog.SetCacheForTest(nil))
+
+	// 中文 2 + 英文 5 + 空格 1 + 数字 2 = 10 个 rune；无官方 reasoning_tokens
+	thinking := "思考hello 42"
+	resp := &transformerModel.InternalLLMResponse{
+		Usage: &transformerModel.Usage{
+			PromptTokens:     100,
+			CompletionTokens: 50,
+		},
+		Choices: []transformerModel.Choice{{
+			Message: &transformerModel.Message{
+				Role:             "assistant",
+				ReasoningContent: &thinking,
+			},
+		}},
+	}
+	metrics := &RelayMetrics{
+		APIKeyID:     1,
+		RequestModel: "claude",
+		EndpointType: "messages",
+		ClientIP:     "127.0.0.1",
+		StartTime:    time.Now().Add(-50 * time.Millisecond),
+		InternalRequest: &transformerModel.InternalLLMRequest{
+			ReasoningEffort: "max",
+		},
+	}
+	metrics.SetInternalResponse(resp, "claude")
+	metrics.saveLog(context.Background(), nil, 50*time.Millisecond, []model.ChannelAttempt{
+		{ChannelID: 1, ChannelName: "ch", ModelName: "claude", Status: model.AttemptSuccess},
+	}, 1, "ch")
+
+	logs, _ := relaylog.GetCacheAndLock()
+	if len(logs) == 0 {
+		t.Fatal("expected log in cache")
+	}
+	last := logs[len(logs)-1]
+	if last.ReasoningTokens != 0 {
+		t.Fatalf("ReasoningTokens=%d, want 0", last.ReasoningTokens)
+	}
+	wantChars := len([]rune(thinking))
+	if last.ReasoningChars != wantChars {
+		t.Fatalf("ReasoningChars=%d, want %d", last.ReasoningChars, wantChars)
+	}
+}
+
+func TestSaveLogSkipsReasoningCharsWhenOfficialTokensPresent(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "metrics-reasoning-official.db")
+	if err := db.InitDB("sqlite", dsn, false); err != nil {
+		t.Fatalf("InitDB failed: %v", err)
+	}
+	if err := db.InitLogDB("", "", false); err != nil {
+		t.Fatalf("InitLogDB(shared) failed: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := setting.RefreshCache(context.Background()); err != nil {
+		t.Fatalf("RefreshCache failed: %v", err)
+	}
+	t.Cleanup(relaylog.SetCacheForTest(nil))
+
+	thinking := "some long thinking text that should not be counted"
+	resp := &transformerModel.InternalLLMResponse{
+		Usage: &transformerModel.Usage{
+			PromptTokens:     100,
+			CompletionTokens: 50,
+			CompletionTokensDetails: &transformerModel.CompletionTokensDetails{
+				ReasoningTokens: 99,
+			},
+		},
+		Choices: []transformerModel.Choice{{
+			Message: &transformerModel.Message{
+				Role:             "assistant",
+				ReasoningContent: &thinking,
+			},
+		}},
+	}
+	metrics := &RelayMetrics{
+		APIKeyID:        1,
+		RequestModel:    "gpt",
+		EndpointType:    "chat",
+		ClientIP:        "127.0.0.1",
+		StartTime:       time.Now().Add(-50 * time.Millisecond),
+		InternalRequest: &transformerModel.InternalLLMRequest{ReasoningEffort: "high"},
+	}
+	metrics.SetInternalResponse(resp, "gpt")
+	metrics.saveLog(context.Background(), nil, 50*time.Millisecond, nil, 1, "ch")
+
+	logs, _ := relaylog.GetCacheAndLock()
+	last := logs[len(logs)-1]
+	if last.ReasoningTokens != 99 {
+		t.Fatalf("ReasoningTokens=%d, want 99", last.ReasoningTokens)
+	}
+	if last.ReasoningChars != 0 {
+		t.Fatalf("ReasoningChars=%d, want 0 when official tokens present", last.ReasoningChars)
+	}
+}

--- a/internal/transformer/inbound/anthropic/model.go
+++ b/internal/transformer/inbound/anthropic/model.go
@@ -146,6 +146,7 @@ const (
 // Effort level constants for OutputConfig
 const (
 	EffortMax    = "max"
+	EffortXHigh  = "xhigh"
 	EffortHigh   = "high"
 	EffortMedium = "medium"
 	EffortLow    = "low"
@@ -157,7 +158,7 @@ type Thinking struct {
 }
 
 type OutputConfig struct {
-	Effort string `json:"effort,omitempty" validate:"omitempty,oneof=max high medium low"`
+	Effort string `json:"effort,omitempty" validate:"omitempty,oneof=max xhigh high medium low"`
 }
 
 type ToolChoice struct {

--- a/internal/transformer/outbound/anthropic/messages.go
+++ b/internal/transformer/outbound/anthropic/messages.go
@@ -311,19 +311,21 @@ func convertToAnthropicRequest(req *model.InternalLLMRequest) *anthropicModel.Me
 	}
 
 	// Convert thinking/reasoning
-	if req.ReasoningEffort != "" {
-		if req.AdaptiveThinking {
-			result.Thinking = &anthropicModel.Thinking{
-				Type: anthropicModel.ThinkingTypeAdaptive,
-			}
-			result.OutputConfig = &anthropicModel.OutputConfig{
-				Effort: req.ReasoningEffort,
-			}
-		} else {
-			result.Thinking = &anthropicModel.Thinking{
-				Type:         anthropicModel.ThinkingTypeEnabled,
-				BudgetTokens: getThinkingBudget(req.ReasoningEffort, req.ReasoningBudget),
-			}
+	// 优先级：
+	// 1) 客户端显式 budget_tokens（ReasoningBudget）→ 保留 enabled+budget，兼容老请求
+	// 2) 有 reasoning effort（含 AdaptiveThinking / OpenAI reasoning_effort）→
+	//    与 Claude Code 一致：adaptive + output_config.effort 原样透传，不再猜 budget
+	if req.ReasoningBudget != nil {
+		result.Thinking = &anthropicModel.Thinking{
+			Type:         anthropicModel.ThinkingTypeEnabled,
+			BudgetTokens: getThinkingBudget(req.ReasoningEffort, req.ReasoningBudget),
+		}
+	} else if effort := strings.TrimSpace(req.ReasoningEffort); effort != "" {
+		result.Thinking = &anthropicModel.Thinking{
+			Type: anthropicModel.ThinkingTypeAdaptive,
+		}
+		result.OutputConfig = &anthropicModel.OutputConfig{
+			Effort: effort,
 		}
 	}
 
@@ -757,13 +759,18 @@ func getThinkingBudget(effort string, budget *int64) *int64 {
 	}
 
 	var result int64
-	switch effort {
+	switch strings.ToLower(strings.TrimSpace(effort)) {
 	case anthropicModel.EffortLow:
 		result = 1024
 	case anthropicModel.EffortMedium:
 		result = 8192
 	case anthropicModel.EffortHigh:
 		result = 32768
+	case anthropicModel.EffortXHigh:
+		// 扩展高强度：介于 high 与 max 之间，给更大 budget。
+		result = 65536
+	case anthropicModel.EffortMax:
+		result = 128000
 	default:
 		result = 8192
 	}

--- a/internal/transformer/outbound/anthropic/messages.go
+++ b/internal/transformer/outbound/anthropic/messages.go
@@ -250,10 +250,27 @@ func (o *MessageOutbound) TransformStream(ctx context.Context, eventData []byte)
 		if streamEvent.Usage != nil {
 			usage := convertAnthropicUsage(streamEvent.Usage)
 			if o.streamUsage != nil {
-				usage.PromptTokens = o.streamUsage.PromptTokens
-				usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+				// message_start 通常只有 input/cache；message_delta 补 output。
+				if usage.PromptTokens == 0 && o.streamUsage.PromptTokens > 0 {
+					usage.PromptTokens = o.streamUsage.PromptTokens
+				}
+				if usage.PromptTokensDetails == nil && o.streamUsage.PromptTokensDetails != nil {
+					usage.PromptTokensDetails = o.streamUsage.PromptTokensDetails
+				}
+				if usage.CacheCreationInputTokens == 0 && o.streamUsage.CacheCreationInputTokens > 0 {
+					usage.CacheCreationInputTokens = o.streamUsage.CacheCreationInputTokens
+				}
+				usage.AnthropicUsage = true
 			}
+			usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+			if usage.PromptTokensDetails != nil {
+				usage.TotalTokens += usage.PromptTokensDetails.CachedTokens
+			}
+			usage.TotalTokens += usage.CacheCreationInputTokens
 			o.streamUsage = usage
+			// 必须写到本 chunk：入站聚合只认 chunk.Usage；仅更新 streamUsage
+			// 而等 message_stop 时，部分网关可能不发 stop 或 stop 被丢弃，导致日志 usage 全 0。
+			resp.Usage = usage
 		}
 
 		if streamEvent.Delta != nil && streamEvent.Delta.StopReason != nil {

--- a/internal/transformer/outbound/anthropic/stream_usage_test.go
+++ b/internal/transformer/outbound/anthropic/stream_usage_test.go
@@ -1,0 +1,70 @@
+package anthropic
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTransformStream_MessageDeltaAttachesUsageToChunk(t *testing.T) {
+	o := &MessageOutbound{}
+
+	// message_start with input tokens only
+	start, err := o.TransformStream(context.Background(), []byte(`{
+		"type":"message_start",
+		"message":{
+			"id":"msg_1",
+			"model":"claude-test",
+			"usage":{"input_tokens":100,"output_tokens":0,"cache_read_input_tokens":20}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("message_start: %v", err)
+	}
+	if start == nil || start.Usage == nil || start.Usage.PromptTokens != 100 {
+		t.Fatalf("message_start usage = %#v", start)
+	}
+
+	// message_delta carries output tokens — must appear on this chunk for inbound aggregation
+	delta, err := o.TransformStream(context.Background(), []byte(`{
+		"type":"message_delta",
+		"delta":{"stop_reason":"end_turn"},
+		"usage":{"output_tokens":42}
+	}`))
+	if err != nil {
+		t.Fatalf("message_delta: %v", err)
+	}
+	if delta == nil || delta.Usage == nil {
+		t.Fatal("message_delta must attach Usage to chunk")
+	}
+	if delta.Usage.PromptTokens != 100 {
+		t.Fatalf("PromptTokens=%d, want 100 (merged from message_start)", delta.Usage.PromptTokens)
+	}
+	if delta.Usage.CompletionTokens != 42 {
+		t.Fatalf("CompletionTokens=%d, want 42", delta.Usage.CompletionTokens)
+	}
+	if delta.Usage.PromptTokensDetails == nil || delta.Usage.PromptTokensDetails.CachedTokens != 20 {
+		t.Fatalf("cached tokens not preserved: %#v", delta.Usage.PromptTokensDetails)
+	}
+}
+
+func TestTransformStream_MessageStopStillCarriesUsage(t *testing.T) {
+	o := &MessageOutbound{}
+	_, _ = o.TransformStream(context.Background(), []byte(`{
+		"type":"message_start",
+		"message":{"id":"msg_1","model":"claude-test","usage":{"input_tokens":10}}
+	}`))
+	_, _ = o.TransformStream(context.Background(), []byte(`{
+		"type":"message_delta",
+		"usage":{"output_tokens":7}
+	}`))
+	stop, err := o.TransformStream(context.Background(), []byte(`{"type":"message_stop"}`))
+	if err != nil {
+		t.Fatalf("message_stop: %v", err)
+	}
+	if stop == nil || stop.Usage == nil {
+		t.Fatal("message_stop should still carry usage")
+	}
+	if stop.Usage.PromptTokens != 10 || stop.Usage.CompletionTokens != 7 {
+		t.Fatalf("stop usage = prompt=%d completion=%d", stop.Usage.PromptTokens, stop.Usage.CompletionTokens)
+	}
+}

--- a/internal/transformer/outbound/anthropic/thinking_budget_test.go
+++ b/internal/transformer/outbound/anthropic/thinking_budget_test.go
@@ -1,0 +1,35 @@
+package anthropic
+
+import (
+	"testing"
+
+	anthropicModel "github.com/lingyuins/octopus/internal/transformer/inbound/anthropic"
+)
+
+func TestGetThinkingBudget_MapsExtendedEfforts(t *testing.T) {
+	cases := map[string]int64{
+		anthropicModel.EffortLow:    1024,
+		anthropicModel.EffortMedium: 8192,
+		anthropicModel.EffortHigh:   32768,
+		"xhigh":                     65536,
+		anthropicModel.EffortMax:    128000,
+		"unknown":                   8192,
+	}
+	for effort, want := range cases {
+		got := getThinkingBudget(effort, nil)
+		if got == nil {
+			t.Fatalf("effort %q: budget is nil", effort)
+		}
+		if *got != want {
+			t.Fatalf("effort %q: budget=%d, want %d", effort, *got, want)
+		}
+	}
+}
+
+func TestGetThinkingBudget_ExplicitBudgetWins(t *testing.T) {
+	budget := int64(4242)
+	got := getThinkingBudget(anthropicModel.EffortMax, &budget)
+	if got == nil || *got != budget {
+		t.Fatalf("expected explicit budget %d, got %#v", budget, got)
+	}
+}

--- a/internal/transformer/outbound/anthropic/thinking_passthrough_test.go
+++ b/internal/transformer/outbound/anthropic/thinking_passthrough_test.go
@@ -1,0 +1,70 @@
+package anthropic
+
+import (
+	"testing"
+
+	anthropicModel "github.com/lingyuins/octopus/internal/transformer/inbound/anthropic"
+	"github.com/lingyuins/octopus/internal/transformer/model"
+)
+
+func TestConvertToAnthropicRequest_PassthroughEffortAsAdaptive(t *testing.T) {
+	for _, effort := range []string{"low", "medium", "high", "xhigh", "max"} {
+		got := convertToAnthropicRequest(&model.InternalLLMRequest{
+			Model:           "claude-opus-4-8",
+			ReasoningEffort: effort,
+			Messages: []model.Message{{
+				Role:    "user",
+				Content: model.MessageContent{Content: strPtr("hi")},
+			}},
+		})
+		if got.Thinking == nil || got.Thinking.Type != anthropicModel.ThinkingTypeAdaptive {
+			t.Fatalf("effort %q: expected adaptive thinking, got %#v", effort, got.Thinking)
+		}
+		if got.Thinking.BudgetTokens != nil {
+			t.Fatalf("effort %q: expected no budget_tokens, got %v", effort, *got.Thinking.BudgetTokens)
+		}
+		if got.OutputConfig == nil || got.OutputConfig.Effort != effort {
+			t.Fatalf("effort %q: expected output_config.effort=%q, got %#v", effort, effort, got.OutputConfig)
+		}
+	}
+}
+
+func TestConvertToAnthropicRequest_ExplicitBudgetKeepsEnabledBudget(t *testing.T) {
+	budget := int64(12345)
+	got := convertToAnthropicRequest(&model.InternalLLMRequest{
+		Model:           "claude-sonnet-4-6",
+		ReasoningEffort: "max",
+		ReasoningBudget: &budget,
+		Messages: []model.Message{{
+			Role:    "user",
+			Content: model.MessageContent{Content: strPtr("hi")},
+		}},
+	})
+	if got.Thinking == nil || got.Thinking.Type != anthropicModel.ThinkingTypeEnabled {
+		t.Fatalf("expected enabled thinking, got %#v", got.Thinking)
+	}
+	if got.Thinking.BudgetTokens == nil || *got.Thinking.BudgetTokens != budget {
+		t.Fatalf("expected budget %d, got %#v", budget, got.Thinking.BudgetTokens)
+	}
+	if got.OutputConfig != nil {
+		t.Fatalf("expected no output_config when explicit budget is set, got %#v", got.OutputConfig)
+	}
+}
+
+func TestConvertToAnthropicRequest_NoEffortOmitsThinking(t *testing.T) {
+	got := convertToAnthropicRequest(&model.InternalLLMRequest{
+		Model: "claude-sonnet-4-6",
+		Messages: []model.Message{{
+			Role:    "user",
+			Content: model.MessageContent{Content: strPtr("hi")},
+		}},
+	})
+	if got.Thinking != nil {
+		t.Fatalf("expected no thinking, got %#v", got.Thinking)
+	}
+	if got.OutputConfig != nil {
+		t.Fatalf("expected no output_config, got %#v", got.OutputConfig)
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/transformer/outbound/gemini/messages.go
+++ b/internal/transformer/outbound/gemini/messages.go
@@ -146,6 +146,10 @@ func reasoningToThinkingBudget(effort string) int32 {
 		return 4096
 	case "high":
 		return 24576
+	case "xhigh":
+		return 49152
+	case "max":
+		return 65536
 	default:
 		// 防御性：未知值走动态
 		return -1

--- a/internal/transformer/outbound/openai/chat_test.go
+++ b/internal/transformer/outbound/openai/chat_test.go
@@ -1378,3 +1378,70 @@ func TestChatOutboundTransformResponse_ParsesMimoExtendedFields(t *testing.T) {
 		t.Fatalf("prompt_tokens_details not parsed as expected: %+v", got.Usage.PromptTokensDetails)
 	}
 }
+
+func TestChatOutboundTransformRequest_PreservesOpenAIMaxReasoningEffort(t *testing.T) {
+	outbound := &ChatOutbound{}
+	request := &model.InternalLLMRequest{
+		Model:           "gpt-5.5",
+		ReasoningEffort: "max",
+		Messages: []model.Message{{
+			Role: "user",
+			Content: model.MessageContent{
+				Content: loPtr("hello"),
+			},
+		}},
+	}
+
+	httpReq, err := outbound.TransformRequest(context.Background(), request, "https://api.openai.com/v1", "sk-test")
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+	body, err := io.ReadAll(httpReq.Body)
+	if err != nil {
+		t.Fatalf("failed to read request body: %v", err)
+	}
+	var got struct {
+		ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	}
+	if err := transformer.Unmarshal(body, &got); err != nil {
+		t.Fatalf("failed to unmarshal outbound body: %v", err)
+	}
+	if got.ReasoningEffort != "max" {
+		t.Fatalf("expected openai reasoning_effort max, got %q", got.ReasoningEffort)
+	}
+	if request.ReasoningEffort != "max" {
+		t.Fatalf("expected in-memory request effort max after sanitize, got %q", request.ReasoningEffort)
+	}
+}
+
+func TestChatOutboundTransformRequest_PreservesOpenAIXHighReasoningEffort(t *testing.T) {
+	outbound := &ChatOutbound{}
+	request := &model.InternalLLMRequest{
+		Model:           "gpt-5.5",
+		ReasoningEffort: "xhigh",
+		Messages: []model.Message{{
+			Role: "user",
+			Content: model.MessageContent{
+				Content: loPtr("hello"),
+			},
+		}},
+	}
+
+	httpReq, err := outbound.TransformRequest(context.Background(), request, "https://api.openai.com/v1", "sk-test")
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+	body, err := io.ReadAll(httpReq.Body)
+	if err != nil {
+		t.Fatalf("failed to read request body: %v", err)
+	}
+	var got struct {
+		ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	}
+	if err := transformer.Unmarshal(body, &got); err != nil {
+		t.Fatalf("failed to unmarshal outbound body: %v", err)
+	}
+	if got.ReasoningEffort != "xhigh" {
+		t.Fatalf("expected openai reasoning_effort xhigh, got %q", got.ReasoningEffort)
+	}
+}

--- a/internal/transformer/outbound/openai/reasoning.go
+++ b/internal/transformer/outbound/openai/reasoning.go
@@ -2,21 +2,19 @@ package openai
 
 import "strings"
 
+// normalizeOpenAICompatReasoningEffort 规范化发往 OpenAI 兼容上游的 reasoning_effort。
+// 官方当前支持 none / minimal / low / medium / high / xhigh / max（以模型为准）。
+// none 表示关闭思考；其余合法档位原样透传，避免把 max/xhigh 错误压成 high。
 func normalizeOpenAICompatReasoningEffort(effort string) string {
 	normalized := strings.ToLower(strings.TrimSpace(effort))
 
 	switch normalized {
 	case "", "none":
 		return ""
-	case "low", "medium", "high":
+	case "minimal", "low", "medium", "high", "xhigh", "max":
 		return normalized
-	case "xhigh", "max":
-		// Anthropic/DeepSeek extended reasoning levels —
-		// map to the highest standard OpenAI level.
-		return "high"
 	default:
-		// Unknown effort values are silently dropped rather than passed
-		// through to providers that may reject them.
+		// 未知值静默丢弃，避免部分上游因非法枚举直接 400。
 		return ""
 	}
 }

--- a/internal/transformer/outbound/openai/response_test.go
+++ b/internal/transformer/outbound/openai/response_test.go
@@ -32,3 +32,40 @@ func TestConvertToResponsesRequest_PreservesValidReasoningEffort(t *testing.T) {
 		t.Fatalf("expected reasoning effort high, got %q", got.Reasoning.Effort)
 	}
 }
+
+func TestConvertToResponsesRequest_PreservesMaxAndXHighReasoningEffort(t *testing.T) {
+	for _, effort := range []string{"max", "xhigh", "minimal"} {
+		req := &model.InternalLLMRequest{
+			Model:           "gpt-5.5",
+			ReasoningEffort: effort,
+		}
+		got := ConvertToResponsesRequest(req)
+		if got.Reasoning == nil {
+			t.Fatalf("effort %q: expected reasoning to be present", effort)
+		}
+		if got.Reasoning.Effort != effort {
+			t.Fatalf("effort %q: got %q", effort, got.Reasoning.Effort)
+		}
+	}
+}
+
+func TestNormalizeOpenAICompatReasoningEffort_PreservesExtendedLevels(t *testing.T) {
+	cases := map[string]string{
+		"":        "",
+		"none":    "",
+		"NONE":    "",
+		"minimal": "minimal",
+		"low":     "low",
+		"medium":  "medium",
+		"high":    "high",
+		"xhigh":   "xhigh",
+		"max":     "max",
+		"MAX":     "max",
+		"bogus":   "",
+	}
+	for in, want := range cases {
+		if got := normalizeOpenAICompatReasoningEffort(in); got != want {
+			t.Fatalf("normalizeOpenAICompatReasoningEffort(%q)=%q, want %q", in, got, want)
+		}
+	}
+}

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -2641,7 +2641,7 @@
     },
     "viewOptions": {
       "title": "Display Fields",
-      "endpointType": "Endpoint Type",
+      "endpointType": "Outbound Protocol",
       "channelName": "Channel Name",
       "actualModel": "Actual Model",
       "apiKeyName": "API Key Name",
@@ -2649,7 +2649,9 @@
       "cost": "Cost",
       "reset": "Reset",
       "tps": "TPS",
-      "cacheHitRate": "Cache Hit Rate"
+      "cacheHitRate": "Cache Hit Rate",
+      "reasoningEffort": "Reasoning Effort",
+      "reasoningTokens": "Reasoning Tokens"
     },
     "card": {
       "error": "Error",
@@ -2692,7 +2694,21 @@
         "volcengine": "Volcengine"
       },
       "tps": "TPS",
-      "cacheHitRate": "Cache Hit Rate"
+      "cacheHitRate": "Cache Hit Rate",
+      "reasoningEffort": "Reasoning Effort",
+      "reasoningTokens": "Reasoning Tokens",
+      "adapterLabels": {
+        "chat": "Chat Completions",
+        "response": "Responses",
+        "anthropic": "Anthropic",
+        "gemini": "Gemini",
+        "volcengine": "Volcengine",
+        "embedding": "Embedding",
+        "mimo": "MiMo",
+        "cloudflare": "Cloudflare",
+        "passthrough": "Passthrough",
+        "codex": "Codex"
+      }
     }
   },
   "channel": {

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -2651,7 +2651,7 @@
       "tps": "TPS",
       "cacheHitRate": "Cache Hit Rate",
       "reasoningEffort": "Reasoning Effort",
-      "reasoningTokens": "Reasoning Tokens"
+      "reasoningTokens": "Reasoning Size"
     },
     "card": {
       "error": "Error",
@@ -2696,7 +2696,7 @@
       "tps": "TPS",
       "cacheHitRate": "Cache Hit Rate",
       "reasoningEffort": "Reasoning Effort",
-      "reasoningTokens": "Reasoning Tokens",
+      "reasoningTokens": "Reasoning",
       "adapterLabels": {
         "chat": "Chat Completions",
         "response": "Responses",
@@ -2708,7 +2708,9 @@
         "cloudflare": "Cloudflare",
         "passthrough": "Passthrough",
         "codex": "Codex"
-      }
+      },
+      "reasoningChars": "Reasoning",
+      "reasoningCharsUnit": " chars"
     }
   },
   "channel": {

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -2597,7 +2597,7 @@
     },
     "viewOptions": {
       "title": "显示字段",
-      "endpointType": "接口类型",
+      "endpointType": "出站协议",
       "channelName": "渠道名称",
       "actualModel": "实际模型",
       "apiKeyName": "密钥名称",
@@ -2605,7 +2605,9 @@
       "cost": "费用",
       "reset": "重置",
       "tps": "TPS",
-      "cacheHitRate": "缓存命中率"
+      "cacheHitRate": "缓存命中率",
+      "reasoningEffort": "思考强度",
+      "reasoningTokens": "思考 Token"
     },
     "card": {
       "error": "错误",
@@ -2648,7 +2650,21 @@
         "volcengine": "Volcengine"
       },
       "tps": "TPS",
-      "cacheHitRate": "缓存命中率"
+      "cacheHitRate": "缓存命中率",
+      "reasoningEffort": "思考强度",
+      "reasoningTokens": "思考 Token",
+      "adapterLabels": {
+        "chat": "Chat Completions",
+        "response": "Responses",
+        "anthropic": "Anthropic",
+        "gemini": "Gemini",
+        "volcengine": "Volcengine",
+        "embedding": "Embedding",
+        "mimo": "MiMo",
+        "cloudflare": "Cloudflare",
+        "passthrough": "Passthrough",
+        "codex": "Codex"
+      }
     }
   },
   "channel": {

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -2607,7 +2607,7 @@
       "tps": "TPS",
       "cacheHitRate": "缓存命中率",
       "reasoningEffort": "思考强度",
-      "reasoningTokens": "思考 Token"
+      "reasoningTokens": "思考量"
     },
     "card": {
       "error": "错误",
@@ -2652,7 +2652,7 @@
       "tps": "TPS",
       "cacheHitRate": "缓存命中率",
       "reasoningEffort": "思考强度",
-      "reasoningTokens": "思考 Token",
+      "reasoningTokens": "思考",
       "adapterLabels": {
         "chat": "Chat Completions",
         "response": "Responses",
@@ -2664,7 +2664,9 @@
         "cloudflare": "Cloudflare",
         "passthrough": "Passthrough",
         "codex": "Codex"
-      }
+      },
+      "reasoningChars": "思考",
+      "reasoningCharsUnit": "字"
     }
   },
   "channel": {

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -2607,7 +2607,7 @@
       "tps": "TPS",
       "cacheHitRate": "缓存命中率",
       "reasoningEffort": "思考強度",
-      "reasoningTokens": "思考 Token"
+      "reasoningTokens": "思考量"
     },
     "card": {
       "error": "錯誤",
@@ -2652,7 +2652,7 @@
       "tps": "TPS",
       "cacheHitRate": "缓存命中率",
       "reasoningEffort": "思考強度",
-      "reasoningTokens": "思考 Token",
+      "reasoningTokens": "思考",
       "adapterLabels": {
         "chat": "Chat Completions",
         "response": "Responses",
@@ -2664,7 +2664,9 @@
         "cloudflare": "Cloudflare",
         "passthrough": "Passthrough",
         "codex": "Codex"
-      }
+      },
+      "reasoningChars": "思考",
+      "reasoningCharsUnit": "字"
     }
   },
   "channel": {

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -2597,7 +2597,7 @@
     },
     "viewOptions": {
       "title": "顯示欄位",
-      "endpointType": "介面類型",
+      "endpointType": "出站協議",
       "channelName": "渠道名稱",
       "actualModel": "實際模型",
       "apiKeyName": "金鑰名稱",
@@ -2605,7 +2605,9 @@
       "cost": "費用",
       "reset": "重置",
       "tps": "TPS",
-      "cacheHitRate": "缓存命中率"
+      "cacheHitRate": "缓存命中率",
+      "reasoningEffort": "思考強度",
+      "reasoningTokens": "思考 Token"
     },
     "card": {
       "error": "錯誤",
@@ -2648,7 +2650,21 @@
         "volcengine": "Volcengine"
       },
       "tps": "TPS",
-      "cacheHitRate": "缓存命中率"
+      "cacheHitRate": "缓存命中率",
+      "reasoningEffort": "思考強度",
+      "reasoningTokens": "思考 Token",
+      "adapterLabels": {
+        "chat": "Chat Completions",
+        "response": "Responses",
+        "anthropic": "Anthropic",
+        "gemini": "Gemini",
+        "volcengine": "Volcengine",
+        "embedding": "Embedding",
+        "mimo": "MiMo",
+        "cloudflare": "Cloudflare",
+        "passthrough": "Passthrough",
+        "codex": "Codex"
+      }
     }
   },
   "channel": {

--- a/web/src/api/endpoints/log.ts
+++ b/web/src/api/endpoints/log.ts
@@ -44,6 +44,8 @@ export interface RelayLog {
     output_tokens: number;       // 输出Token
     semantic_cache_hit?: boolean;// 语义缓存命中
     cache_read_tokens?: number;  // 提供方提示缓存命中 Token
+    reasoning_effort?: string;   // 出站最终思考强度
+    reasoning_tokens?: number;   // 上游返回的思考 Token
     ftut: number;                // 首字时间(毫秒)
     use_time: number;            // 总用时(毫秒)
     cost: number;                // 消耗费用

--- a/web/src/api/endpoints/log.ts
+++ b/web/src/api/endpoints/log.ts
@@ -45,7 +45,8 @@ export interface RelayLog {
     semantic_cache_hit?: boolean;// 语义缓存命中
     cache_read_tokens?: number;  // 提供方提示缓存命中 Token
     reasoning_effort?: string;   // 出站最终思考强度
-    reasoning_tokens?: number;   // 上游返回的思考 Token
+    reasoning_tokens?: number;   // 上游返回的思考 Token（确定性）
+    reasoning_chars?: number;    // 思考文本字符数（无官方 token 时的估算回退）
     ftut: number;                // 首字时间(毫秒)
     use_time: number;            // 总用时(毫秒)
     cost: number;                // 消耗费用

--- a/web/src/components/modules/log/Item.tsx
+++ b/web/src/components/modules/log/Item.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { memo, useMemo, useState, useEffect } from 'react';
-import { Clock, Cpu, Gauge, Zap, AlertCircle, ArrowDownToLine, ArrowUpFromLine, DollarSign, JapaneseYen, ArrowRight, ArrowDown, Send, MessageSquare, Loader2, Percent, RotateCw, ChevronDown, ChevronUp, Pin, KeyRound, Globe, ChevronsDownUp, ChevronsUpDown, TestTube2, Sigma } from 'lucide-react';
+import { Clock, Cpu, Gauge, Zap, AlertCircle, ArrowDownToLine, ArrowUpFromLine, DollarSign, JapaneseYen, ArrowRight, ArrowDown, Send, MessageSquare, Loader2, Percent, RotateCw, ChevronDown, ChevronUp, Pin, KeyRound, Globe, ChevronsDownUp, ChevronsUpDown, TestTube2, Sigma, Brain } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { motion, AnimatePresence } from 'motion/react';
 import JsonView from '@uiw/react-json-view';
@@ -312,16 +311,24 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
     const inputLabel = cacheReadTokens > 0 ? t('realInput') : t('input');
     const displayChannelName = displayFields.channelName || '-';
     const displayEndpointType = useMemo(() => {
+        const adapter = displayFields.outboundAdapterType;
+        if (adapter) {
+            const label = t(`adapterLabels.${adapter}`);
+            // next-intl 缺 key 时可能回传 key 路径；有专用文案用文案，否则用原始 adapter
+            if (label && !label.includes('adapterLabels.')) return label;
+            return adapter;
+        }
+        // 旧日志无 adapter_type 时回退 endpoint/request type，避免整块空白
         const reqTypeKey = displayFields.requestTypeKey;
         if (reqTypeKey) {
             const label = t(`requestTypeLabels.${reqTypeKey}`);
-            if (label) return label;
+            if (label && !label.includes('requestTypeLabels.')) return label;
         }
         const rawEndpointType = displayFields.endpointType;
-        if (!rawEndpointType) return '-';
+        if (!rawEndpointType) return '';
         const labelKey = endpointTypeLabelKey(rawEndpointType);
         return labelKey ? tGroup(labelKey) : rawEndpointType;
-    }, [displayFields.endpointType, displayFields.requestTypeKey, t, tGroup]);
+    }, [displayFields.endpointType, displayFields.outboundAdapterType, displayFields.requestTypeKey, t, tGroup]);
     const displayActualModelName = displayFields.actualModelName || '-';
     const displayRequestModelName = displayFields.requestModelName || log.request_model_name;
 
@@ -392,7 +399,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                                     </Badge>
                                 )}
                                 <ArrowRight className="size-3.5 shrink-0 text-muted-foreground/50" />
-                                {vis.endpointType && (
+                                {vis.endpointType && displayEndpointType && (
                                     <Badge
                                         variant="secondary"
                                         className="max-w-full shrink-0 text-xs px-1.5 py-0"
@@ -504,6 +511,18 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                                         </span>
                                     </div>
                                 )}
+                                {vis.reasoningEffort && !!log.reasoning_effort && (
+                                    <div className="flex items-center gap-1.5">
+                                        <Brain className="size-3.5 shrink-0 text-violet-500" />
+                                        <span>{t('reasoningEffort')} {log.reasoning_effort}</span>
+                                    </div>
+                                )}
+                                {vis.reasoningTokens && (log.reasoning_tokens ?? 0) > 0 && (
+                                    <div className="flex items-center gap-1.5">
+                                        <Brain className="size-3.5 shrink-0 text-indigo-500" />
+                                        <span>{t('reasoningTokens')} {fmt(formatCount(log.reasoning_tokens ?? 0).formatted)}</span>
+                                    </div>
+                                )}
                             </div>
                             {hasError && (
                                 <div className="p-2.5 rounded-xl bg-destructive/10 border border-destructive/20 overflow-hidden">
@@ -530,7 +549,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                                 </Badge>
                             )}
                             <ArrowRight className="size-3.5 text-muted-foreground/50" />
-                            {vis.endpointType && (
+                            {vis.endpointType && displayEndpointType && (
                                 <Badge
                                     variant="secondary"
                                     className="max-w-full shrink-0 text-xs px-1.5 py-0"
@@ -839,6 +858,18 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                                     <span className="font-medium text-emerald-600 dark:text-emerald-400">
                                         {t('cost')}: {costDisplay}
                                     </span>
+                                </div>
+                            )}
+                            {vis.reasoningEffort && !!log.reasoning_effort && (
+                                <div className="flex items-center gap-1.5">
+                                    <Brain className="size-3.5 text-violet-500" />
+                                    <span>{t('reasoningEffort')}: {log.reasoning_effort}</span>
+                                </div>
+                            )}
+                            {vis.reasoningTokens && (log.reasoning_tokens ?? 0) > 0 && (
+                                <div className="flex items-center gap-1.5">
+                                    <Brain className="size-3.5 text-indigo-500" />
+                                    <span>{t('reasoningTokens')}: {fmt(formatCount(log.reasoning_tokens ?? 0).formatted)}</span>
                                 </div>
                             )}
                             </div>

--- a/web/src/components/modules/log/Item.tsx
+++ b/web/src/components/modules/log/Item.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { memo, useMemo, useState, useEffect } from 'react';
 import { Clock, Cpu, Gauge, Zap, AlertCircle, ArrowDownToLine, ArrowUpFromLine, DollarSign, JapaneseYen, ArrowRight, ArrowDown, Send, MessageSquare, Loader2, Percent, RotateCw, ChevronDown, ChevronUp, Pin, KeyRound, Globe, ChevronsDownUp, ChevronsUpDown, TestTube2, Sigma, Brain } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { motion, AnimatePresence } from 'motion/react';

--- a/web/src/components/modules/log/Item.tsx
+++ b/web/src/components/modules/log/Item.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { memo, useMemo, useState, useEffect } from 'react';
-import { Clock, Cpu, Gauge, Zap, AlertCircle, ArrowDownToLine, ArrowUpFromLine, DollarSign, JapaneseYen, ArrowRight, ArrowDown, Send, MessageSquare, Loader2, Percent, RotateCw, ChevronDown, ChevronUp, Pin, KeyRound, Globe, ChevronsDownUp, ChevronsUpDown, TestTube2, Sigma, Brain } from 'lucide-react';
+import { Clock, Cpu, Gauge, Zap, AlertCircle, ArrowDownToLine, ArrowUpFromLine, DollarSign, JapaneseYen, ArrowRight, ArrowDown, Send, MessageSquare, Loader2, Percent, RotateCw, ChevronDown, ChevronUp, Pin, KeyRound, Globe, ChevronsDownUp, ChevronsUpDown, TestTube2, Sigma, Brain, Type } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { motion, AnimatePresence } from 'motion/react';
 import JsonView from '@uiw/react-json-view';
@@ -521,7 +521,13 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                                 {vis.reasoningTokens && (log.reasoning_tokens ?? 0) > 0 && (
                                     <div className="flex items-center gap-1.5">
                                         <Brain className="size-3.5 shrink-0 text-indigo-500" />
-                                        <span>{t('reasoningTokens')} {fmt(formatCount(log.reasoning_tokens ?? 0).formatted)}</span>
+                                        <span>{t('reasoningTokens')} {fmt(formatCount(log.reasoning_tokens ?? 0).formatted)}t</span>
+                                    </div>
+                                )}
+                                {vis.reasoningTokens && (log.reasoning_tokens ?? 0) <= 0 && (log.reasoning_chars ?? 0) > 0 && (
+                                    <div className="flex items-center gap-1.5">
+                                        <Type className="size-3.5 shrink-0 text-indigo-500" />
+                                        <span>{t('reasoningChars')} {fmt(formatCount(log.reasoning_chars ?? 0).formatted)}{t('reasoningCharsUnit')}</span>
                                     </div>
                                 )}
                             </div>
@@ -870,7 +876,13 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                             {vis.reasoningTokens && (log.reasoning_tokens ?? 0) > 0 && (
                                 <div className="flex items-center gap-1.5">
                                     <Brain className="size-3.5 text-indigo-500" />
-                                    <span>{t('reasoningTokens')}: {fmt(formatCount(log.reasoning_tokens ?? 0).formatted)}</span>
+                                    <span>{t('reasoningTokens')}: {fmt(formatCount(log.reasoning_tokens ?? 0).formatted)}t</span>
+                                </div>
+                            )}
+                            {vis.reasoningTokens && (log.reasoning_tokens ?? 0) <= 0 && (log.reasoning_chars ?? 0) > 0 && (
+                                <div className="flex items-center gap-1.5">
+                                    <Type className="size-3.5 text-indigo-500" />
+                                    <span>{t('reasoningChars')}: {fmt(formatCount(log.reasoning_chars ?? 0).formatted)}{t('reasoningCharsUnit')}</span>
                                 </div>
                             )}
                             </div>

--- a/web/src/components/modules/log/display.test.ts
+++ b/web/src/components/modules/log/display.test.ts
@@ -226,3 +226,57 @@ test('formatJsonForCopy returns empty string for empty or missing input', () => 
 
 
 
+
+test('resolveLogDisplayFields prefers successful attempt adapter_type as outbound protocol', () => {
+    const log = buildLog({
+        attempts: [
+            {
+                channel_id: 1,
+                channel_name: 'A',
+                model_name: 'gpt-5.5',
+                adapter_type: 'chat',
+                attempt_num: 1,
+                status: 'failed',
+                duration: 5,
+            },
+            {
+                channel_id: 2,
+                channel_name: 'B',
+                model_name: 'gpt-5.5',
+                adapter_type: 'response',
+                attempt_num: 2,
+                status: 'success',
+                duration: 8,
+            },
+        ],
+    });
+    const result = resolveLogDisplayFields(log);
+    assert.equal(result.outboundAdapterType, 'response');
+});
+
+test('resolveLogDisplayFields falls back to last non-empty adapter_type when no success', () => {
+    const log = buildLog({
+        attempts: [
+            {
+                channel_id: 1,
+                channel_name: 'A',
+                model_name: 'claude',
+                adapter_type: 'anthropic',
+                attempt_num: 1,
+                status: 'failed',
+                duration: 5,
+            },
+            {
+                channel_id: 2,
+                channel_name: 'B',
+                model_name: 'claude',
+                adapter_type: '',
+                attempt_num: 2,
+                status: 'failed',
+                duration: 5,
+            },
+        ],
+    });
+    const result = resolveLogDisplayFields(log);
+    assert.equal(result.outboundAdapterType, 'anthropic');
+});

--- a/web/src/components/modules/log/display.ts
+++ b/web/src/components/modules/log/display.ts
@@ -48,6 +48,23 @@ function lastAttemptChannelId(attempts: ChannelAttempt[] | undefined) {
     return 0;
 }
 
+/** 取最终成功 attempt 的 adapter_type；无成功则取最后一个非空 adapter_type。 */
+function resolveOutboundAdapterType(attempts: ChannelAttempt[] | undefined): string {
+    if (!attempts?.length) return '';
+    for (let i = attempts.length - 1; i >= 0; i--) {
+        const a = attempts[i];
+        if (a.status === 'success' && a.adapter_type?.trim()) {
+            return a.adapter_type.trim();
+        }
+    }
+    for (let i = attempts.length - 1; i >= 0; i--) {
+        const t = attempts[i].adapter_type?.trim();
+        if (t) return t;
+    }
+    return '';
+}
+
+
 function isStreamRequest(requestContent?: string | null) {
     if (!requestContent) return false;
     try {
@@ -142,6 +159,7 @@ export function resolveLogDisplayFields(
         actualModelName,
         endpointType,
         requestTypeKey: inferRequestTypeKey(endpointType, [actualModelName, requestModelName], requestContent),
+        outboundAdapterType: resolveOutboundAdapterType(mergedAttempts),
         channelId,
         channelName,
         semanticCacheHit: detail?.semantic_cache_hit ?? log.semantic_cache_hit ?? false,

--- a/web/src/components/modules/log/index.tsx
+++ b/web/src/components/modules/log/index.tsx
@@ -299,7 +299,7 @@ function LogFilterBar({
                 <PopoverContent align="end" className="w-52 p-3">
                     <p className="text-xs font-medium text-muted-foreground mb-2">{tView('title')}</p>
                     <div className="flex flex-col gap-1">
-                        {(['endpointType', 'channelName', 'actualModel', 'apiKeyName', 'clientIP', 'cost', 'tps', 'cacheHitRate'] as LogFieldName[]).map((field) => (
+                        {(['endpointType', 'channelName', 'actualModel', 'apiKeyName', 'clientIP', 'cost', 'tps', 'cacheHitRate', 'reasoningEffort', 'reasoningTokens'] as LogFieldName[]).map((field) => (
                             <label key={field} className="flex items-center gap-2 cursor-pointer rounded px-1.5 py-1 text-xs hover:bg-muted transition-colors">
                                 <input
                                     type="checkbox"

--- a/web/src/components/modules/log/ui-store.ts
+++ b/web/src/components/modules/log/ui-store.ts
@@ -11,7 +11,9 @@ export type LogFieldName =
     | 'clientIP'
     | 'cost'
     | 'tps'
-    | 'cacheHitRate';
+    | 'cacheHitRate'
+    | 'reasoningEffort'
+    | 'reasoningTokens';
 
 export type LogFieldVisibility = Record<LogFieldName, boolean>;
 
@@ -24,6 +26,8 @@ export const DEFAULT_LOG_FIELD_VISIBILITY: LogFieldVisibility = {
     cost: true,
     tps: true,
     cacheHitRate: true,
+    reasoningEffort: true,
+    reasoningTokens: true,
 };
 
 type LogFieldVisibilityState = {


### PR DESCRIPTION
## Summary
- 日志卡片展示**出站协议**（Chat Completions / Responses / Anthropic / Gemini…），来自成功 attempt 的 `adapter_type`
- 日志新增**思考强度**（出站最终 `reasoning_effort`）与**思考量**：
  - 有官方 `reasoning_tokens` → 显示「思考 XXt」
  - 无官方 token 时回退思考文本 UTF-8 字符数 → 显示「思考 XX字」
  - 无数据隐藏；字段开关默认开启
- **OpenAI** 兼容 `reasoning_effort` 保留 `minimal` / `xhigh` / `max`，不再错误压成 `high`
- **Anthropic** 默认透传 `thinking.adaptive + output_config.effort`（对齐 Claude Code）；仅客户端显式 `budget_tokens` 时才走 budget
- **Anthropic 流式**：`message_delta` 上挂载 usage，避免 `message_stop` 丢失时日志 input/output 全未知

## Why
1. 确认客户端设置的思考强度是否真正出站生效（而不是被 normalize 丢掉）
2. 确认上游是否在思考，以及思考量（官方 token 优先，Anthropic 等无字段时用文本字数）
3. 一眼看出请求实际打到上游的协议形态

## Test plan
- [x] `go test ./internal/transformer/outbound/openai ./internal/transformer/outbound/anthropic ./internal/relay ./internal/model ./internal/db/migrate -count=1`
- [x] 前端 `display.test.ts` + 构建通过
- [x] 本地验证：Anthropic 出站日志显示协议徽章与思考强度；有 thinking 文本时显示「思考 XX字」
- [x] 本地验证：OpenAI 路径 `max`/`xhigh` 不再被压成 `high`
- [ ] 实际验证：OpenAI 兼容上游返回 `reasoning_tokens` 时显示「思考 XXt」
- [ ] 实际验证：Anthropic 流式长请求 input/output/TPS 不再「未知」