### PR TITLE
fix(relay): Anthropic 入站尊重出站格式，透传改写上游模型名

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Backup (issue #158)**: 数据导入性能优化——大表分批插入（每批 1000 行），避免单次超大事务超时/内存溢出；导入大小上限从 64 MB 提升至 256 MB，前端导入页增加大小提示。
 
 ### 🐛 Bug Fixes
+- **Group/Relay**: Anthropic 入站请求现在会正确应用分组出站格式（`messages` / `messages_only` 等）；此前 `isLLMRequestFormat` 漏判 Anthropic Messages，导致强制退回渠道原生 OpenAI Chat。
+- **Passthrough**: 原始透传会把分组解析后的上游模型名写回请求体 `model` 字段，不再把分组名原样发给上游。
 - **Relay**: 上游 400 类客户端错误（如 `context_length_exceeded`）不再被 adapter 回退链路改写成换渠道，也不再吞成管理端 502；原样把上游状态码与错误体回给下游，便于 omp 等客户端识别溢出并自动压缩上下文。
 - **Transformer**: Anthropic streaming now attaches usage on `message_delta` chunks so relay logs keep input/output tokens when `message_stop` is missing.
 - **Transformer**: preserve OpenAI `reasoning_effort` values `minimal`/`xhigh`/`max` instead of collapsing them to `high`; Anthropic/Gemini budget mapping now covers `xhigh`/`max`.

--- a/internal/relay/chat_responses_fallback_test.go
+++ b/internal/relay/chat_responses_fallback_test.go
@@ -199,6 +199,72 @@ func TestOutboundAttemptTypesPassthroughDisablesFallback(t *testing.T) {
 	}
 }
 
+func TestOutboundAttemptTypesAnthropicMessagesOnlyUsesAnthropic(t *testing.T) {
+	req := &model.InternalLLMRequest{RawAPIFormat: model.APIFormatAnthropicMessage}
+
+	got := outboundAttemptTypes(outbound.OutboundTypeOpenAIChat, req, "messages_only")
+	want := []outbound.OutboundType{outbound.OutboundTypeAnthropic}
+
+	if len(got) != len(want) {
+		t.Fatalf("attempt types len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("attempt types = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestOutboundAttemptTypesAnthropicMessagesPrefersAnthropicFirst(t *testing.T) {
+	req := &model.InternalLLMRequest{RawAPIFormat: model.APIFormatAnthropicMessage}
+
+	got := outboundAttemptTypes(outbound.OutboundTypeOpenAIChat, req, "messages")
+	want := []outbound.OutboundType{outbound.OutboundTypeAnthropic, outbound.OutboundTypeOpenAIChat, outbound.OutboundTypeOpenAIResponse}
+
+	if len(got) != len(want) {
+		t.Fatalf("attempt types len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("attempt types = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestOutboundAttemptTypesAnthropicPassthroughDisablesFallback(t *testing.T) {
+	req := &model.InternalLLMRequest{RawAPIFormat: model.APIFormatAnthropicMessage}
+
+	got := outboundAttemptTypes(outbound.OutboundTypeOpenAIChat, req, "passthrough")
+	want := []outbound.OutboundType{outbound.OutboundTypePassthrough}
+
+	if len(got) != len(want) {
+		t.Fatalf("attempt types len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("attempt types = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestOutboundAttemptTypesAnthropicAutoStillPrefersChatFallbackChain(t *testing.T) {
+	// Anthropic inbound + auto format on an OpenAI-compatible channel should still
+	// enter the LLM adapter-selection path instead of hard-coding channel type.
+	req := &model.InternalLLMRequest{RawAPIFormat: model.APIFormatAnthropicMessage}
+
+	got := outboundAttemptTypes(outbound.OutboundTypeOpenAIChat, req, "")
+	want := []outbound.OutboundType{outbound.OutboundTypeOpenAIChat, outbound.OutboundTypeOpenAIResponse}
+
+	if len(got) != len(want) {
+		t.Fatalf("attempt types len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("attempt types = %#v, want %#v", got, want)
+		}
+	}
+}
+
 // Unknown format values fall back to the default auto behavior so a stale or
 // mistyped setting never disables routing entirely.
 func TestOutboundAttemptTypesUnknownFormatFallsBackToAuto(t *testing.T) {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -130,7 +130,7 @@ func outboundAttemptTypes(channelType outbound.OutboundType, request *model.Inte
 
 func isLLMRequestFormat(request *model.InternalLLMRequest) bool {
 	switch request.RawAPIFormat {
-	case model.APIFormatOpenAIChatCompletion, model.APIFormatOpenAIResponse:
+	case model.APIFormatOpenAIChatCompletion, model.APIFormatOpenAIResponse, model.APIFormatAnthropicMessage:
 		return true
 	default:
 		return false

--- a/internal/transformer/outbound/passthrough/passthrough.go
+++ b/internal/transformer/outbound/passthrough/passthrough.go
@@ -3,6 +3,7 @@ package passthrough
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -32,8 +33,12 @@ func (o *Outbound) TransformRequest(ctx context.Context, request *model.Internal
 		return nil, err
 	}
 	o.delegate = delegate
+	body, err := rewritePassthroughModel(request.RawRequest, request.Model)
+	if err != nil {
+		return nil, fmt.Errorf("failed to rewrite passthrough model: %w", err)
+	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", bytes.NewReader(request.RawRequest))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create passthrough request: %w", err)
 	}
@@ -101,6 +106,28 @@ func delegateAndEndpointForFormat(format model.APIFormat) (model.Outbound, strin
 	default:
 		return nil, "", fmt.Errorf("passthrough does not support raw api format %q", format)
 	}
+}
+
+// rewritePassthroughModel rewrites the top-level "model" field in the original
+// inbound JSON body to the resolved upstream model name. Format conversion is
+// intentionally skipped in passthrough mode, but group/channel model mapping
+// must still apply — otherwise the group name would be sent upstream as-is.
+func rewritePassthroughModel(raw []byte, modelName string) ([]byte, error) {
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" || len(raw) == 0 {
+		return raw, nil
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		// Keep the original body when it is not a JSON object (defensive).
+		return raw, nil
+	}
+	if current, ok := obj["model"].(string); ok && current == modelName {
+		return raw, nil
+	}
+	obj["model"] = modelName
+	return json.Marshal(obj)
 }
 
 func buildPassthroughURL(baseURL, endpointPath string, query url.Values, format model.APIFormat) (string, error) {

--- a/internal/transformer/outbound/passthrough/passthrough_test.go
+++ b/internal/transformer/outbound/passthrough/passthrough_test.go
@@ -2,6 +2,7 @@ package passthrough
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"strings"
 	"testing"
@@ -90,6 +91,59 @@ func TestTransformRequestAnthropicUsesRawBodyAndMessagesPath(t *testing.T) {
 	}
 	if got := req.Header.Get("Accept"); got != "text/event-stream" {
 		t.Fatalf("Accept = %q", got)
+	}
+}
+
+func TestTransformRequestRewritesResolvedUpstreamModel(t *testing.T) {
+	raw := []byte(`{"model":"group-name","messages":[{"role":"user","content":"hello"}],"max_tokens":32,"custom":true}`)
+	stream := false
+	req, err := (&Outbound{}).TransformRequest(context.Background(), &model.InternalLLMRequest{
+		Model:        "claude-sonnet-4-20250514",
+		RawRequest:   raw,
+		RawAPIFormat: model.APIFormatAnthropicMessage,
+		Stream:       &stream,
+	}, "https://anthropic.example.com/api", "sk-ant")
+	if err != nil {
+		t.Fatalf("TransformRequest error: %v", err)
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got["model"] != "claude-sonnet-4-20250514" {
+		t.Fatalf("model = %#v, want rewritten upstream model", got["model"])
+	}
+	if got["custom"] != true {
+		t.Fatalf("custom field should be preserved, got %#v", got["custom"])
+	}
+	if req.URL.String() != "https://anthropic.example.com/api/messages" {
+		t.Fatalf("url = %s", req.URL.String())
+	}
+}
+
+func TestTransformRequestKeepsBodyWhenModelUnchanged(t *testing.T) {
+	raw := []byte(`{"model":"client-model","messages":[{"role":"user","content":"hello"}],"custom":true}`)
+	req, err := (&Outbound{}).TransformRequest(context.Background(), &model.InternalLLMRequest{
+		Model:        "client-model",
+		RawRequest:   raw,
+		RawAPIFormat: model.APIFormatOpenAIChatCompletion,
+	}, "https://example.com/api", "sk-test")
+	if err != nil {
+		t.Fatalf("TransformRequest error: %v", err)
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(body) != string(raw) {
+		t.Fatalf("body should remain byte-identical when model is unchanged:\n got %s\nwant %s", string(body), string(raw))
 	}
 }
 


### PR DESCRIPTION
## Summary
- 修复分组选择 `messages` / `messages_only` 时，Anthropic Messages 入站被忽略并退回渠道原生 OpenAI Chat 的问题：`isLLMRequestFormat` 此前只覆盖 OpenAI Chat/Responses。
- 修复原始透传（`passthrough`）直接把客户端/分组名写进上游 `model` 的问题：现在会在保持原始协议 body 的同时，把分组解析后的上游模型名写回 `model` 字段。

## Changes
- `internal/relay/relay.go`: `isLLMRequestFormat` 增加 `APIFormatAnthropicMessage`
- `internal/transformer/outbound/passthrough`: 出站前 `rewritePassthroughModel`
- 补充 Anthropic 入站出站格式选择测试与 passthrough 模型改写测试
- 更新 `CHANGELOG.md`

## Test plan
- [x] `go test ./internal/relay/ -run TestOutboundAttemptTypes`
- [x] `go test ./internal/transformer/outbound/passthrough/`
- [ ] 分组设为「仅 Anthropic Messages」，客户端走 `/v1/messages`，确认上游收到 Anthropic Messages 而非 OpenAI Chat
- [ ] 分组设为「原始透传」，确认上游 body 仍是原协议，但 `model` 为渠道/分组条目解析后的上游模型名，而不是分组名