### PR TITLE
feat: 主页今日使用卡片重构并新增缓存指标

### DIFF
--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -1274,7 +1274,8 @@
         "requests": "Today's Calls",
         "successRate": "Today's Success Rate",
         "cost": "Today's Spend",
-        "cacheReadTokens": "Today's Cache Reuse"
+        "cacheReadTokens": "Today's Cache Reuse",
+        "successRateShort": "Success Rate"
       },
       "metrics": {
         "avgWait": "Average Response Time",

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -1273,7 +1273,8 @@
       "signals": {
         "requests": "Today's Calls",
         "successRate": "Today's Success Rate",
-        "cost": "Today's Spend"
+        "cost": "Today's Spend",
+        "cacheReadTokens": "Today's Cache Reuse"
       },
       "metrics": {
         "avgWait": "Average Response Time",

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -1276,7 +1276,7 @@
         "cost": "Today's Spend",
         "cacheReadTokens": "Today's Cache Reuse",
         "successRateShort": "Success Rate",
-        "cacheRate": "Today's Cache Rate",
+        "cacheRate": "Today's Token Usage",
         "cacheRateShort": "Cache Rate"
       },
       "metrics": {

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -1275,7 +1275,9 @@
         "successRate": "Today's Success Rate",
         "cost": "Today's Spend",
         "cacheReadTokens": "Today's Cache Reuse",
-        "successRateShort": "Success Rate"
+        "successRateShort": "Success Rate",
+        "cacheRate": "Today's Cache Rate",
+        "cacheRateShort": "Cache Rate"
       },
       "metrics": {
         "avgWait": "Average Response Time",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -1231,7 +1231,9 @@
         "successRate": "今日成功率",
         "cost": "今日花费",
         "cacheReadTokens": "今日缓存复用",
-        "successRateShort": "成功率"
+        "successRateShort": "成功率",
+        "cacheRate": "今日缓存率",
+        "cacheRateShort": "缓存率"
       },
       "metrics": {
         "avgWait": "平均响应时延",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -1232,7 +1232,7 @@
         "cost": "今日花费",
         "cacheReadTokens": "今日缓存复用",
         "successRateShort": "成功率",
-        "cacheRate": "今日缓存率",
+        "cacheRate": "今日Token使用",
         "cacheRateShort": "缓存率"
       },
       "metrics": {

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -1230,7 +1230,8 @@
         "requests": "今日调用",
         "successRate": "今日成功率",
         "cost": "今日花费",
-        "cacheReadTokens": "今日缓存复用"
+        "cacheReadTokens": "今日缓存复用",
+        "successRateShort": "成功率"
       },
       "metrics": {
         "avgWait": "平均响应时延",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -1229,7 +1229,8 @@
       "signals": {
         "requests": "今日调用",
         "successRate": "今日成功率",
-        "cost": "今日花费"
+        "cost": "今日花费",
+        "cacheReadTokens": "今日缓存复用"
       },
       "metrics": {
         "avgWait": "平均响应时延",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -1229,7 +1229,8 @@
       "signals": {
         "requests": "今日呼叫",
         "successRate": "今日成功率",
-        "cost": "今日花費"
+        "cost": "今日花費",
+        "cacheReadTokens": "今日快取復用"
       },
       "metrics": {
         "avgWait": "平均回應時延",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -1230,7 +1230,8 @@
         "requests": "今日呼叫",
         "successRate": "今日成功率",
         "cost": "今日花費",
-        "cacheReadTokens": "今日快取復用"
+        "cacheReadTokens": "今日快取復用",
+        "successRateShort": "成功率"
       },
       "metrics": {
         "avgWait": "平均回應時延",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -1232,7 +1232,7 @@
         "cost": "今日花費",
         "cacheReadTokens": "今日快取復用",
         "successRateShort": "成功率",
-        "cacheRate": "今日快取率",
+        "cacheRate": "今日Token使用",
         "cacheRateShort": "快取率"
       },
       "metrics": {

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -1231,7 +1231,9 @@
         "successRate": "今日成功率",
         "cost": "今日花費",
         "cacheReadTokens": "今日快取復用",
-        "successRateShort": "成功率"
+        "successRateShort": "成功率",
+        "cacheRate": "今日快取率",
+        "cacheRateShort": "快取率"
       },
       "metrics": {
         "avgWait": "平均回應時延",

--- a/web/src/components/modules/home/hero.tsx
+++ b/web/src/components/modules/home/hero.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'motion/react';
-import { Activity, Coins, DollarSign, HardDrive, Receipt, Timer, Waves } from 'lucide-react';
+import { Activity, DollarSign, HardDrive, Timer, Waves } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useStatsToday } from '@/api/endpoints/stats';
 import { useOpsCacheStatus, type OpsProviderPromptCacheTrendPoint } from '@/api/endpoints/ops';
@@ -20,6 +20,7 @@ export function HomeHero() {
     const requestCount = (statsToday?.request_success ?? 0) + (statsToday?.request_failed ?? 0);
     const successCount = statsToday?.request_success ?? 0;
     const totalCost = (statsToday?.input_cost ?? 0) + (statsToday?.output_cost ?? 0);
+    const totalTokens = (statsToday?.input_token ?? 0) + (statsToday?.output_token ?? 0);
     const totalWaitTime = statsToday?.wait_time ?? 0;
     const successRate = requestCount > 0 ? (successCount / requestCount) * 100 : 0;
     const avgWait = requestCount > 0 ? totalWaitTime / requestCount : 0;
@@ -30,12 +31,14 @@ export function HomeHero() {
     const todayCacheReadTokens = cacheTrend
         .filter((point) => point.timestamp >= Math.floor(new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate()).getTime() / 1000))
         .reduce((sum, point) => sum + (point.cache_read_tokens ?? 0), 0);
-    const todayCacheRead = formatCount(todayCacheReadTokens);
+    const cacheRate = totalTokens > 0 ? (todayCacheReadTokens / totalTokens) * 100 : 0;
 
-    // 统一 2 列网格卡片：metrics 与 signals 混合排列。
-    // 调用类三指标（成功调用/今日调用/今日成功率）合并为一张复合卡：成功值 / 总数 + 成功率。
     const callsSuccess = formatCount(successCount).formatted;
     const callsTotal = formatCount(requestCount).formatted;
+    const cacheRead = formatCount(todayCacheReadTokens).formatted;
+    const tokens = formatCount(totalTokens).formatted;
+
+    // 2 列 × 2 行：第一行普通指标（平均响应时延 / 今日花费），第二行复合卡（今日调用 / 今日缓存率）。
     const cards = [
         {
             key: 'avgWait',
@@ -46,48 +49,38 @@ export function HomeHero() {
             accent: 'bg-violet-500/10 text-violet-700',
         },
         {
-            key: 'calls',
-            label: t('signals.requests'),
-            icon: Activity,
-            accent: 'bg-emerald-500/10 text-emerald-700',
-            isSummary: true,
-            successValue: callsSuccess.value,
-            successUnit: callsSuccess.unit,
-            totalValue: callsTotal.value,
-            totalUnit: callsTotal.unit,
-            rate: successRate.toFixed(2),
-        },
-        {
-            key: 'tokens',
-            label: t('metrics.tokens'),
-            value: formatCount((statsToday?.input_token ?? 0) + (statsToday?.output_token ?? 0)).formatted.value,
-            unit: formatCount((statsToday?.input_token ?? 0) + (statsToday?.output_token ?? 0)).formatted.unit,
-            icon: Coins,
-            accent: 'bg-indigo-500/10 text-indigo-700',
-        },
-        {
-            key: 'cacheReadTokens',
-            label: t('signals.cacheReadTokens'),
-            value: todayCacheRead.formatted.value,
-            unit: todayCacheRead.formatted.unit,
-            icon: HardDrive,
-            accent: 'bg-sky-500/10 text-sky-700',
-        },
-        {
-            key: 'costPerReq',
-            label: t('metrics.costPerRequest'),
-            value: formatMoney(requestCount > 0 ? totalCost / requestCount : 0).formatted.value,
-            unit: formatMoney(requestCount > 0 ? totalCost / requestCount : 0).formatted.unit,
-            icon: Receipt,
-            accent: 'bg-rose-500/10 text-rose-700',
-        },
-        {
             key: 'cost',
             label: t('signals.cost'),
             value: formatMoney(totalCost).formatted.value,
             unit: formatMoney(totalCost).formatted.unit,
             icon: DollarSign,
             accent: 'bg-amber-500/10 text-amber-700',
+        },
+        {
+            key: 'calls',
+            label: t('signals.requests'),
+            icon: Activity,
+            accent: 'bg-emerald-500/10 text-emerald-700',
+            isComposite: true,
+            mainValue: callsSuccess.value,
+            mainUnit: callsSuccess.unit,
+            dividerValue: callsTotal.value,
+            dividerUnit: callsTotal.unit,
+            rate: successRate.toFixed(2),
+            rateLabel: t('signals.successRateShort'),
+        },
+        {
+            key: 'cacheRate',
+            label: t('signals.cacheRate'),
+            icon: HardDrive,
+            accent: 'bg-sky-500/10 text-sky-700',
+            isComposite: true,
+            mainValue: cacheRead.value,
+            mainUnit: cacheRead.unit,
+            dividerValue: tokens.value,
+            dividerUnit: tokens.unit,
+            rate: cacheRate.toFixed(2),
+            rateLabel: t('signals.cacheRateShort'),
         },
     ];
 
@@ -134,19 +127,19 @@ export function HomeHero() {
                                 </div>
                             </div>
                             <div className="mt-5 text-xs text-muted-foreground">{card.label}</div>
-                            {card.isSummary ? (
+                            {card.isComposite ? (
                                 <div className="mt-2 space-y-1">
                                     <div className="flex items-baseline gap-1.5">
                                         <span className="text-xl font-semibold tracking-tight sm:text-2xl">
-                                            <AnimatedNumber value={card.successValue} />
-                                            {card.successUnit ? <span className="text-sm text-muted-foreground">{card.successUnit}</span> : null}
+                                            <AnimatedNumber value={card.mainValue} />
+                                            {card.mainUnit ? <span className="text-sm text-muted-foreground">{card.mainUnit}</span> : null}
                                         </span>
                                         <span className="text-sm text-muted-foreground">
-                                            / {card.totalValue}{card.totalUnit}
+                                            / {card.dividerValue}{card.dividerUnit}
                                         </span>
                                     </div>
                                     <div className="text-xs text-muted-foreground">
-                                        {t('signals.successRateShort')} {card.rate}%
+                                        {card.rateLabel} {card.rate}%
                                     </div>
                                 </div>
                             ) : (

--- a/web/src/components/modules/home/hero.tsx
+++ b/web/src/components/modules/home/hero.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'motion/react';
-import { Activity, DollarSign, HardDrive, Timer, Waves } from 'lucide-react';
+import { Waves } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useStatsToday } from '@/api/endpoints/stats';
 import { useOpsCacheStatus, type OpsProviderPromptCacheTrendPoint } from '@/api/endpoints/ops';
@@ -38,29 +38,23 @@ export function HomeHero() {
     const cacheRead = formatCount(todayCacheReadTokens).formatted;
     const tokens = formatCount(totalTokens).formatted;
 
-    // 2 列 × 2 行：第一行普通指标（平均响应时延 / 今日花费），第二行复合卡（今日调用 / 今日缓存率）。
+    // 2 列 × 2 行：第一行普通指标（平均响应时延 / 今日花费），第二行复合卡（今日调用 / 今日Token使用）。
     const cards = [
         {
             key: 'avgWait',
             label: t('metrics.avgWait'),
             value: formatTime(avgWait).formatted.value,
             unit: formatTime(avgWait).formatted.unit,
-            icon: Timer,
-            accent: 'bg-violet-500/10 text-violet-700',
         },
         {
             key: 'cost',
             label: t('signals.cost'),
             value: formatMoney(totalCost).formatted.value,
             unit: formatMoney(totalCost).formatted.unit,
-            icon: DollarSign,
-            accent: 'bg-amber-500/10 text-amber-700',
         },
         {
             key: 'calls',
             label: t('signals.requests'),
-            icon: Activity,
-            accent: 'bg-emerald-500/10 text-emerald-700',
             isComposite: true,
             mainValue: callsSuccess.value,
             mainUnit: callsSuccess.unit,
@@ -72,8 +66,6 @@ export function HomeHero() {
         {
             key: 'cacheRate',
             label: t('signals.cacheRate'),
-            icon: HardDrive,
-            accent: 'bg-sky-500/10 text-sky-700',
             isComposite: true,
             mainValue: cacheRead.value,
             mainUnit: cacheRead.unit,
@@ -119,16 +111,12 @@ export function HomeHero() {
                     {cards.map((card) => (
                         <article
                             key={card.key}
-                            className="group rounded-lg border border-border bg-card p-3 sm:p-4 transition-[transform,border-color] duration-300 hover:-translate-y-0.5 hover:border-border/80"
+                            className="group rounded-lg border border-border bg-card px-3 py-2.5 transition-colors duration-200 hover:border-border/80 hover:bg-muted/30 sm:px-4 sm:py-3"
                         >
-                            <div className="flex items-start justify-between gap-3">
-                                <div className={`flex h-10 w-10 items-center justify-center rounded-lg ${card.accent}`}>
-                                    <card.icon className="h-[1.125rem] w-[1.125rem]" strokeWidth={1.5} />
-                                </div>
-                            </div>
-                            <div className="mt-5 text-xs text-muted-foreground">{card.label}</div>
+                            <div className="mb-2 h-1 w-10 rounded-full bg-primary/20 transition-all duration-300 group-hover:w-14 group-hover:bg-primary/30" />
+                            <div className="text-xs font-medium text-muted-foreground">{card.label}</div>
                             {card.isComposite ? (
-                                <div className="mt-2 space-y-1">
+                                <div className="mt-1 space-y-0.5">
                                     <div className="flex items-baseline gap-1.5">
                                         <span className="text-xl font-semibold tracking-tight sm:text-2xl">
                                             <AnimatedNumber value={card.mainValue} />
@@ -143,8 +131,8 @@ export function HomeHero() {
                                     </div>
                                 </div>
                             ) : (
-                                <div className="mt-2 flex items-baseline gap-1">
-                                    <span className="text-2xl font-semibold tracking-tight">
+                                <div className="mt-1 flex items-baseline gap-1">
+                                    <span className="text-xl font-semibold tracking-tight sm:text-2xl">
                                         <AnimatedNumber value={card.value} />
                                     </span>
                                     {card.unit ? <span className="text-sm text-muted-foreground">{card.unit}</span> : null}

--- a/web/src/components/modules/home/hero.tsx
+++ b/web/src/components/modules/home/hero.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'motion/react';
-import { Activity, DollarSign, HardDrive, ShieldCheck, Waves } from 'lucide-react';
+import { Activity, CheckCircle2, Coins, DollarSign, HardDrive, Receipt, ShieldCheck, Timer, Waves } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useStatsToday } from '@/api/endpoints/stats';
 import { useOpsCacheStatus, type OpsProviderPromptCacheTrendPoint } from '@/api/endpoints/ops';
@@ -32,7 +32,40 @@ export function HomeHero() {
         .reduce((sum, point) => sum + (point.cache_read_tokens ?? 0), 0);
     const todayCacheRead = formatCount(todayCacheReadTokens);
 
-    const signals = [
+    // 统一 2 列 × 4 行卡片网格：metrics 与 signals 混合排列
+    const cards = [
+        {
+            key: 'avgWait',
+            label: t('metrics.avgWait'),
+            value: formatTime(avgWait).formatted.value,
+            unit: formatTime(avgWait).formatted.unit,
+            icon: Timer,
+            accent: 'bg-violet-500/10 text-violet-700',
+        },
+        {
+            key: 'successful',
+            label: t('metrics.successful'),
+            value: formatCount(successCount).formatted.value,
+            unit: formatCount(successCount).formatted.unit,
+            icon: CheckCircle2,
+            accent: 'bg-teal-500/10 text-teal-700',
+        },
+        {
+            key: 'tokens',
+            label: t('metrics.tokens'),
+            value: formatCount((statsToday?.input_token ?? 0) + (statsToday?.output_token ?? 0)).formatted.value,
+            unit: formatCount((statsToday?.input_token ?? 0) + (statsToday?.output_token ?? 0)).formatted.unit,
+            icon: Coins,
+            accent: 'bg-indigo-500/10 text-indigo-700',
+        },
+        {
+            key: 'cacheReadTokens',
+            label: t('signals.cacheReadTokens'),
+            value: todayCacheRead.formatted.value,
+            unit: todayCacheRead.formatted.unit,
+            icon: HardDrive,
+            accent: 'bg-sky-500/10 text-sky-700',
+        },
         {
             key: 'requests',
             label: t('signals.requests'),
@@ -50,47 +83,20 @@ export function HomeHero() {
             accent: 'bg-primary/10 text-primary',
         },
         {
+            key: 'costPerReq',
+            label: t('metrics.costPerRequest'),
+            value: formatMoney(requestCount > 0 ? totalCost / requestCount : 0).formatted.value,
+            unit: formatMoney(requestCount > 0 ? totalCost / requestCount : 0).formatted.unit,
+            icon: Receipt,
+            accent: 'bg-rose-500/10 text-rose-700',
+        },
+        {
             key: 'cost',
             label: t('signals.cost'),
             value: formatMoney(totalCost).formatted.value,
             unit: formatMoney(totalCost).formatted.unit,
             icon: DollarSign,
             accent: 'bg-amber-500/10 text-amber-700',
-        },
-        {
-            key: 'cacheReadTokens',
-            label: t('signals.cacheReadTokens'),
-            value: todayCacheRead.formatted.value,
-            unit: todayCacheRead.formatted.unit,
-            icon: HardDrive,
-            accent: 'bg-sky-500/10 text-sky-700',
-        },
-    ];
-
-    const metrics = [
-        {
-            key: 'avgWait',
-            label: t('metrics.avgWait'),
-            value: formatTime(avgWait).formatted.value,
-            unit: formatTime(avgWait).formatted.unit,
-        },
-        {
-            key: 'successful',
-            label: t('metrics.successful'),
-            value: formatCount(successCount).formatted.value,
-            unit: formatCount(successCount).formatted.unit,
-        },
-        {
-            key: 'tokens',
-            label: t('metrics.tokens'),
-            value: formatCount((statsToday?.input_token ?? 0) + (statsToday?.output_token ?? 0)).formatted.value,
-            unit: formatCount((statsToday?.input_token ?? 0) + (statsToday?.output_token ?? 0)).formatted.unit,
-        },
-        {
-            key: 'costPerReq',
-            label: t('metrics.costPerRequest'),
-            value: formatMoney(requestCount > 0 ? totalCost / requestCount : 0).formatted.value,
-            unit: formatMoney(requestCount > 0 ? totalCost / requestCount : 0).formatted.unit,
         },
     ];
 
@@ -101,64 +107,47 @@ export function HomeHero() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.45, ease: EASING.easeOutExpo }}
         >
-            <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(20rem,0.88fr)]">
-                <div className="space-y-5">
-                    <div className="space-y-3">
-                        <div className="flex flex-wrap items-center justify-between gap-3 sm:gap-4">
-                            <div className="flex items-center gap-3 sm:gap-4">
-                                <div className="grid h-11 w-11 sm:h-14 sm:w-14 shrink-0 place-items-center overflow-hidden rounded-lg border border-border bg-card text-primary">
-                                    <Waves className="h-5 w-5 sm:h-6 sm:w-6" strokeWidth={1.5} />
-                                </div>
-                                <div className="space-y-1">
-                                    <h1 className="text-[1.65rem] font-semibold tracking-tight sm:text-2xl md:text-3xl lg:text-4xl">{t('title')}</h1>
-                                    {t('subtitle') ? (
-                                        <p className="text-sm leading-6 text-muted-foreground md:text-base">{t('subtitle')}</p>
-                                    ) : null}
-                                </div>
+            <div className="space-y-5">
+                <div className="space-y-3">
+                    <div className="flex flex-wrap items-center justify-between gap-3 sm:gap-4">
+                        <div className="flex items-center gap-3 sm:gap-4">
+                            <div className="grid h-11 w-11 sm:h-14 sm:w-14 shrink-0 place-items-center overflow-hidden rounded-lg border border-border bg-card text-primary">
+                                <Waves className="h-5 w-5 sm:h-6 sm:w-6" strokeWidth={1.5} />
                             </div>
-                            <StatsRefreshControls />
+                            <div className="space-y-1">
+                                <h1 className="text-[1.65rem] font-semibold tracking-tight sm:text-2xl md:text-3xl lg:text-4xl">{t('title')}</h1>
+                                {t('subtitle') ? (
+                                    <p className="text-sm leading-6 text-muted-foreground md:text-base">{t('subtitle')}</p>
+                                ) : null}
+                            </div>
                         </div>
-
-                        {t('description') ? (
-                            <p className="max-w-2xl text-sm leading-7 text-muted-foreground md:text-[15px]">
-                                {t('description')}
-                            </p>
-                        ) : null}
+                        <StatsRefreshControls />
                     </div>
 
-                    <div className="grid grid-cols-2 gap-2.5 sm:gap-3 xl:grid-cols-4">
-                        {metrics.map((metric) => (
-                            <div key={metric.key} className="group rounded-lg border border-border bg-card px-3 py-2.5 transition-colors duration-200 hover:border-border/80 hover:bg-muted/30 sm:px-4 sm:py-3">
-                                <div className="mb-2 h-1 w-10 rounded-full bg-primary/20 transition-all duration-300 group-hover:w-14 group-hover:bg-primary/30" />
-                                <div className="text-xs font-medium text-muted-foreground">{metric.label}</div>
-                                <div className="mt-1 flex items-baseline gap-1">
-                                    <span className="text-xl font-semibold sm:text-2xl">
-                                        <AnimatedNumber value={metric.value} />
-                                    </span>
-                                    {metric.unit ? <span className="text-sm text-muted-foreground">{metric.unit}</span> : null}
-                                </div>
-                            </div>
-                        ))}
-                    </div>
+                    {t('description') ? (
+                        <p className="max-w-2xl text-sm leading-7 text-muted-foreground md:text-[15px]">
+                            {t('description')}
+                        </p>
+                    ) : null}
                 </div>
 
-                <div className="grid grid-cols-2 gap-2.5 sm:gap-3 xl:grid-cols-4">
-                    {signals.map((signal) => (
+                <div className="grid grid-cols-2 gap-2.5 sm:gap-3">
+                    {cards.map((card) => (
                         <article
-                            key={signal.key}
+                            key={card.key}
                             className="group rounded-lg border border-border bg-card p-3 sm:p-4 transition-[transform,border-color] duration-300 hover:-translate-y-0.5 hover:border-border/80"
                         >
                             <div className="flex items-start justify-between gap-3">
-                                <div className={`flex h-10 w-10 items-center justify-center rounded-lg ${signal.accent}`}>
-                                    <signal.icon className="h-[1.125rem] w-[1.125rem]" strokeWidth={1.5} />
+                                <div className={`flex h-10 w-10 items-center justify-center rounded-lg ${card.accent}`}>
+                                    <card.icon className="h-[1.125rem] w-[1.125rem]" strokeWidth={1.5} />
                                 </div>
                             </div>
-                            <div className="mt-5 text-xs text-muted-foreground">{signal.label}</div>
+                            <div className="mt-5 text-xs text-muted-foreground">{card.label}</div>
                             <div className="mt-2 flex items-baseline gap-1">
                                 <span className="text-2xl font-semibold tracking-tight">
-                                    <AnimatedNumber value={signal.value} />
+                                    <AnimatedNumber value={card.value} />
                                 </span>
-                                {signal.unit ? <span className="text-sm text-muted-foreground">{signal.unit}</span> : null}
+                                {card.unit ? <span className="text-sm text-muted-foreground">{card.unit}</span> : null}
                             </div>
                         </article>
                     ))}

--- a/web/src/components/modules/home/hero.tsx
+++ b/web/src/components/modules/home/hero.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { motion } from 'motion/react';
-import { Activity, DollarSign, ShieldCheck, Waves } from 'lucide-react';
+import { Activity, DollarSign, HardDrive, ShieldCheck, Waves } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useStatsToday } from '@/api/endpoints/stats';
+import { useOpsCacheStatus, type OpsProviderPromptCacheTrendPoint } from '@/api/endpoints/ops';
 import { useHomeStatsRefreshMs } from './store';
 import { StatsRefreshControls } from './refresh-controls';
 import { AnimatedNumber } from '@/components/common/AnimatedNumber';
@@ -14,6 +15,7 @@ export function HomeHero() {
     const t = useTranslations('home.hero');
     const statsRefreshMs = useHomeStatsRefreshMs();
     const { data: statsToday } = useStatsToday({ refetchIntervalMs: statsRefreshMs });
+    const { data: cacheStatus } = useOpsCacheStatus();
 
     const requestCount = (statsToday?.request_success ?? 0) + (statsToday?.request_failed ?? 0);
     const successCount = statsToday?.request_success ?? 0;
@@ -21,6 +23,14 @@ export function HomeHero() {
     const totalWaitTime = statsToday?.wait_time ?? 0;
     const successRate = requestCount > 0 ? (successCount / requestCount) * 100 : 0;
     const avgWait = requestCount > 0 ? totalWaitTime / requestCount : 0;
+
+    // 今日缓存复用 Tokens：对 provider prompt cache 的 24h 趋势点求和（timestamp >= 本地时区今日 0 点）。
+    // trend 按 UTC 整点对齐（后端 opsHourlyWindowStart），+8 时区下今日 0 点恰为整点边界，过滤无污染。
+    const cacheTrend = cacheStatus?.provider_prompt_cache?.trend ?? ([] as OpsProviderPromptCacheTrendPoint[]);
+    const todayCacheReadTokens = cacheTrend
+        .filter((point) => point.timestamp >= Math.floor(new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate()).getTime() / 1000))
+        .reduce((sum, point) => sum + (point.cache_read_tokens ?? 0), 0);
+    const todayCacheRead = formatCount(todayCacheReadTokens);
 
     const signals = [
         {
@@ -46,6 +56,14 @@ export function HomeHero() {
             unit: formatMoney(totalCost).formatted.unit,
             icon: DollarSign,
             accent: 'bg-amber-500/10 text-amber-700',
+        },
+        {
+            key: 'cacheReadTokens',
+            label: t('signals.cacheReadTokens'),
+            value: todayCacheRead.formatted.value,
+            unit: todayCacheRead.formatted.unit,
+            icon: HardDrive,
+            accent: 'bg-sky-500/10 text-sky-700',
         },
     ];
 
@@ -124,11 +142,11 @@ export function HomeHero() {
                     </div>
                 </div>
 
-                <div className="grid grid-cols-2 gap-2.5 sm:gap-3 xl:grid-cols-3">
-                    {signals.map((signal, index) => (
+                <div className="grid grid-cols-2 gap-2.5 sm:gap-3 xl:grid-cols-4">
+                    {signals.map((signal) => (
                         <article
                             key={signal.key}
-                            className={`group rounded-lg border border-border bg-card p-3 sm:p-4 transition-[transform,border-color] duration-300 hover:-translate-y-0.5 hover:border-border/80 ${index === 0 ? 'col-span-2 sm:col-span-1' : ''}`}
+                            className="group rounded-lg border border-border bg-card p-3 sm:p-4 transition-[transform,border-color] duration-300 hover:-translate-y-0.5 hover:border-border/80"
                         >
                             <div className="flex items-start justify-between gap-3">
                                 <div className={`flex h-10 w-10 items-center justify-center rounded-lg ${signal.accent}`}>

--- a/web/src/components/modules/home/hero.tsx
+++ b/web/src/components/modules/home/hero.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'motion/react';
-import { Activity, CheckCircle2, Coins, DollarSign, HardDrive, Receipt, ShieldCheck, Timer, Waves } from 'lucide-react';
+import { Activity, Coins, DollarSign, HardDrive, Receipt, Timer, Waves } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useStatsToday } from '@/api/endpoints/stats';
 import { useOpsCacheStatus, type OpsProviderPromptCacheTrendPoint } from '@/api/endpoints/ops';
@@ -32,7 +32,10 @@ export function HomeHero() {
         .reduce((sum, point) => sum + (point.cache_read_tokens ?? 0), 0);
     const todayCacheRead = formatCount(todayCacheReadTokens);
 
-    // 统一 2 列 × 4 行卡片网格：metrics 与 signals 混合排列
+    // 统一 2 列网格卡片：metrics 与 signals 混合排列。
+    // 调用类三指标（成功调用/今日调用/今日成功率）合并为一张复合卡：成功值 / 总数 + 成功率。
+    const callsSuccess = formatCount(successCount).formatted;
+    const callsTotal = formatCount(requestCount).formatted;
     const cards = [
         {
             key: 'avgWait',
@@ -43,12 +46,16 @@ export function HomeHero() {
             accent: 'bg-violet-500/10 text-violet-700',
         },
         {
-            key: 'successful',
-            label: t('metrics.successful'),
-            value: formatCount(successCount).formatted.value,
-            unit: formatCount(successCount).formatted.unit,
-            icon: CheckCircle2,
-            accent: 'bg-teal-500/10 text-teal-700',
+            key: 'calls',
+            label: t('signals.requests'),
+            icon: Activity,
+            accent: 'bg-emerald-500/10 text-emerald-700',
+            isSummary: true,
+            successValue: callsSuccess.value,
+            successUnit: callsSuccess.unit,
+            totalValue: callsTotal.value,
+            totalUnit: callsTotal.unit,
+            rate: successRate.toFixed(2),
         },
         {
             key: 'tokens',
@@ -65,22 +72,6 @@ export function HomeHero() {
             unit: todayCacheRead.formatted.unit,
             icon: HardDrive,
             accent: 'bg-sky-500/10 text-sky-700',
-        },
-        {
-            key: 'requests',
-            label: t('signals.requests'),
-            value: formatCount(requestCount).formatted.value,
-            unit: formatCount(requestCount).formatted.unit,
-            icon: Activity,
-            accent: 'bg-emerald-500/10 text-emerald-700',
-        },
-        {
-            key: 'successRate',
-            label: t('signals.successRate'),
-            value: successRate.toFixed(2),
-            unit: '%',
-            icon: ShieldCheck,
-            accent: 'bg-primary/10 text-primary',
         },
         {
             key: 'costPerReq',
@@ -143,12 +134,29 @@ export function HomeHero() {
                                 </div>
                             </div>
                             <div className="mt-5 text-xs text-muted-foreground">{card.label}</div>
-                            <div className="mt-2 flex items-baseline gap-1">
-                                <span className="text-2xl font-semibold tracking-tight">
-                                    <AnimatedNumber value={card.value} />
-                                </span>
-                                {card.unit ? <span className="text-sm text-muted-foreground">{card.unit}</span> : null}
-                            </div>
+                            {card.isSummary ? (
+                                <div className="mt-2 space-y-1">
+                                    <div className="flex items-baseline gap-1.5">
+                                        <span className="text-xl font-semibold tracking-tight sm:text-2xl">
+                                            <AnimatedNumber value={card.successValue} />
+                                            {card.successUnit ? <span className="text-sm text-muted-foreground">{card.successUnit}</span> : null}
+                                        </span>
+                                        <span className="text-sm text-muted-foreground">
+                                            / {card.totalValue}{card.totalUnit}
+                                        </span>
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">
+                                        {t('signals.successRateShort')} {card.rate}%
+                                    </div>
+                                </div>
+                            ) : (
+                                <div className="mt-2 flex items-baseline gap-1">
+                                    <span className="text-2xl font-semibold tracking-tight">
+                                        <AnimatedNumber value={card.value} />
+                                    </span>
+                                    {card.unit ? <span className="text-sm text-muted-foreground">{card.unit}</span> : null}
+                                </div>
+                            )}
                         </article>
                     ))}
                 </div>


### PR DESCRIPTION
对主页「今日使用」卡片进行了完全重构，并移除了意义不大的「单次调用成本」指标。请上游自行评估是否合并。本次修改是纯前端改动。

## 改动内容

- 新增「今日缓存复用 / 今日Token使用」复合指标卡：缓存复用 Tokens 与总 Token 消耗对比 + 缓存率
- 「今日调用」合并为复合卡：成功调用 / 总调用 + 成功率
- 移除「单次调用成本」指标卡（仅前端）
- 卡片统一为小色条样式（去图标），布局 2x2
- 数据源：复用现有 ops/cache 24h 趋势接口求和（纯前端，无后端改动）

## 效果对比
修改前
<img width="1385" height="2360" alt="Screenshot_2026-08-08-16-17-31-940_com miui gallery" src="https://github.com/user-attachments/assets/12517d6a-6855-4dc9-8ef6-a31cc9810ab9" />
修改后
<img width="1434" height="1986" alt="Screenshot_2026-08-08-16-16-57-086_com aries octopus" src="https://github.com/user-attachments/assets/c014c239-37ff-4abd-95fd-f5b8904ef195" />



## 影响范围

web/public/locale/*.json + web/src/components/modules/home/hero.tsx