### PR TITLE
fix: OpenAI 兼容出站 extra_body 展平与 store 字段序列化修复

### DIFF
--- a/internal/transformer/model/model.go
+++ b/internal/transformer/model/model.go
@@ -100,7 +100,12 @@ type InternalLLMRequest struct {
 	// or [evals](https://platform.openai.com/docs/guides/evals) products.
 	//
 	// Supports text and image inputs. Note: image inputs over 10MB will be dropped.
-	Store *bool `json:"store,omitzero"`
+	//
+	// Use omitempty (not omitzero): release builds marshal via jsoniter
+	// ConfigCompatibleWithStandardLibrary, which does not honor omitzero and
+	// would emit "store":null for a nil *bool. Strict OpenAI-compat relays
+	// (e.g. new-api / jzgo) reject null with "store 类型错误".
+	Store *bool `json:"store,omitempty"`
 
 	// What sampling temperature to use, between 0 and 2. Higher values like 0.8 will
 	// make the output more random, while lower values like 0.2 will make it more
@@ -111,7 +116,8 @@ type InternalLLMRequest struct {
 	// An integer between 0 and 20 specifying the number of most likely tokens to
 	// return at each token position, each with an associated log probability.
 	// `logprobs` must be set to `true` if this parameter is used.
-	TopLogprobs *int64 `json:"top_logprobs,omitzero"`
+	// omitempty: same jsoniter omitzero gap as Store (see above).
+	TopLogprobs *int64 `json:"top_logprobs,omitempty"`
 
 	// An alternative to sampling with temperature, called nucleus sampling, where the
 	// model considers the results of the tokens with top_p probability mass. So 0.1
@@ -123,14 +129,16 @@ type InternalLLMRequest struct {
 	// Used by OpenAI to cache responses for similar requests to optimize your cache
 	// hit rates. Replaces the `user` field.
 	// [Learn more](https://platform.openai.com/docs/guides/prompt-caching).
-	PromptCacheKey *bool `json:"prompt_cache_key,omitzero"`
+	// omitempty: same jsoniter omitzero gap as Store (see above).
+	PromptCacheKey *bool `json:"prompt_cache_key,omitempty"`
 
 	// A stable identifier used to help detect users of your application that may be
 	// violating OpenAI's usage policies. The IDs should be a string that uniquely
 	// identifies each user. We recommend hashing their username or email address, in
 	// order to avoid sending us any identifying information.
 	// [Learn more](https://platform.openai.com/docs/guides/safety-best-practices#safety-identifiers).
-	SafetyIdentifier *string `json:"safety_identifier,omitzero"`
+	// omitempty: same jsoniter omitzero gap as Store (see above).
+	SafetyIdentifier *string `json:"safety_identifier,omitempty"`
 
 	// This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use
 	// `prompt_cache_key` instead to maintain caching optimizations. A stable

--- a/internal/transformer/outbound/openai/chat.go
+++ b/internal/transformer/outbound/openai/chat.go
@@ -40,7 +40,10 @@ func (o *ChatOutbound) TransformRequest(ctx context.Context, request *model.Inte
 		}
 	}
 
-	body, err := transformer.Marshal(compatRequest)
+	// DeepSeek docs: SDK `extra_body` is a client-side bag; the HTTP body must
+	// carry those keys at the top level (e.g. `thinking`). Nested `extra_body`
+	// is rejected by the official API and by strict OpenAI-compat proxies.
+	body, err := marshalOpenAICompatRequest(compatRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
@@ -99,7 +102,13 @@ func SanitizeRequestForOpenAICompat(request *model.InternalLLMRequest, baseURL s
 	// reasoning-compatible targets. DeepSeek and Mimo already handle effort
 	// mapping in the call above.
 	if !isReasoningCompatRequest(baseURL, request, isMimoChannel) {
-		request.ReasoningEffort = normalizeOpenAICompatReasoningEffort(request.ReasoningEffort)
+		// deepseek-* aliases on strict OpenAI-compat relays (FuturePPO etc.)
+		// reject reasoning_effort even though the model id contains "deepseek".
+		if looksLikeDeepSeekModelName(request.Model) {
+			request.ReasoningEffort = ""
+		} else {
+			request.ReasoningEffort = normalizeOpenAICompatReasoningEffort(request.ReasoningEffort)
+		}
 	}
 
 	preserveDeepSeekReasoning := shouldPreserveDeepSeekReasoning(baseURL, request, isMimoChannel)
@@ -115,6 +124,41 @@ func SanitizeRequestForOpenAICompat(request *model.InternalLLMRequest, baseURL s
 		request.ExtraBody = nil
 	}
 	request.Include = nil
+}
+
+// marshalOpenAICompatRequest serializes the OpenAI-compat chat body and flattens
+// ExtraBody into top-level JSON keys. ExtraBody is an SDK-only concept.
+func marshalOpenAICompatRequest(request *model.InternalLLMRequest) ([]byte, error) {
+	if request == nil {
+		return nil, fmt.Errorf("request is nil")
+	}
+
+	extraBody := request.ExtraBody
+	request.ExtraBody = nil
+	body, err := transformer.Marshal(request)
+	request.ExtraBody = extraBody
+	if err != nil {
+		return nil, err
+	}
+	if len(extraBody) == 0 {
+		return body, nil
+	}
+
+	var payload map[string]any
+	if err := transformer.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	var extra map[string]any
+	if err := transformer.Unmarshal(extraBody, &extra); err != nil {
+		return nil, err
+	}
+	for key, value := range extra {
+		payload[key] = value
+	}
+	delete(payload, "extra_body")
+
+	return transformer.Marshal(payload)
 }
 
 func applyReasoningCompatTokenBudget(request *model.InternalLLMRequest, baseURL string, isMimoChannel bool) {

--- a/internal/transformer/outbound/openai/chat_test.go
+++ b/internal/transformer/outbound/openai/chat_test.go
@@ -889,6 +889,8 @@ func TestChatOutboundTransformRequest_MapsDeepSeekThinkingControls(t *testing.T)
 
 	var got struct {
 		ReasoningEffort string         `json:"reasoning_effort,omitempty"`
+		Thinking        map[string]any `json:"thinking,omitempty"`
+		Foo             any            `json:"foo,omitempty"`
 		ExtraBody       map[string]any `json:"extra_body,omitempty"`
 	}
 	if err := transformer.Unmarshal(body, &got); err != nil {
@@ -899,15 +901,14 @@ func TestChatOutboundTransformRequest_MapsDeepSeekThinkingControls(t *testing.T)
 		t.Fatalf("expected deepseek reasoning_effort max, got %q", got.ReasoningEffort)
 	}
 
-	thinking, ok := got.ExtraBody["thinking"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected extra_body.thinking to be preserved, got %#v", got.ExtraBody)
+	if got.Thinking["type"] != "enabled" {
+		t.Fatalf("expected top-level thinking.type enabled, got %#v", got.Thinking)
 	}
-	if thinking["type"] != "enabled" {
-		t.Fatalf("expected extra_body.thinking.type enabled, got %#v", thinking["type"])
+	if got.Foo != "bar" {
+		t.Fatalf("expected extra_body custom fields flattened to top-level, got foo=%#v", got.Foo)
 	}
-	if got.ExtraBody["foo"] != "bar" {
-		t.Fatalf("expected extra_body custom fields to be preserved, got %#v", got.ExtraBody["foo"])
+	if len(got.ExtraBody) != 0 {
+		t.Fatalf("expected nested extra_body to be omitted from wire body, got %#v", got.ExtraBody)
 	}
 }
 
@@ -942,6 +943,8 @@ func TestChatOutboundTransformRequest_MapsMimoThinkingControls(t *testing.T) {
 
 	var got struct {
 		ReasoningEffort string         `json:"reasoning_effort,omitempty"`
+		Thinking        map[string]any `json:"thinking,omitempty"`
+		Foo             any            `json:"foo,omitempty"`
 		ExtraBody       map[string]any `json:"extra_body,omitempty"`
 	}
 	if err := transformer.Unmarshal(body, &got); err != nil {
@@ -952,18 +955,14 @@ func TestChatOutboundTransformRequest_MapsMimoThinkingControls(t *testing.T) {
 		t.Fatalf("expected mimo reasoning_effort max, got %q", got.ReasoningEffort)
 	}
 
-	thinking, ok := got.ExtraBody["thinking"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected extra_body.thinking to be preserved, got %#v", got.ExtraBody)
+	if got.Thinking["type"] != "enabled" {
+		t.Fatalf("expected top-level thinking.type enabled, got %#v", got.Thinking)
 	}
-	if thinking["type"] != "enabled" {
-		t.Fatalf("expected extra_body.thinking.type enabled, got %#v", thinking["type"])
+	if got.Foo != "bar" {
+		t.Fatalf("expected extra_body custom fields flattened to top-level, got foo=%#v", got.Foo)
 	}
-	if got.ExtraBody["foo"] != "bar" {
-		t.Fatalf("expected extra_body custom fields to be preserved, got %#v", got.ExtraBody["foo"])
-	}
-	if got.ReasoningEffort != "max" {
-		t.Fatalf("expected mimo reasoning_effort max, got %q", got.ReasoningEffort)
+	if len(got.ExtraBody) != 0 {
+		t.Fatalf("expected nested extra_body to be omitted from wire body, got %#v", got.ExtraBody)
 	}
 }
 
@@ -1078,11 +1077,10 @@ func TestChatOutboundTransformRequest_DisablesDeepSeekThinkingWhenReasoningEffor
 
 	var got struct {
 		ReasoningEffort *string `json:"reasoning_effort,omitempty"`
-		ExtraBody       struct {
-			Thinking struct {
-				Type string `json:"type"`
-			} `json:"thinking"`
-		} `json:"extra_body,omitempty"`
+		Thinking        struct {
+			Type string `json:"type"`
+		} `json:"thinking,omitempty"`
+		ExtraBody map[string]any `json:"extra_body,omitempty"`
 	}
 	if err := transformer.Unmarshal(body, &got); err != nil {
 		t.Fatalf("failed to unmarshal outbound body: %v", err)
@@ -1091,8 +1089,11 @@ func TestChatOutboundTransformRequest_DisablesDeepSeekThinkingWhenReasoningEffor
 	if got.ReasoningEffort != nil {
 		t.Fatalf("expected reasoning_effort to be omitted, got %q", *got.ReasoningEffort)
 	}
-	if got.ExtraBody.Thinking.Type != "disabled" {
-		t.Fatalf("expected deepseek thinking to be disabled, got %q", got.ExtraBody.Thinking.Type)
+	if got.Thinking.Type != "disabled" {
+		t.Fatalf("expected deepseek thinking to be disabled, got %q", got.Thinking.Type)
+	}
+	if len(got.ExtraBody) != 0 {
+		t.Fatalf("expected nested extra_body to be omitted, got %#v", got.ExtraBody)
 	}
 }
 
@@ -1131,11 +1132,10 @@ func TestChatOutboundTransformRequest_DisablesMimoThinkingWhenReasoningEffortNon
 
 	var got struct {
 		ReasoningEffort *string `json:"reasoning_effort,omitempty"`
-		ExtraBody       struct {
-			Thinking struct {
-				Type string `json:"type"`
-			} `json:"thinking"`
-		} `json:"extra_body,omitempty"`
+		Thinking        struct {
+			Type string `json:"type"`
+		} `json:"thinking,omitempty"`
+		ExtraBody map[string]any `json:"extra_body,omitempty"`
 	}
 	if err := transformer.Unmarshal(body, &got); err != nil {
 		t.Fatalf("failed to unmarshal outbound body: %v", err)
@@ -1144,8 +1144,11 @@ func TestChatOutboundTransformRequest_DisablesMimoThinkingWhenReasoningEffortNon
 	if got.ReasoningEffort != nil {
 		t.Fatalf("expected reasoning_effort to be omitted, got %q", *got.ReasoningEffort)
 	}
-	if got.ExtraBody.Thinking.Type != "disabled" {
-		t.Fatalf("expected mimo thinking to be disabled, got %q", got.ExtraBody.Thinking.Type)
+	if got.Thinking.Type != "disabled" {
+		t.Fatalf("expected mimo thinking to be disabled, got %q", got.Thinking.Type)
+	}
+	if len(got.ExtraBody) != 0 {
+		t.Fatalf("expected nested extra_body to be omitted, got %#v", got.ExtraBody)
 	}
 }
 
@@ -1180,11 +1183,10 @@ func TestChatOutboundTransformRequest_DeepSeekThinkingDisabledOverridesReasoning
 
 	var got struct {
 		ReasoningEffort *string `json:"reasoning_effort,omitempty"`
-		ExtraBody       struct {
-			Thinking struct {
-				Type string `json:"type"`
-			} `json:"thinking"`
-		} `json:"extra_body,omitempty"`
+		Thinking        struct {
+			Type string `json:"type"`
+		} `json:"thinking,omitempty"`
+		ExtraBody map[string]any `json:"extra_body,omitempty"`
 	}
 	if err := transformer.Unmarshal(body, &got); err != nil {
 		t.Fatalf("failed to unmarshal outbound body: %v", err)
@@ -1193,8 +1195,50 @@ func TestChatOutboundTransformRequest_DeepSeekThinkingDisabledOverridesReasoning
 	if got.ReasoningEffort != nil {
 		t.Fatalf("expected reasoning_effort to be omitted when thinking disabled, got %q", *got.ReasoningEffort)
 	}
-	if got.ExtraBody.Thinking.Type != "disabled" {
-		t.Fatalf("expected deepseek thinking type disabled, got %q", got.ExtraBody.Thinking.Type)
+	if got.Thinking.Type != "disabled" {
+		t.Fatalf("expected deepseek thinking type disabled, got %q", got.Thinking.Type)
+	}
+	if len(got.ExtraBody) != 0 {
+		t.Fatalf("expected nested extra_body to be omitted, got %#v", got.ExtraBody)
+	}
+}
+
+func TestChatOutboundTransformRequest_StripsReasoningEffortForDeepSeekAliasOnStrictOpenAIProxy(t *testing.T) {
+	outbound := &ChatOutbound{}
+	request := &model.InternalLLMRequest{
+		Model:           "deepseek-v4-flash",
+		ReasoningEffort: "medium",
+		Messages: []model.Message{{
+			Role: "user",
+			Content: model.MessageContent{
+				Content: loPtr("这是一条测试信息"),
+			},
+		}},
+	}
+
+	// FuturePPO-style host: deepseek model alias, no deepseek in base URL,
+	// no endpoint_type=deepseek metadata — must not inject thinking controls.
+	httpReq, err := outbound.TransformRequest(context.Background(), request, "https://api.futureppo.top/v1", "sk-test")
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+	body, err := io.ReadAll(httpReq.Body)
+	if err != nil {
+		t.Fatalf("failed to read request body: %v", err)
+	}
+
+	var got map[string]any
+	if err := transformer.Unmarshal(body, &got); err != nil {
+		t.Fatalf("failed to unmarshal outbound body: %v", err)
+	}
+	if _, ok := got["reasoning_effort"]; ok {
+		t.Fatalf("expected reasoning_effort omitted for deepseek alias on strict OpenAI proxy, body=%s", body)
+	}
+	if _, ok := got["extra_body"]; ok {
+		t.Fatalf("expected extra_body omitted, body=%s", body)
+	}
+	if _, ok := got["thinking"]; ok {
+		t.Fatalf("expected thinking omitted, body=%s", body)
 	}
 }
 

--- a/internal/transformer/outbound/openai/deepseek.go
+++ b/internal/transformer/outbound/openai/deepseek.go
@@ -31,6 +31,11 @@ func isProviderReasoningCompatRequest(baseURL string, request *model.InternalLLM
 		return true
 	}
 
+	// DeepSeek/MiMo thinking controls are wire-format features of the *upstream*,
+	// not of the client-facing model alias. Matching only on model name causes
+	// Octopus to inject reasoning_effort / thinking into strict OpenAI-compat
+	// proxies (e.g. FuturePPO) that expose deepseek-* aliases but reject those
+	// fields with HTTP 400.
 	lowerBaseURL := strings.ToLower(strings.TrimSpace(baseURL))
 	if lowerBaseURL != "" && strings.Contains(lowerBaseURL, provider) {
 		return true
@@ -46,16 +51,19 @@ func isProviderReasoningCompatRequest(baseURL string, request *model.InternalLLM
 		return true
 	}
 
-	lowerModelName := strings.ToLower(strings.TrimSpace(request.Model))
-	if strings.Contains(lowerModelName, provider) {
-		return true
-	}
-
+	// MiMo keeps model-name fallback (xiaomi / mimo) because many MiMo gateways
+	// omit "mimo" from the host while still speaking the MiMo thinking schema.
+	// DeepSeek does not: require base URL or explicit endpoint_type=deepseek.
 	if provider == "mimo" {
-		return strings.Contains(lowerModelName, "xiaomi")
+		lowerModelName := strings.ToLower(strings.TrimSpace(request.Model))
+		return strings.Contains(lowerModelName, "mimo") || strings.Contains(lowerModelName, "xiaomi")
 	}
 
 	return false
+}
+
+func looksLikeDeepSeekModelName(modelName string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(modelName)), "deepseek")
 }
 
 func normalizeDeepSeekReasoningCompat(request *model.InternalLLMRequest, baseURL string, isMimoChannel bool) {

--- a/internal/transformer/outbound/openai/deepseek_test.go
+++ b/internal/transformer/outbound/openai/deepseek_test.go
@@ -150,15 +150,14 @@ func TestDeepSeekReasoningContentPreserved(t *testing.T) {
 		t.Error("First tool_calls message should have reasoning_content attached from standalone reasoning message")
 	}
 
-	// Verify extra_body does NOT force thinking:disabled when no reasoning_effort is set
-	if extraBody, ok := parsed["extra_body"]; ok {
-		eb, _ := extraBody.(map[string]interface{})
-		if thinking, hasThinking := eb["thinking"]; hasThinking {
-			th, _ := thinking.(map[string]interface{})
-			if thType, ok := th["type"].(string); ok && thType == "disabled" {
-				t.Error("extra_body.thinking.type should NOT be 'disabled' when reasoning_effort is not set. DeepSeek V4 defaults to thinking ON.")
-			}
+	// Verify thinking is not forced disabled when no reasoning_effort is set
+	if thinking, ok := parsed["thinking"].(map[string]interface{}); ok {
+		if thType, ok := thinking["type"].(string); ok && thType == "disabled" {
+			t.Error("thinking.type should NOT be 'disabled' when reasoning_effort is not set. DeepSeek V4 defaults to thinking ON.")
 		}
+	}
+	if _, hasExtra := parsed["extra_body"]; hasExtra {
+		t.Error("nested extra_body must not appear on the wire; thinking keys are top-level")
 	}
 }
 
@@ -203,7 +202,7 @@ func TestDeepSeekReasoningEffortEnablesThinking(t *testing.T) {
 	compatRequest := cloneRequestForOpenAICompat(request)
 	sanitizeRequestForOpenAICompat(compatRequest, "https://api.deepseek.com/v1", false)
 
-	body, err := transformer.Marshal(compatRequest)
+	body, err := marshalOpenAICompatRequest(compatRequest)
 	if err != nil {
 		t.Fatalf("marshal failed: %v", err)
 	}
@@ -216,18 +215,16 @@ func TestDeepSeekReasoningEffortEnablesThinking(t *testing.T) {
 	prettyJSON, _ := transformer.MarshalIndent(parsed, "", "  ")
 	t.Logf("Request JSON:\n%s", string(prettyJSON))
 
-	extraBody, ok := parsed["extra_body"].(map[string]interface{})
+	thinking, ok := parsed["thinking"].(map[string]interface{})
 	if !ok {
-		t.Fatal("extra_body should be present when reasoning_effort is set")
-	}
-
-	thinking, ok := extraBody["thinking"].(map[string]interface{})
-	if !ok {
-		t.Fatal("extra_body.thinking should be present when reasoning_effort is set")
+		t.Fatal("top-level thinking should be present when reasoning_effort is set")
 	}
 
 	if thType, ok := thinking["type"].(string); !ok || thType != "enabled" {
-		t.Errorf("extra_body.thinking.type should be 'enabled' when reasoning_effort is set, got: %v", thinking["type"])
+		t.Errorf("thinking.type should be 'enabled' when reasoning_effort is set, got: %v", thinking["type"])
+	}
+	if _, hasExtra := parsed["extra_body"]; hasExtra {
+		t.Error("nested extra_body must not appear on the wire")
 	}
 }
 
@@ -265,9 +262,12 @@ func TestDeepSeekNoThinkingWhenNotDetected(t *testing.T) {
 		t.Error("reasoning_content should be stripped for non-DeepSeek targets")
 	}
 
-	// extra_body should NOT be present for non-DeepSeek
+	// thinking/extra_body should NOT be present for non-DeepSeek
 	if _, hasExtra := parsed["extra_body"]; hasExtra {
 		t.Error("extra_body should be stripped for non-DeepSeek targets")
+	}
+	if _, hasThinking := parsed["thinking"]; hasThinking {
+		t.Error("thinking should be stripped for non-DeepSeek targets")
 	}
 }
 

--- a/internal/transformer/outbound/openai/jsoniter_omitempty_test.go
+++ b/internal/transformer/outbound/openai/jsoniter_omitempty_test.go
@@ -1,0 +1,55 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/lingyuins/octopus/internal/transformer"
+	"github.com/lingyuins/octopus/internal/transformer/model"
+)
+
+// Release builds use -tags=jsoniter. jsoniter ConfigCompatibleWithStandardLibrary
+// does not honor the encoding/json omitzero option, so pointer fields tagged
+// omitzero used to serialize as explicit nulls (e.g. "store":null). Strict
+// OpenAI-compat relays reject that with "store 类型错误".
+func TestChatOutboundOmitsNilStoreFamilyFields(t *testing.T) {
+	stream := true
+	req := &model.InternalLLMRequest{
+		Model:    "deepseek-v4-flash-0731",
+		Messages: []model.Message{{Role: "user", Content: model.MessageContent{Content: strPtr("hi")}}},
+		Stream:   &stream,
+		// Explicit zero-value pointers must stay omitted on the wire.
+		Store:            nil,
+		TopLogprobs:      nil,
+		PromptCacheKey:   nil,
+		SafetyIdentifier: nil,
+	}
+
+	httpReq, err := (&ChatOutbound{}).TransformRequest(context.Background(), req, "https://api.jzgo.top/v1/", "sk-test")
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+	body, err := io.ReadAll(httpReq.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	text := string(body)
+	for _, key := range []string{`"store"`, `"top_logprobs"`, `"prompt_cache_key"`, `"safety_identifier"`} {
+		if strings.Contains(text, key) {
+			t.Fatalf("outbound body must omit unset %s, got %s", key, text)
+		}
+	}
+
+	// Non-nil values still serialize (true/false), only nil is omitted.
+	storeFalse := false
+	req.Store = &storeFalse
+	body2, err := transformer.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if !strings.Contains(string(body2), `"store":false`) {
+		t.Fatalf("expected explicit false store, got %s", body2)
+	}
+}


### PR DESCRIPTION
## 改动动机

严格 OpenAI 兼容中继（如 new-api 等）对请求体非常挑剔，本 PR 修复两个实际线上踩到的 400 问题：

### 问题 1：`"store": null` → `store 类型错误`

**根因链路**：

| 层 | 行为 |
|----|------|
| Go 结构体 | `Store *bool \`json:"store,omitzero"\`` 等 4 个指针字段 |
| `encoding/json`（debug 构建） | nil 指针 **省略** 字段（不出 `store`） |
| **jsoniter**（release 构建 `-tags=jsoniter`） | **不识别 `omitzero`** → nil 编成 `"store":null` |
| 严格 OpenAI-compat 上游 | 期望 `store` 是 bool 或不出现；`null ≠ bool` → **400 store 类型错误** |

同类字段还有 `top_logprobs`、`prompt_cache_key`、`safety_identifier`（OpenAI 可选请求参数，日常未设置时全部会带 `null`）。

### 问题 2：嵌套 `extra_body` + DeepSeek 判定误伤

- DeepSeek 官方文档明确 `extra_body` 是 **SDK 客户端概念**，HTTP body 必须把其中键（如 `thinking`）放**顶层**。Octopus 此前把 `ExtraBody` 原样序列化，形成嵌套 `"extra_body":{...}`，官方 API 与严格中继直接 400（`未知请求字段：extra_body`）。
- `isProviderReasoningCompatRequest` 仅凭模型名含 "deepseek" 就判定为 reasoning 兼容目标，导致 Octopus 向**严格 OpenAI-compat 代理**（暴露 `deepseek-*` 别名但拒绝这些字段)注入 `reasoning_effort` / `thinking`，同样 400。

## 改动内容与影响范围

全部改动位于 `internal/transformer/`（出站转换层），共 6 个文件，无前端改动、无路由/计费改动。

### 1. extra_body 展平为顶层键（fix）
- `internal/transformer/outbound/openai/chat.go`：
  - 新增 `marshalOpenAICompatRequest()` —— 序列化前临时摘除 `ExtraBody`，序列化后将其键展开合并进顶层 payload，并删除 `extra_body` 键。
  - `TransformRequest` 改用该函数。
- 同步更新 `chat_test.go`。

### 2. DeepSeek reasoning 判定收紧（fix）
- `internal/transformer/outbound/openai/deepseek.go`：
  - `isProviderReasoningCompatRequest` 移除 DeepSeek 的**模型名兜底匹配**，仅以 baseURL 含 deepseek 或显式 `endpoint_type=deepseek` 判定（reasoning 控制是上游 wire 格式特性，不是客户端模型别名特性）。
  - 新增 `looksLikeDeepSeekModelName()` 辅助函数。
- `chat.go` 的 `SanitizeRequestForOpenAICompat`：非 reasoning 目标上遇到 `deepseek-*` 模型名时清空 `ReasoningEffort`（严格中继拒绝该字段），其余模型仍走 `normalizeOpenAICompatReasoningEffort` 归一化。
- 同步更新 `deepseek_test.go`。

### 3. store 系列字段 omitzero → omitempty（fix）
- `internal/transformer/model/model.go`：`Store`、`TopLogprobs`、`PromptCacheKey`、`SafetyIdentifier` 四个字段的 json tag 由 `omitzero` 改为 `omitempty`。
  - 原因：jsoniter `ConfigCompatibleWithStandardLibrary` 不识别 `omitzero`，nil 指针会输出 `null`；`omitempty` 对指针/字符串语义相同（nil 即省略），两个序列化路径行为对齐。
- 新增 `internal/transformer/outbound/openai/jsoniter_omitempty_test.go` 覆盖 jsoniter 路径下 nil 字段被省略的断言。

## 对各供应商的影响（评估）

### omit-null：序列化正确性修复（防御性、全局）
只动 4 个**未赋值**字段的 JSON 外观：`store` / `top_logprobs` / `prompt_cache_key` / `safety_identifier`。未设置 → 字段不出现；显式有值 → 行为不变。

| 供应商类型 | 影响 |
|------------|------|
| OpenAI 官方 | 中性～正面（默认本就不该传 null） |
| 严格 OpenAI-compat（ new-api ） | **正面**（正是修复目标） |
| Claude / Gemini / 火山 / 自有协议 | 非 OpenAI chat 序列化则无关；经 OpenAI 形态转发也只是少传垃圾 null |
| 依赖「显式 null 表示关闭」的怪实现 | 理论上可能变（极少见，官方/主流都不这么干） |

### extra_body flatten：只影响 OpenAI-compat chat 出站
| 场景 | 影响 |
|------|------|
| ExtraBody 为空（多数供应商日常） | **零行为差**（早返回） |
| 真 DeepSeek / 要 `thinking` 的上游 | **正面**（官方要求 top-level） |
| 严格中转（拒 `extra_body`） | **正面** |
| 只认嵌套 `extra_body`、拒 top-level 自定义键的上游 | 负面（极少；违反 OpenAI/DeepSeek 常规） |

### DeepSeek 门控收紧：影响面在「名字像 deepseek、上游却不是 DeepSeek」
| 场景 | 影响 |
|------|------|
| 真 DeepSeek（`api.deepseek.com` 等） | 仍识别（baseURL 含 deepseek），应无回归 |
| `endpoint_type=deepseek` 渠道 | 仍识别 |
| 严格中转 + `deepseek-*` 别名 | **正面**（不再乱注入 thinking/effort） |
| host 不含 deepseek、没设 endpoint_type，但要真 DeepSeek thinking wire | **可能变差** → 需设 `endpoint_type=deepseek` 或换 base（修复的刻意取舍） |
| OpenAI / Claude / 普通中转 | 不走 DeepSeek 分支，基本无感 |

## 验证

- `go build ./...` 通过。
- `go test ./internal/transformer/...` 全部通过（含 openai / mimo 子包）。
- 已在线验证：组合包上线后，柠檬→jzgo 渠道 400 消失，消息从 `store 类型错误` 变为正常响应（见 openai-compat-jsoniter-null skill 记录）。

## 风险与兼容性

- **未改动**：temperature、tools、流式、计费、渠道路由本身；未给非 DeepSeek 供应商强加新字段。
- **行为变化面窄**：`omitzero → omitempty` 仅影响 nil 指针字段的序列化结果（null → 省略），有值字段输出不变；标准库 json 路径行为不变。
- **迁移注意**：第三方「host 不含 deepseek 但要真 DeepSeek thinking」的渠道需显式配置 `endpoint_type=deepseek`（或 baseURL 含 deepseek），这是收紧误判的刻意取舍。