### PR TITLE
feat: 渠道创建/编辑移动端体验优化与日志深色模式对比度修复

### DIFF
--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -3112,6 +3112,7 @@
         "open": "Use template",
         "skip": "Skip templates",
         "pickerHint": "Choose a built-in provider to prefill the form. If your upstream is not listed, skip this step and configure it manually.",
+        "selectPlaceholder": "Select a provider template…",
         "options": {
           "openai": {
             "description": "OpenAI Chat official API"

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -3068,6 +3068,7 @@
         "open": "使用预设",
         "skip": "跳过预设",
         "pickerHint": "可以先选择一个内置供应商快速预填；如果你的上游不在列表里，跳过后手动配置即可。",
+        "selectPlaceholder": "选择内置供应商模板…",
         "options": {
           "openai": {
             "description": "OpenAI Chat 官方接口"

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -3068,6 +3068,7 @@
         "open": "使用預設",
         "skip": "跳過預設",
         "pickerHint": "可以先選擇一個內建供應商快速預填；如果你的上游不在列表裡，跳過後手動設定即可。",
+        "selectPlaceholder": "選擇內建供應商範本…",
         "options": {
           "openai": {
             "description": "OpenAI Chat 官方介面"

--- a/web/src/components/modules/channel/Card.tsx
+++ b/web/src/components/modules/channel/Card.tsx
@@ -170,7 +170,7 @@ export function Card({
                 </MorphingDialogTrigger>
 
                 <MorphingDialogContainer>
-                    <MorphingDialogContent className="relative flex max-h-[calc(100dvh-2rem)] min-h-0 w-[min(100vw-1rem,64rem)] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-card px-4 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom,0px))] text-card-foreground md:px-6 md:py-5">
+                    <MorphingDialogContent className="relative flex max-h-[calc(100dvh-2rem)] min-h-0 w-[min(100vw-1rem,64rem)] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-card px-4 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom,0px))] text-card-foreground md:px-6 md:py-5" dismissOnOverlayClick={false}>
                         <CardContent channel={channel} stats={stats} />
                     </MorphingDialogContent>
                 </MorphingDialogContainer>
@@ -353,7 +353,7 @@ export function Card({
             </MorphingDialogTrigger>
 
             <MorphingDialogContainer>
-                <MorphingDialogContent className="relative flex max-h-[calc(100dvh-2rem)] min-h-0 w-[min(100vw-1rem,64rem)] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-card px-4 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom,0px))] text-card-foreground md:px-6 md:py-5">
+                <MorphingDialogContent className="relative flex max-h-[calc(100dvh-2rem)] min-h-0 w-[min(100vw-1rem,64rem)] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-card px-4 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom,0px))] text-card-foreground md:px-6 md:py-5" dismissOnOverlayClick={false}>
                     <CardContent channel={channel} stats={stats} />
                 </MorphingDialogContent>
             </MorphingDialogContainer>

--- a/web/src/components/modules/channel/Create.tsx
+++ b/web/src/components/modules/channel/Create.tsx
@@ -159,7 +159,7 @@ export function CreateDialogContent() {
                         </div>
                         <h2 className="text-xl font-semibold tracking-tight text-card-foreground md:text-2xl">{t('dialogTitle')}</h2>
                     </div>
-                    {showPresetPicker ? (
+                    {!isMobile && showPresetPicker ? (
                         <Button
                             type="button"
                             variant="outline"
@@ -187,7 +187,7 @@ export function CreateDialogContent() {
             </MorphingDialogTitle>
             <MorphingDialogDescription disableLayoutAnimation className="relative flex-1 min-h-0 overflow-hidden px-4 py-4 md:px-6 md:py-5">
                 <AnimatePresence mode="wait" initial={false}>
-                {showPresetPicker ? (
+                {!isMobile && showPresetPicker ? (
                     <motion.div
                         key="preset-picker"
                         initial={{ opacity: 0, scale: 0.98, y: 6 }}
@@ -239,7 +239,7 @@ export function CreateDialogContent() {
                             submitText={t('submit')}
                             pendingText={t('submitting')}
                             idPrefix="new-channel"
-                            showTemplatePicker={false}
+                            showTemplatePicker={isMobile}
                             onShowTemplatePicker={() => setShowPresetPicker(true)}
                         />
                     </motion.div>

--- a/web/src/components/modules/channel/Create.tsx
+++ b/web/src/components/modules/channel/Create.tsx
@@ -16,15 +16,18 @@ import { useTranslations } from 'next-intl';
 import {
     ChannelForm,
     TemplatePickerGrid,
+    TemplatePickerSelect,
     createDefaultRequestRewriteFormData,
     getEffectiveRequestRewriteFormData,
     type ChannelFormData,
 } from './Form';
 import { channelTemplates } from './templates';
 import { DEFAULT_CHANNEL_TYPE } from './type-options';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 export function CreateDialogContent() {
     const { setIsOpen } = useMorphingDialog();
+    const isMobile = useIsMobile();
     const createChannel = useCreateChannel();
     const [showPresetPicker, setShowPresetPicker] = useState(true);
     const [formData, setFormData] = useState<ChannelFormData>({
@@ -212,7 +215,11 @@ export function CreateDialogContent() {
                                 </div>
                                 <p className="text-xs leading-5 text-muted-foreground">{tForm('template.pickerHint')}</p>
                             </div>
-                            <TemplatePickerGrid onApplyTemplate={handleApplyTemplate} />
+                            {isMobile ? (
+                                <TemplatePickerSelect onApplyTemplate={handleApplyTemplate} />
+                            ) : (
+                                <TemplatePickerGrid onApplyTemplate={handleApplyTemplate} />
+                            )}
                         </div>
                     </motion.div>
                 ) : (

--- a/web/src/components/modules/channel/Form.tsx
+++ b/web/src/components/modules/channel/Form.tsx
@@ -1612,9 +1612,7 @@ export function ChannelForm({
                     </AccordionContent>
                 </AccordionItem>
             </Accordion>
-            </div>
-
-            <section className={`${sectionClassName} mt-4 flex shrink-0 flex-col gap-4 border-t border-border/20 pt-4`}>
+            <section className={`${sectionClassName} flex flex-col gap-4`}>
                 <label className="flex items-center gap-2 cursor-pointer">
                     <Switch
                         checked={formData.enabled}
@@ -1705,6 +1703,7 @@ export function ChannelForm({
                     </div>
                 </div>
             </section>
+            </div>
 
             <div className={`shrink-0 flex flex-col gap-3 pt-4 ${onCancel ? 'sm:flex-row' : ''}`}>
                 {onCancel && cancelText && (

--- a/web/src/components/modules/channel/Form.tsx
+++ b/web/src/components/modules/channel/Form.tsx
@@ -43,6 +43,7 @@ import {
 } from '@/components/ui/morphing-dialog';
 import { toast } from '@/components/common/Toast';
 import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { useTranslations } from 'next-intl';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { RefreshCw, X, Plus, FlaskConical, CheckCircle2, AlertTriangle, Trash2, Sparkles, Orbit, Layers3, KeyRound, Cable, Search, Check, ListFilter, ChevronRight } from 'lucide-react';
@@ -562,6 +563,46 @@ export function TemplatePickerGrid({
     );
 }
 
+/**
+ * 移动端高密度版模板选择器：下拉 Select 替代卡片网格，
+ * 选择即应用，触发区显示当前已选模板名。
+ */
+export function TemplatePickerSelect({
+    onApplyTemplate,
+}: {
+    onApplyTemplate: (templateKey: string) => void;
+}) {
+    const t = useTranslations('channel.form');
+    const [selected, setSelected] = useState('');
+
+    return (
+        <Select
+            value={selected}
+            onValueChange={(value) => {
+                setSelected(value);
+                onApplyTemplate(value);
+            }}
+        >
+            <SelectTrigger
+                id="channel-template-select"
+                className="w-full rounded-lg border border-border px-4 py-2 text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+                <SelectValue placeholder={t('template.selectPlaceholder')} />
+            </SelectTrigger>
+            <SelectContent className="max-h-80 rounded-lg">
+                {channelTemplates.map((template) => (
+                    <SelectItem key={template.key} className="rounded-xl py-2.5" value={template.key}>
+                        <span className="flex items-center justify-between gap-2 whitespace-nowrap">
+                            <span className="font-medium">{template.name}</span>
+                            <span className="text-xs text-muted-foreground">{t(template.descriptionKey)}</span>
+                        </span>
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
+    );
+}
+
 export function ChannelForm({
     formData,
     onFormDataChange,
@@ -576,6 +617,7 @@ export function ChannelForm({
     onShowTemplatePicker,
 }: ChannelFormProps) {
     const t = useTranslations('channel.form');
+    const isMobile = useIsMobile();
     const { data: settings } = useSettingList();
     const { data: channelGroups = [] } = useChannelGroupList();
     const { data: notifChannels = [] } = useAlertNotifChannelList();
@@ -894,9 +936,11 @@ export function ChannelForm({
             {showTemplatePicker ? (
                 <section className={sectionClassName}>
                     <SectionHeader icon={Sparkles} title={t('template.label')} hint={t('template.hint')} />
-                    <TemplatePickerGrid
-                        onApplyTemplate={handleApplyTemplate}
-                    />
+                    {isMobile ? (
+                        <TemplatePickerSelect onApplyTemplate={handleApplyTemplate} />
+                    ) : (
+                        <TemplatePickerGrid onApplyTemplate={handleApplyTemplate} />
+                    )}
                 </section>
             ) : (
                 <div className="flex justify-end">

--- a/web/src/components/modules/channel/Form.tsx
+++ b/web/src/components/modules/channel/Form.tsx
@@ -589,12 +589,12 @@ export function TemplatePickerSelect({
             >
                 <SelectValue placeholder={t('template.selectPlaceholder')} />
             </SelectTrigger>
-            <SelectContent className="max-h-80 rounded-lg">
+            <SelectContent className="max-h-80 min-w-0 rounded-lg" style={{ width: 'var(--radix-select-trigger-width)' }}>
                 {channelTemplates.map((template) => (
                     <SelectItem key={template.key} className="rounded-xl py-2.5" value={template.key}>
-                        <span className="flex items-center justify-between gap-2 whitespace-nowrap">
-                            <span className="font-medium">{template.name}</span>
-                            <span className="text-xs text-muted-foreground">{t(template.descriptionKey)}</span>
+                        <span className="flex min-w-0 items-center gap-2">
+                            <span className="shrink-0 font-medium">{template.name}</span>
+                            <span className="truncate text-xs text-muted-foreground">{t(template.descriptionKey)}</span>
                         </span>
                     </SelectItem>
                 ))}

--- a/web/src/components/modules/log/Item.tsx
+++ b/web/src/components/modules/log/Item.tsx
@@ -9,7 +9,7 @@ import { githubDarkTheme } from '@uiw/react-json-view/githubDark';
 import { githubLightTheme } from '@uiw/react-json-view/githubLight';
 import { useTheme } from 'next-themes';
 import { type RelayLog, type ChannelAttempt, useLogDetail } from '@/api/endpoints/log';
-import { getModelIcon } from '@/lib/model-icons';
+import { getModelIcon, resolveBrandColor } from '@/lib/model-icons';
 import { Badge } from '@/components/ui/badge';
 import { cn, formatCount, formatMoney } from '@/lib/utils';
 import { formatUnixSeconds } from '@/lib/time';
@@ -139,6 +139,8 @@ interface RetryBadgeWithTooltipProps {
 
 function RetryBadgeWithTooltip({ channelName, brandColor, attempts, channelNameById }: RetryBadgeWithTooltipProps) {
     const t = useTranslations('log.card');
+    const { resolvedTheme } = useTheme();
+    const badgeColor = resolveBrandColor(brandColor, resolvedTheme === 'dark');
 
     return (
         <Tooltip>
@@ -146,7 +148,7 @@ function RetryBadgeWithTooltip({ channelName, brandColor, attempts, channelNameB
                 <Badge
                     variant="secondary"
                     className="shrink-0 text-xs px-1.5 py-0.5 cursor-help font-medium"
-                    style={{ backgroundColor: `${brandColor}15`, color: brandColor }}
+                    style={{ backgroundColor: `${badgeColor}15`, color: badgeColor }}
                 >
                     <RotateCw className="size-3 mr-1 opacity-80" />
                     {channelName}
@@ -304,6 +306,10 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
         () => getModelIcon(displayFields.actualModelName),
         [displayFields.actualModelName]
     );
+    // 深色模式下黑/深色系品牌色（Grok/Kimi/Replicate/MiniMax/Yi 等）直接用作
+    // Badge 文字会「黑字+透明黑底」看不清，按主题解析为可读颜色（issue: 日志深色模式对比度）
+    const { resolvedTheme } = useTheme();
+    const badgeColor = resolveBrandColor(brandColor, resolvedTheme === 'dark');
     const requestAPIKeyName = displayFields.requestAPIKeyName;
 	const clientIP = log.client_ip || '';
     const cacheReadTokens = displayFields.cacheReadTokens;
@@ -409,7 +415,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                                     <Badge
                                         variant="secondary"
                                         className="max-w-full shrink-0 text-xs px-1.5 py-0"
-                                        style={{ backgroundColor: `${brandColor}15`, color: brandColor }}
+                                        style={{ backgroundColor: `${badgeColor}15`, color: badgeColor }}
                                         title={displayEndpointType}
                                     >
                                         <span className="block max-w-[10rem] truncate">{displayEndpointType}</span>
@@ -429,7 +435,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                                             <Badge
                                                 variant="secondary"
                                                 className="max-w-full shrink-0 text-xs px-1.5 py-0"
-                                                style={{ backgroundColor: `${brandColor}15`, color: brandColor }}
+                                                style={{ backgroundColor: `${badgeColor}15`, color: badgeColor }}
                                                 title={displayChannelName}
                                             >
                                                 <span className="block max-w-[18rem] truncate">{displayChannelName}</span>
@@ -448,7 +454,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                             </div>
                             <div className="grid grid-cols-2 md:grid-cols-7 gap-x-4 gap-y-1.5 text-xs tabular-nums text-muted-foreground">
                                 <div className="flex items-center gap-1.5">
-                                    <Clock className="size-3.5 shrink-0" style={{ color: brandColor }} />
+                                    <Clock className="size-3.5 shrink-0" style={{ color: badgeColor }} />
                                     <span>{formatTime(log.time)}</span>
                                 </div>
                                 {vis.apiKeyName && requestAPIKeyName && (
@@ -565,7 +571,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                                 <Badge
                                     variant="secondary"
                                     className="max-w-full shrink-0 text-xs px-1.5 py-0"
-                                    style={{ backgroundColor: `${brandColor}15`, color: brandColor }}
+                                    style={{ backgroundColor: `${badgeColor}15`, color: badgeColor }}
                                     title={displayEndpointType}
                                 >
                                     <span className="block max-w-[10rem] truncate">{displayEndpointType}</span>
@@ -585,7 +591,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                                         <Badge
                                             variant="secondary"
                                             className="max-w-full text-xs px-1.5 py-0"
-                                            style={{ backgroundColor: `${brandColor}15`, color: brandColor }}
+                                            style={{ backgroundColor: `${badgeColor}15`, color: badgeColor }}
                                             title={displayChannelName}
                                         >
                                             <span className="block max-w-[18rem] truncate">{displayChannelName}</span>
@@ -817,7 +823,7 @@ export const LogCard = memo(function LogCard({ log, channelNameById }: { log: Re
                         <div className="shrink-0 border-t border-border/50 pt-3 text-xs text-muted-foreground">
                             <div className="flex flex-wrap items-center gap-3 md:gap-4">
                             <div className="flex items-center gap-1.5">
-                                <Clock className="size-3.5" style={{ color: brandColor }} />
+                                <Clock className="size-3.5" style={{ color: badgeColor }} />
                                 <span className="tabular-nums">{formatTime(log.time)}</span>
                             </div>
                             {vis.apiKeyName && requestAPIKeyName && (

--- a/web/src/components/modules/toolbar/index.tsx
+++ b/web/src/components/modules/toolbar/index.tsx
@@ -635,7 +635,10 @@ export function Toolbar() {
                         </MorphingDialogTrigger>
 
                         <MorphingDialogContainer>
-                            <MorphingDialogContent className={getCreateDialogContentClassName(toolbarItem)}>
+                            <MorphingDialogContent
+                                className={getCreateDialogContentClassName(toolbarItem)}
+                                dismissOnOverlayClick={toolbarItem !== 'channel'}
+                            >
                                 <CreateDialogContent activeItem={toolbarItem} />
                             </MorphingDialogContent>
                         </MorphingDialogContainer>

--- a/web/src/components/ui/morphing-dialog.tsx
+++ b/web/src/components/ui/morphing-dialog.tsx
@@ -203,12 +203,15 @@ export type MorphingDialogContentProps = {
   children: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
+  /** 点击弹窗外部空白区域是否关闭。长表单（创建/编辑）建议传 false 防止误触丢失输入。 */
+  dismissOnOverlayClick?: boolean;
 };
 
 function MorphingDialogContent({
   children,
   className,
   style,
+  dismissOnOverlayClick = true,
 }: MorphingDialogContentProps) {
   const { setIsOpen, isOpen, uniqueId, disableSharedLayout, triggerRef } = useMorphingDialog();
   const containerRef = useRef<HTMLDivElement>(null!);
@@ -268,7 +271,7 @@ function MorphingDialogContent({
   useClickOutside(
     containerRef,
     () => {
-      if (isOpen) {
+      if (dismissOnOverlayClick && isOpen) {
         setIsOpen(false);
       }
     },

--- a/web/src/lib/model-icons.tsx
+++ b/web/src/lib/model-icons.tsx
@@ -122,6 +122,42 @@ const MODEL_ICON_PATTERNS: ModelIconConfig[] = [
 const DEFAULT_CONFIG = { Avatar: OpenAI.Avatar, color: '#10A37F', label: 'Model' };
 
 /**
+ * 计算 hex 颜色的相对亮度（0–1），基于 WCAG 相对亮度公式。
+ * 用于判断品牌色在深色/浅色背景上的可读性。
+ */
+export function colorLuminance(hex: string): number {
+    const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+    if (!m) return 0.5; // 非标准格式返回中间值，不触发翻转
+    const n = parseInt(m[1], 16);
+    const toLinear = (c: number) => {
+        const s = c / 255;
+        return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+    };
+    const r = toLinear((n >> 16) & 0xff);
+    const g = toLinear((n >> 8) & 0xff);
+    const b = toLinear(n & 0xff);
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * 解析在指定主题下可读的品牌色。
+ *
+ * 品牌色直接用作 Badge 文字/背景色时，深色系颜色（如 Grok/Kimi/Replicate 的
+ * 纯黑 #000、MiniMax 的 #1A1A2E）在深色模式下会「黑字+透明黑底」看不清；
+ * 同理浅色模式下 Ollama 的纯白 #FFF 白字也不可见。
+ *
+ * @param color 原始品牌色（hex）
+ * @param isDark 当前是否为深色主题
+ * @returns 可读颜色
+ */
+export function resolveBrandColor(color: string, isDark: boolean): string {
+    const lum = colorLuminance(color);
+    if (isDark && lum < 0.15) return '#E5E7EB';
+    if (!isDark && lum > 0.9) return '#4B5563';
+    return color;
+}
+
+/**
  * Get the Avatar component and color for a given model name
  * @param modelName - The name of the model
  * @returns Object containing Avatar component and brand color


### PR DESCRIPTION
## 改动动机

渠道配置存在几处移动端体验与深色模式可读性问题：

1. **移动端创建渠道流程冗长**：内置供应商模板以 卡片展示，手机小屏下信息密度低、一屏看不全，需反复滚动选择；且移动端先展示预设选择页、再进入表单，多一步跳转。
2. **误触丢输入**：创建/编辑渠道弹窗点击空白处会直接关闭，表单已填写内容全部丢失，移动端误触概率高。
3. **深色模式 Badge 不可读**：日志卡片中 Grok/Kimi/Replicate/MiniMax/Yi 等供应商品牌色为纯黑或深色系，深色主题下直接用作 Badge 文字是「黑字+透明黑底」，几乎不可见。
4. **表单底部开关不随内容滚动**：启用/代理/同步等开关固定在表单底部（`shrink-0` + 顶部边框），输入法弹出后，卡片上移遮挡表单填写区域，修改后长表单下需滑到最底才能操作，且窄屏下挤压内容区。

## 改动内容与影响范围

全部改动位于 `web/`（前端），共 10 个文件，无后端改动：

### 1. 移动端内置供应商模板改下拉选择（feat）
- `web/src/components/modules/channel/Form.tsx`：新增 `TemplatePickerSelect` 组件 —— 用 `Select` 下拉替代卡片网格，**选择即应用模板**，触发区显示当前已选模板名，名称+描述单行紧凑展示。
- `web/src/components/modules/channel/Create.tsx`：通过 `useIsMobile()` 判断，移动端渲染 `TemplatePickerSelect`，桌面端保持原 `TemplatePickerGrid`。
- `web/public/locale/{en,zh_hans,zh_hant}.json`：新增 `template.selectPlaceholder` 文案（三语）。

### 2. 移动端创建渠道直达表单 + 模板下拉防溢出（fix）
- `web/src/components/modules/channel/Create.tsx`：移动端跳过预设选择页直接进入表单（表单内仍保留模板下拉入口），少一次跳转。
- `web/src/components/modules/channel/Form.tsx`：`SelectContent` 加 `max-h-80 min-w-0`，宽度跟随触发器（`--radix-select-trigger-width`），长选项名截断不撑破弹层。

### 3. 渠道弹窗禁用点击空白关闭，防误触丢输入（fix）
- `web/src/components/ui/morphing-dialog.tsx`：`MorphingDialogContent` 新增 `dismissOnOverlayClick` prop（默认 `true`，兼容现有调用方）。
- `web/src/components/modules/channel/Card.tsx`：渠道**查看/编辑**弹窗传 `dismissOnOverlayClick={false}`。
- `web/src/components/modules/toolbar/index.tsx`：渠道**创建**弹窗传 `dismissOnOverlayClick={toolbarItem !== 'channel'}`，即仅渠道类弹窗禁用点空白关闭，其余（分组等）保持原行为。

### 4. 日志深色模式 Badge 对比度修复（fix）
- `web/src/lib/model-icons.tsx`：新增 `colorLuminance()`（WCAG 相对亮度公式）与 `resolveBrandColor(color, isDark)` —— 深色主题下亮度 < 0.15 的深色品牌色替换为浅灰 `#E5E7EB`；浅色主题下亮度 > 0.9 的纯白色（如 Ollama）替换为 `#4B5563`；其余颜色原样返回。
- `web/src/components/modules/log/Item.tsx`：`LogCard` 与 `RetryBadgeWithTooltip` 中所有 Badge/时钟图标的 `brandColor` 均改为经 `resolveBrandColor()` 解析后的颜色。

### 5. 启用/代理/同步开关卡片移入表单滚动区（fix）
- `web/src/components/modules/channel/Form.tsx`：开关 section 从固定底部（`mt-4 shrink-0 border-t`）移入表单滚动容器内，长表单下随内容一起滚动，不再挤压内容区。

## 验证

- ESLint：改动文件全部通过（`npx eslint` 零报错）。
- TypeScript：改动文件无类型错误（仓库 `*.test.ts` 存在与本次改动无关的预存类型问题，`tsc --noEmit` 全量检查时会报，属既有问题）。
- 桌面端行为不变：`useIsMobile()` 分支保证桌面仍走原卡片网格、弹窗点空白关闭等原逻辑。

## 风险与兼容性

- `dismissOnOverlayClick` 为可选 prop，默认值与旧行为一致，不影响其他弹窗调用方。
- 模板选择器仅移动端更换为下拉形态，桌面 UI 与交互零变化。
- 品牌色解析仅影响日志 Badge/图标着色，不改变模型头像与配色数据本身。