### PR TITLE
fix(web): use line indicator for home chart tooltip

### DIFF
--- a/web/src/components/modules/home/chart.tsx
+++ b/web/src/components/modules/home/chart.tsx
@@ -303,12 +303,8 @@ export function StatsChart() {
                         cursor={false}
                         content={
                             <ChartTooltipContent
-                                indicator="dot"
-                                labelFormatter={(_value, payload) => {
-                                    const date = payload?.[0]?.payload?.date;
-                                    return typeof date === 'string' ? date : '';
-                                }}
-                                formatter={(value) => {
+                                indicator="line"
+                                valueFormatter={(value) => {
                                     const primary = chartMetrics[0] ?? 'cost';
                                     if (primary === 'cost') return costAxisFormatter(Number(value));
                                     if (primary === 'success-rate') return `${Number(value).toFixed(2)}%`;

--- a/web/src/components/ui/chart.tsx
+++ b/web/src/components/ui/chart.tsx
@@ -127,6 +127,7 @@ function ChartTooltipContent({
   labelFormatter,
   labelClassName,
   formatter,
+  valueFormatter,
   color,
   nameKey,
   labelKey,
@@ -135,6 +136,7 @@ function ChartTooltipContent({
     hideLabel?: boolean
     hideIndicator?: boolean
     indicator?: "line" | "dot" | "dashed"
+    valueFormatter?: (value: TooltipValueType) => React.ReactNode
     nameKey?: string
     labelKey?: string
   } & Omit<
@@ -254,7 +256,9 @@ function ChartTooltipContent({
                       </div>
                       {item.value != null && (
                         <span className="font-mono font-medium text-foreground tabular-nums">
-                          {typeof item.value === "number"
+                          {valueFormatter
+                            ? valueFormatter(item.value)
+                            : typeof item.value === "number"
                             ? item.value.toLocaleString()
                             : String(item.value)}
                         </span>


### PR DESCRIPTION
## Summary
- Add optional `valueFormatter` to `ChartTooltipContent` so chart values can be formatted without overriding the default tooltip DOM layout
- Switch the home stats chart tooltip from `indicator=\"dot\"` + `formatter` to `indicator=\"line\"` + `valueFormatter`
- Keeps existing cost / success-rate / token formatting while restoring the vertical-bar tooltip indicator style

## Test plan
- [ ] Open home dashboard chart and hover a data point
- [ ] Confirm tooltip shows the vertical line indicator (`w-1` bar) instead of a dot
- [ ] Confirm cost / request count / tokens / success rate values still format correctly
- [ ] Confirm chinaMode cost display remains consistent with the overview cards