### PR TITLE
fix: 修复近期改动中的 14 个问题（含 normalize 死循环、代理凭据明文展示、panic 日志丢失）

### DIFF
--- a/internal/helper/channel_probe.go
+++ b/internal/helper/channel_probe.go
@@ -61,11 +61,14 @@ func TestChannel(ctx context.Context, request appmodel.Channel) (*ChannelTestSum
 		return nil, err
 	}
 
-	baseURLs := make([]string, 0, len(request.BaseUrls))
+	baseURLs := make([]probeBaseURL, 0, len(request.BaseUrls))
 	for _, item := range request.BaseUrls {
 		url := strings.TrimSpace(item.URL)
 		if url != "" {
-			baseURLs = append(baseURLs, request.GetNormalizedBaseUrlFor(url))
+			baseURLs = append(baseURLs, probeBaseURL{
+				url:        request.GetNormalizedBaseUrlFor(url),
+				suffixMode: item.SuffixMode,
+			})
 		}
 	}
 	if len(baseURLs) == 0 {
@@ -84,7 +87,8 @@ func TestChannel(ctx context.Context, request appmodel.Channel) (*ChannelTestSum
 	}
 
 	summary := &ChannelTestSummary{Results: make([]ChannelTestResult, 0, len(baseURLs)*len(keys))}
-	for _, baseURL := range baseURLs {
+	for _, base := range baseURLs {
+		baseURL := base.url
 		for _, key := range keys {
 			result := ChannelTestResult{
 				BaseURL:   baseURL,
@@ -106,9 +110,10 @@ func TestChannel(ctx context.Context, request appmodel.Channel) (*ChannelTestSum
 			// 连通性探测失败时，若渠道配置了可用的模型，回退到一次真实模型调用
 			// 做综合判断：部分上游（如某些中转站）的 GET /models 端点行为异常，
 			// 即使 key/网络正常也返回非 200，导致健康渠道误报失败（issue 反馈）。
-			// 真实调用成功则视为渠道可用。
-			if !result.Passed && fallbackModelName(&request) != "" {
-				fallbackStatus, fallbackBody, _, fallbackErr := performChannelModelFallback(ctx, &request, baseURL, key.ChannelKey)
+			// 真实调用成功则视为渠道可用。SkipModelTest 渠道（低字节请求会扣费/
+			// 封禁，issue #98）不发真实调用，手动测试入口同样要遵守该约定。
+			if !result.Passed && !request.SkipModelTest && fallbackModelName(&request) != "" {
+				fallbackStatus, fallbackBody, _, fallbackErr := performChannelModelFallback(ctx, &request, base, key.ChannelKey)
 				if fallbackErr == nil {
 					result.Passed = true
 					result.Message = "ok (via model call)"
@@ -204,10 +209,19 @@ func fallbackModelName(channel *appmodel.Channel) string {
 	return ""
 }
 
+// probeBaseURL 携带归一化后的探测地址与其原始 SuffixMode：回退调用会再次
+// 归一化 base URL，丢失 SuffixMode 会让 custom/volcengine 等非默认模式的
+// 地址被按默认规则二次拼接（如 …/api/custom → …/api/custom/v1）。
+// 同一 SuffixMode 下归一化幂等，携带原模式可保证二次归一化为 no-op。
+type probeBaseURL struct {
+	url        string
+	suffixMode string
+}
+
 // performChannelModelFallback 用渠道配置的模型发起一次真实 chat 探测请求，
 // 用于连通性探测（GET /models）失败时的综合判断。经 outbound adapter 转发，
 // 与分组/模型测试同源。返回 status、响应体与错误。
-func performChannelModelFallback(ctx context.Context, channel *appmodel.Channel, baseURL, apiKey string) (int, string, *transmodel.InternalLLMResponse, error) {
+func performChannelModelFallback(ctx context.Context, channel *appmodel.Channel, base probeBaseURL, apiKey string) (int, string, *transmodel.InternalLLMResponse, error) {
 	if channel == nil {
 		return 0, "", nil, fmt.Errorf("channel is nil")
 	}
@@ -227,7 +241,7 @@ func performChannelModelFallback(ctx context.Context, channel *appmodel.Channel,
 
 	// 临时把 baseURL 替换为当前探测的 baseURL，保证回退请求打到同一地址。
 	cloned := *channel
-	cloned.BaseUrls = []appmodel.BaseUrl{{URL: baseURL}}
+	cloned.BaseUrls = []appmodel.BaseUrl{{URL: base.url, SuffixMode: base.suffixMode}}
 	cloned.Keys = []appmodel.ChannelKey{{ChannelKey: apiKey}}
 
 	// 与 group probe 一致，对 OpenAI 类型渠道走 adapter 回退（issue #187）：

--- a/internal/helper/channel_probe_fallback_test.go
+++ b/internal/helper/channel_probe_fallback_test.go
@@ -158,7 +158,7 @@ func TestPerformChannelModelFallback_OpenAIResponseFallsBackToChat(t *testing.T)
 		Model:    "gpt-4o-mini",
 	}
 
-	statusCode, _, _, err := performChannelModelFallback(context.Background(), channel, server.URL, "sk-test")
+	statusCode, _, _, err := performChannelModelFallback(context.Background(), channel, probeBaseURL{url: server.URL}, "sk-test")
 	if err != nil {
 		t.Fatalf("performChannelModelFallback() error = %v", err)
 	}

--- a/internal/op/llm/price_category.go
+++ b/internal/op/llm/price_category.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"github.com/lingyuins/octopus/internal/db"
 	"github.com/lingyuins/octopus/internal/model"
@@ -13,10 +14,9 @@ import (
 // priceCategoryCache 缓存启用且按 sort_order 排序的分类，供 price.GetLLMPrice
 // 兜底匹配热点路径使用，避免每次查询都访问 DB。与 modelCache 类似的全局内存缓存，
 // 由 Create/Update/Delete/RefreshPriceCategoryCache 维护。
-var priceCategoryCache = modelPriceCategoryList(nil)
-
-// modelPriceCategoryList 是只读的快照切片类型，便于并发安全地整体替换。
-type modelPriceCategoryList []model.ModelPriceCategory
+// atomic.Pointer：RefreshPriceCategoryCache 与热路径 PriceCategoryMatch 并发读写，
+// 普通赋值存在数据竞争（slice 头非原子）。
+var priceCategoryCache atomic.Pointer[[]model.ModelPriceCategory]
 
 // ListPriceCategories 返回全部分类（含禁用），按 sort_order 升序。
 func ListPriceCategories(ctx context.Context) ([]model.ModelPriceCategory, error) {
@@ -27,12 +27,12 @@ func ListPriceCategories(ctx context.Context) ([]model.ModelPriceCategory, error
 	return rows, nil
 }
 
-// listEnabledPriceCategories 返回启用的分类快照（复制，避免调用方持有全局切片引用）。
+// listEnabledPriceCategories 返回启用的分类快照。快照切片替换后只读，可直接共享。
 func listEnabledPriceCategories() []model.ModelPriceCategory {
-	c := priceCategoryCache
-	out := make([]model.ModelPriceCategory, len(c))
-	copy(out, c)
-	return out
+	if c := priceCategoryCache.Load(); c != nil {
+		return *c
+	}
+	return nil
 }
 
 // RefreshPriceCategoryCache 从 DB 重载启用分类进内存缓存。
@@ -44,7 +44,7 @@ func RefreshPriceCategoryCache(ctx context.Context) error {
 		Find(&rows).Error; err != nil {
 		return err
 	}
-	priceCategoryCache = modelPriceCategoryList(rows)
+	priceCategoryCache.Store(&rows)
 	return nil
 }
 
@@ -120,9 +120,15 @@ func validatePriceCategory(c model.ModelPriceCategory) error {
 }
 
 // categoryMatches 判断 modelName（小写后）是否命中分类规则。
+// RuleValue 需在此小写并去空白：modelName 已小写，历史数据/用户录入的
+// 大写或带空格规则值否则永远无法命中（与 model/price_category.go 声称的
+// 忽略大小写语义保持一致）。
 func categoryMatches(c model.ModelPriceCategory, modelName string) bool {
 	rule := model.ModelPriceCategoryRule(c.RuleType)
-	v := c.RuleValue
+	v := strings.ToLower(strings.TrimSpace(c.RuleValue))
+	if v == "" {
+		return false
+	}
 	switch rule {
 	case model.ModelPriceCategoryRuleExact:
 		return modelName == v

--- a/internal/op/model_market.go
+++ b/internal/op/model_market.go
@@ -62,12 +62,17 @@ func ModelMarketGet(ctx context.Context, lastUpdateTime time.Time) (model.ModelM
 
 	// 缓存 miss：合并并发重算，避免多请求各自全量执行（DB 查询 + 聚合）。
 	result, err, _ := marketSingleFlight.Do("market", func() (any, error) {
-		models, err := LLMList(ctx)
+		// singleflight 的执行结果由所有并发等待者共享，不能绑定首个进入者的
+		// 请求 ctx——该客户端断开会让其余等待者一起收到 context.Canceled。
+		sfCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		models, err := LLMList(sfCtx)
 		if err != nil {
 			return model.ModelMarketResponse{}, err
 		}
 
-		modelChannels, err := ChannelLLMList(ctx)
+		modelChannels, err := ChannelLLMList(sfCtx)
 		if err != nil {
 			return model.ModelMarketResponse{}, err
 		}

--- a/internal/op/modelnormalize/normalize.go
+++ b/internal/op/modelnormalize/normalize.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/lingyuins/octopus/internal/model"
 	"github.com/lingyuins/octopus/internal/op/setting"
@@ -151,7 +152,7 @@ func stripFunctionalSuffixes(name string, rules Rules) string {
 			if suffix == "" {
 				continue
 			}
-			if n, ok := matchSuffixCandidate(lower, suffix); ok && len(result) > n {
+			if n, ok := matchSuffixCandidate(lower, suffix); ok && n > 0 && len(result) > n {
 				result = result[:len(result)-n]
 				changed = true
 				break
@@ -163,8 +164,9 @@ func stripFunctionalSuffixes(name string, rules Rules) string {
 
 // matchSuffixCandidate 尝试字面变体与正则变体，返回匹配的字符数。
 func matchSuffixCandidate(lower, suffix string) (int, bool) {
-	// 字面候选：原样、-: → :、-( → (。
-	for _, cand := range literalSuffixCandidates(suffix) {
+	// 字面候选：原样、-: → :、-( → (。lower 已小写，候选也需小写才能命中
+	// 用户配置的含大写后缀（如 -Thinking）。
+	for _, cand := range literalSuffixCandidates(strings.ToLower(suffix)) {
 		if strings.HasSuffix(lower, cand) && len(lower) > len(cand) {
 			return len(cand), true
 		}
@@ -176,7 +178,9 @@ func matchSuffixCandidate(lower, suffix string) (int, bool) {
 			if re == nil {
 				continue
 			}
-			if loc := re.FindStringIndex(lower); loc != nil {
+			// loc[0] == len(lower) 表示只匹配到空串（如 -*、(x)? 这类可空 pattern），
+			// 剥离长度为 0，放行会让外层循环永不收敛。
+			if loc := re.FindStringIndex(lower); loc != nil && loc[0] < len(lower) {
 				return len(lower) - loc[0], true
 			}
 		}
@@ -185,11 +189,14 @@ func matchSuffixCandidate(lower, suffix string) (int, bool) {
 }
 
 // getSuffixRegex 返回锚定结尾的正则（带编译缓存）。
+// pattern 包进 (?:...) 再锚定，避免含 | 的 pattern（如 -32k|-64k）只有
+// 最后一个分支被 $ 锚定、其余分支从字符串中间命中；(?i) 与字面候选的
+// 大小写不敏感语义保持一致（待匹配串已小写）。
 func getSuffixRegex(pattern string) *regexp.Regexp {
 	if v, ok := suffixRegexCache.Load(pattern); ok {
 		return v.(*regexp.Regexp)
 	}
-	re, err := regexp.Compile(pattern + "$")
+	re, err := regexp.Compile("(?i)(?:" + pattern + ")$")
 	if err != nil {
 		return nil
 	}
@@ -247,9 +254,12 @@ func stripPathAndRouterPrefix(name string, rules Rules) string {
 			break
 		}
 		// 去尾 - 变体（[官B]- → [官B] 匹配 [官B]claude-opus-4-6）。
+		// 仅当 base 以非字母数字结尾（]、) 等括号类标记）才启用：
+		// agent-/anthropic- 这类字母结尾的前缀去尾后会从单词中间误剥
+		// （agentic-coder → ic-coder、anthropic.claude-x → .claude-x）。
 		if strings.HasSuffix(prefix, "-") {
 			base := strings.TrimSuffix(prefix, "-")
-			if base != "" && strings.HasPrefix(lower, strings.ToLower(base)) {
+			if base != "" && !endsWithAlphanumeric(base) && strings.HasPrefix(lower, strings.ToLower(base)) {
 				result = result[len(base):]
 				// 若原名字带 -（dmxapi-kimi → 剥 dmxapi 剩 -kimi），去掉。
 				result = strings.TrimLeft(result, "-")
@@ -258,6 +268,16 @@ func stripPathAndRouterPrefix(name string, rules Rules) string {
 		}
 	}
 	return result
+}
+
+// endsWithAlphanumeric 报告字符串最后一个 rune 是否为字母或数字。
+func endsWithAlphanumeric(s string) bool {
+	runes := []rune(s)
+	if len(runes) == 0 {
+		return false
+	}
+	last := runes[len(runes)-1]
+	return unicode.IsLetter(last) || unicode.IsDigit(last)
 }
 
 func loadRules() Rules {

--- a/internal/op/modelnormalize/normalize_test.go
+++ b/internal/op/modelnormalize/normalize_test.go
@@ -1,6 +1,9 @@
 package modelnormalize
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestNormalizeWithRules_UsesBuiltinRules(t *testing.T) {
 	rules := Rules{}
@@ -78,5 +81,64 @@ func TestNormalizeWithRules_RuntimeRulesOverrideBuiltinPrefixesAndSuffixes(t *te
 	}
 	if got := NormalizeWithRules("custom-kimi-k2.5-route", rules); got != "kimi-k2.5" {
 		t.Fatalf("NormalizeWithRules custom = %q, want kimi-k2.5", got)
+	}
+}
+
+// 可匹配空串的正则后缀（-*、(x)? 等）不应导致 stripFunctionalSuffixes 死循环。
+func TestNormalizeWithRules_EmptyMatchRegexSuffixTerminates(t *testing.T) {
+	for _, suffix := range []string{"-*", "(x)?", "-32k|"} {
+		done := make(chan string, 1)
+		go func() {
+			done <- NormalizeWithRules("gpt-4o", Rules{FunctionalSuffixes: []string{suffix}})
+		}()
+		select {
+		case got := <-done:
+			if got != "gpt-4o" {
+				t.Fatalf("suffix %q: NormalizeWithRules(gpt-4o) = %q, want gpt-4o", suffix, got)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatalf("suffix %q: NormalizeWithRules 死循环（3s 未返回）", suffix)
+		}
+	}
+}
+
+// 含 | 的正则后缀每个分支都应锚定结尾，不得从字符串中间剥离。
+func TestNormalizeWithRules_AlternationSuffixAnchorsAllBranches(t *testing.T) {
+	rules := Rules{FunctionalSuffixes: []string{"-32k|-64k"}}
+	if got := NormalizeWithRules("qwen-32k-chat", rules); got != "qwen-32k-chat" {
+		t.Fatalf("NormalizeWithRules(qwen-32k-chat) = %q, want qwen-32k-chat（-32k 在中间，不应剥离）", got)
+	}
+	if got := NormalizeWithRules("qwen-turbo-32k", rules); got != "qwen-turbo" {
+		t.Fatalf("NormalizeWithRules(qwen-turbo-32k) = %q, want qwen-turbo", got)
+	}
+	if got := NormalizeWithRules("qwen-turbo-64k", rules); got != "qwen-turbo" {
+		t.Fatalf("NormalizeWithRules(qwen-turbo-64k) = %q, want qwen-turbo", got)
+	}
+}
+
+// 字母结尾前缀的去尾 - 变体不应从单词中间误剥；括号类前缀保持生效。
+func TestNormalizeWithRules_TrailingDashVariantRequiresBoundary(t *testing.T) {
+	if got := Normalize("agentic-coder"); got != "agentic-coder" {
+		t.Fatalf("Normalize(agentic-coder) = %q, want agentic-coder", got)
+	}
+	if got := Normalize("anthropic.claude-sonnet-4-5"); got != "anthropic.claude-sonnet-4-5" {
+		t.Fatalf("Normalize(anthropic.claude-sonnet-4-5) = %q, want anthropic.claude-sonnet-4-5", got)
+	}
+	// [官B]- 写法仍应命中 [官B]claude-opus-4-6（无连字符）。
+	rules := Rules{RouterPrefixes: []string{"[官B]-"}}
+	if got := NormalizeWithRules("[官B]claude-opus-4-6", rules); got != "claude-opus-4-6" {
+		t.Fatalf("NormalizeWithRules([官B]claude-opus-4-6) = %q, want claude-opus-4-6", got)
+	}
+}
+
+// 后缀匹配保持大小写不敏感（与旧版行为一致）。
+func TestNormalizeWithRules_SuffixMatchingCaseInsensitive(t *testing.T) {
+	rules := Rules{FunctionalSuffixes: []string{"-Thinking"}}
+	if got := NormalizeWithRules("claude-x-thinking", rules); got != "claude-x" {
+		t.Fatalf("字面后缀大小写: got %q, want claude-x", got)
+	}
+	rules = Rules{FunctionalSuffixes: []string{`-V\d+`}}
+	if got := NormalizeWithRules("model-v20250514", rules); got != "model" {
+		t.Fatalf("正则后缀大小写: got %q, want model", got)
 	}
 }

--- a/internal/planprovider/deepseek_login.go
+++ b/internal/planprovider/deepseek_login.go
@@ -160,7 +160,11 @@ func ensureDeepSeekSession(ctx context.Context, provider *model.PlanProvider) (s
 	}
 	token, err := deepseekPlatformLogin(ctx, provider.LoginUsername, pw)
 	if err != nil {
-		entry.nextRetry = now.Add(deepseekLoginCooldown)
+		// ctx 取消（用户刷新/离开页面中断 ListProviders）不是登录失败，
+		// 不触发冷却，否则一次页面刷新就让官方用量静默降级 5 分钟。
+		if !errors.Is(err, context.Canceled) {
+			entry.nextRetry = now.Add(deepseekLoginCooldown)
+		}
 		return "", err
 	}
 	entry.s = &deepseekSession{token: token, expiresAt: now.Add(deepseekSessionTTL)}

--- a/internal/price/price.go
+++ b/internal/price/price.go
@@ -106,14 +106,16 @@ func GetLastUpdateTime() time.Time {
 func GetLLMPrice(modelName string) *model.LLMPrice {
 	modelName = strings.ToLower(modelName)
 	price, err := llm.Get(modelName)
-	if err == nil {
+	// 渠道同步（LLMPriceAddToDB）会给未知价模型插入四价全 0 的行，DB 命中
+	// 不能无条件短路，否则分类兜底恰好对它设计要覆盖的"同步过但没匹配到
+	// 价格"的模型不生效。0 价行继续走兜底链。
+	if err == nil && !isZeroPrice(price) {
 		return &price
 	}
 	llmPriceLock.RLock()
 	defer llmPriceLock.RUnlock()
-	price, ok := llmPrice[modelName]
-	if ok {
-		return &price
+	if p, ok := llmPrice[modelName]; ok {
+		return &p
 	}
 	// 分类表兜底：按规则匹配的模型价格分类（优先级高于整词子串兜底）。
 	if cat := llm.PriceCategoryMatch(modelName); cat != nil {
@@ -123,7 +125,16 @@ func GetLLMPrice(modelName string) *model.LLMPrice {
 	if fallback := matchFallbackPrice(modelName); fallback != nil {
 		return fallback
 	}
+	if err == nil {
+		// DB 有 0 价行且所有兜底都未命中：维持原语义，返回 DB 行（0 价）。
+		return &price
+	}
 	return nil
+}
+
+// isZeroPrice 报告四项价格是否全为 0（渠道同步为未知价模型写入的占位行）。
+func isZeroPrice(p model.LLMPrice) bool {
+	return p.Input == 0 && p.Output == 0 && p.CacheRead == 0 && p.CacheWrite == 0
 }
 
 // GetLLMPriceFromUpstream 仅从同步价格源（外部价格文件 + presets.go +

--- a/internal/server/handlers/error_log.go
+++ b/internal/server/handlers/error_log.go
@@ -102,13 +102,10 @@ func reportErrorLog(c *gin.Context) {
 		resp.Success(c, nil)
 		return
 	}
-	if len(message) > 8192 {
-		message = message[:8192]
-	}
-	stack := req.Stack
-	if len(stack) > 65536 {
-		stack = stack[:65536]
-	}
+	// 按 rune 截断：字节切片会切坏 UTF-8 多字节字符，MySQL/PostgreSQL
+	// 会拒绝写入非法编码，导致含中文/emoji 的超长堆栈永远记录不进库。
+	message = truncateStr(message, 8192)
+	stack := truncateStr(req.Stack, 65536)
 	level := strings.TrimSpace(req.Level)
 	if level == "" {
 		level = "error"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -58,7 +58,11 @@ func Start() error {
 			UserAgent:     c.Request.UserAgent(),
 			Version:       conf.Version,
 		}
-		if err := errorlog.Add(c.Request.Context(), entry); err != nil {
+		// 不用 c.Request.Context()：客户端断连（流式请求中途断开正是最常见的
+		// panic 诱因）会取消请求 ctx，导致最需要的崩溃记录恰好写库失败。
+		writeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := errorlog.Add(writeCtx, entry); err != nil {
 			log.Errorf("failed to record panic error log: %v", err)
 		}
 		log.Errorf("panic recovered: %v\n%s", recovered, stack)

--- a/internal/utils/proxyx/parse.go
+++ b/internal/utils/proxyx/parse.go
@@ -236,7 +236,12 @@ type vmessParsed struct {
 
 // parseVMess parses a VMess share link: vmess://base64(JSON).
 func parseVMess(raw string) (*vmessParsed, error) {
-	payload := strings.TrimPrefix(raw, "vmess://")
+	// Scheme 大小写不敏感：校验层（NormalizeProxyURL）与其余协议的解析
+	// （url.Parse / parseSS 的 Index）都接受 VMESS://，此处保持一致。
+	payload := raw
+	if len(raw) >= len("vmess://") && strings.EqualFold(raw[:len("vmess://")], "vmess://") {
+		payload = raw[len("vmess://"):]
+	}
 	// Some clients emit vmess:// with an extra slash or URL-encoded payload.
 	payload = strings.TrimPrefix(payload, "/")
 	if idx := strings.Index(payload, "#"); idx >= 0 {

--- a/web/src/components/modules/proxy-pool/ProxyPoolDialog.tsx
+++ b/web/src/components/modules/proxy-pool/ProxyPoolDialog.tsx
@@ -28,6 +28,7 @@ import {
     PROXY_SCHEME_PLACEHOLDERS,
     buildSchemeTemplate,
     detectProxyScheme,
+    maskProxyURL,
     schemeBadgeClass,
     schemeLabel,
     type ProxyScheme,
@@ -57,16 +58,6 @@ const emptyForm: FormState = {
 };
 
 const DEFAULT_TEST_URL = 'https://api.openai.com/v1/models';
-
-function maskProxyURL(value: string) {
-    try {
-        const parsed = new URL(value);
-        if (parsed.password) parsed.password = '***';
-        return parsed.toString();
-    } catch {
-        return value;
-    }
-}
 
 function errorMessage(error: unknown, fallback: string) {
     if (error instanceof Error) return error.message;

--- a/web/src/components/modules/proxy-pool/scheme.test.ts
+++ b/web/src/components/modules/proxy-pool/scheme.test.ts
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
     detectProxyScheme,
+    maskProxyURL,
     buildSchemeTemplate,
     schemeLabel,
     PROXY_SCHEMES,
@@ -55,4 +56,25 @@ test('schemeLabel returns a display name', () => {
     assert.equal(schemeLabel('socks5'), 'SOCKS5');
     assert.equal(schemeLabel('ss'), 'SS');
     assert.equal(schemeLabel('vmess'), 'VMess');
+});
+
+test('maskProxyURL masks credentials in the username slot (trojan/ss/vless)', () => {
+    assert.ok(!maskProxyURL('trojan://secret-pass@example.com:443').includes('secret-pass'));
+    assert.ok(!maskProxyURL('ss://YWVzLTI1Ni1nY206cGFzc3dvcmQ@example.com:8388').includes('YWVzLTI1Ni1nY206cGFzc3dvcmQ'));
+    assert.ok(!maskProxyURL('vless://11111111-2222-3333-4444-555555555555@example.com:443').includes('11111111'));
+    // host 仍可见，便于辨认条目。
+    assert.ok(maskProxyURL('trojan://secret-pass@example.com:443').includes('example.com'));
+});
+
+test('maskProxyURL masks the whole vmess payload and userinfo-less ss links', () => {
+    assert.equal(maskProxyURL('vmess://eyJhZGQiOiJleGFtcGxlLmNvbSIsImlkIjoidXVpZCJ9'), 'vmess://***');
+    assert.equal(maskProxyURL('ss://YWVzOnBhc3NAZXhhbXBsZS5jb206ODM4OA=='), 'ss://***');
+});
+
+test('maskProxyURL keeps masking http/socks5 passwords, preserves username', () => {
+    const masked = maskProxyURL('http://user:secret@127.0.0.1:7890');
+    assert.ok(!masked.includes('secret'));
+    assert.ok(masked.includes('user'));
+    assert.equal(maskProxyURL('socks5://127.0.0.1:1080'), 'socks5://127.0.0.1:1080');
+    assert.equal(maskProxyURL('not a url'), 'not a url');
 });

--- a/web/src/components/modules/proxy-pool/scheme.ts
+++ b/web/src/components/modules/proxy-pool/scheme.ts
@@ -52,6 +52,33 @@ export function buildSchemeTemplate(scheme: ProxyScheme): string {
     return PROXY_SCHEME_PLACEHOLDERS[scheme];
 }
 
+/** 凭据位于 userinfo 用户名位的 scheme：trojan://密码@host、ss://base64(加密法:密码)@host、vless://UUID@host。 */
+const USERNAME_SECRET_SCHEMES = new Set(['trojan', 'ss', 'vless']);
+
+/**
+ * 打码代理 URL 中的凭据用于列表展示。
+ * 只打码 URL password 位不够：trojan/ss/vless 的密钥在用户名位，
+ * vmess 整个 payload 是含 UUID 的 base64(JSON)，无法局部打码。
+ */
+export function maskProxyURL(value: string): string {
+    const scheme = detectProxyScheme(value);
+    if (scheme === 'vmess') return 'vmess://***';
+    if (scheme === 'ss' && !value.includes('@')) {
+        // 全 base64 形式 ss://base64(method:pass@host:port)，密码在 payload 里。
+        return 'ss://***';
+    }
+    try {
+        const parsed = new URL(value);
+        if (scheme && USERNAME_SECRET_SCHEMES.has(scheme) && parsed.username) {
+            parsed.username = '***';
+        }
+        if (parsed.password) parsed.password = '***';
+        return parsed.toString();
+    } catch {
+        return value;
+    }
+}
+
 /** 协议徽章样式：按 scheme 返回 Tailwind 类。 */
 export function schemeBadgeClass(scheme: ProxyScheme): string {
     switch (scheme) {

--- a/web/src/lib/error-report-core.test.ts
+++ b/web/src/lib/error-report-core.test.ts
@@ -40,4 +40,20 @@ describe('ErrorReportDedupe', () => {
         dedupe.reset();
         assert.equal(dedupe.isDuplicate('TypeError: boom', 'stack-1'), false);
     });
+
+    it('alternating errors are still deduped within the window', () => {
+        // 单槽位实现下 A/B 交替会互相顶掉，每次都判为新错误。
+        assert.equal(dedupe.isDuplicate('ErrorA', 'stack-a'), false);
+        assert.equal(dedupe.isDuplicate('ErrorB', 'stack-b'), false);
+        assert.equal(dedupe.isDuplicate('ErrorA', 'stack-a'), true);
+        assert.equal(dedupe.isDuplicate('ErrorB', 'stack-b'), true);
+    });
+
+    it('entry count stays bounded under many distinct errors', () => {
+        for (let i = 0; i < 500; i++) {
+            dedupe.isDuplicate(`Error-${i}`, 'stack');
+        }
+        // 最新条目仍在窗口内应判重，且不会因容量淘汰而误报新错误。
+        assert.equal(dedupe.isDuplicate('Error-499', 'stack'), true);
+    });
 });

--- a/web/src/lib/error-report-core.ts
+++ b/web/src/lib/error-report-core.ts
@@ -6,8 +6,13 @@
 
 export const DEDUP_WINDOW_MS = 30_000;
 
+/** 去重表容量上限：防止 message 含时间戳/URL 等变化片段时无限增长。 */
+export const DEDUP_MAX_ENTRIES = 100;
+
 export class ErrorReportDedupe {
-    private lastReport: { key: string; at: number } | null = null;
+    // 多槽位：单槽位在两种错误交替出现时（如两个轮询接口各自报错）
+    // 每次都判为"新错误"，30 秒窗口形同虚设。
+    private reports = new Map<string, number>();
 
     /**
      * 返回 true 表示该错误在窗口内已上报过，应跳过。
@@ -15,14 +20,28 @@ export class ErrorReportDedupe {
     isDuplicate(message: string, stack?: string): boolean {
         const key = `${message}|${(stack ?? '').slice(0, 200)}`;
         const now = Date.now();
-        if (this.lastReport && this.lastReport.key === key && now - this.lastReport.at < DEDUP_WINDOW_MS) {
+        const last = this.reports.get(key);
+        if (last !== undefined && now - last < DEDUP_WINDOW_MS) {
             return true;
         }
-        this.lastReport = { key, at: now };
+        this.prune(now);
+        this.reports.set(key, now);
         return false;
     }
 
+    private prune(now: number): void {
+        for (const [key, at] of this.reports) {
+            if (now - at >= DEDUP_WINDOW_MS) this.reports.delete(key);
+        }
+        // 极端情况下（窗口内大量不同 message）按插入序淘汰最旧的。
+        while (this.reports.size >= DEDUP_MAX_ENTRIES) {
+            const oldest = this.reports.keys().next().value;
+            if (oldest === undefined) break;
+            this.reports.delete(oldest);
+        }
+    }
+
     reset(): void {
-        this.lastReport = null;
+        this.reports.clear();
     }
 }

--- a/web/src/lib/error-report.ts
+++ b/web/src/lib/error-report.ts
@@ -6,14 +6,15 @@
  * 2. unhandledrejection —— 未处理的 Promise 拒绝
  * 3. React 渲染错误（ErrorBoundary 单独调用 reportError 上报）
  *
- * 上报到后端 /api/v1/error-log/report（需登录态，apiClient 自动携带 JWT）。
+ * 上报到后端 /api/v1/error-log/report（需登录态，手动携带 JWT；不走 apiClient
+ * 以避免其 401 全局处理把用户强制登出）。
  * 策略：
  * - 去重：相同 message+stack 在 DEDUP_WINDOW_MS 内只上报一次，避免循环错误刷屏
  * - 静默：上报失败不抛错、不打断用户操作（console.warn 记录）
  * - 有 token 才上报（未登录崩溃无诊断上下文，避免无效请求）
  */
 
-import { apiClient } from '@/api/client';
+import { API_BASE_URL } from '@/api/client';
 import { useAuthStore } from '@/api/endpoints/user';
 import { useNavStore } from '@/components/modules/navbar';
 import { APP_VERSION } from '@/lib/info';
@@ -61,15 +62,25 @@ export async function reportError(payload: ErrorReportPayload): Promise<void> {
         if (!message || dedupe.isDuplicate(message, payload.stack)) return;
 
         // 未登录（无 JWT）时不上报：report 端点需要登录态，避免无效请求。
-        if (!useAuthStore.getState().token) return;
+        const token = useAuthStore.getState().token;
+        if (!token) return;
 
-        await apiClient.post('/api/v1/error-log/report', {
-            level: payload.level,
-            message,
-            stack: payload.stack ?? '',
-            page_url: payload.page_url ?? window.location.href,
-            route_id: payload.route_id ?? currentRouteId(),
-            version: payload.version ?? APP_VERSION,
+        // 用裸 fetch 而非 apiClient：apiClient 的全局错误处理对 401 会强制
+        // logout。上报是零交互的后台行为，token 恰好过期时不应把用户登出。
+        await fetch(`${API_BASE_URL}/api/v1/error-log/report`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({
+                level: payload.level,
+                message,
+                stack: payload.stack ?? '',
+                page_url: payload.page_url ?? window.location.href,
+                route_id: payload.route_id ?? currentRouteId(),
+                version: payload.version ?? APP_VERSION,
+            }),
         });
     } catch (e) {
         console.warn('[error-report] failed to report error:', e);


### PR DESCRIPTION
## 概述

对 v2.5.x 近期改动（f3252343..182f223d 范围）做了一轮系统性代码审查，修复其中确认的 14 个 bug。全部改动均通过 `go vet`、后端全量测试与前端 lint / 单测（165/165），并为关键修复补充了回归测试。

## 修复清单

### 高危（本地已复现）

**1. modelnormalize：空匹配正则后缀导致死循环**（`normalize.go`）
用户配置能匹配空串的后缀正则（如 `-*`、`(x)?`、末尾 `|`）后，`stripFunctionalSuffixes` 的循环条件 `ok && len(result) > n` 对 n==0 恒真，无限循环。规则持久化在 DB，重启无效，模型广场热路径每个请求 CPU 空转。实测 `["-*"]` 下 `NormalizeWithRules("gpt-4o")` 挂死。补 `n > 0` 与空匹配守卫。

**2. modelnormalize：含 `|` 的正则后缀只有最后一个分支被 `$` 锚定**
`pattern + "$"` 使 `-32k|-64k` 变成 `-32k|(-64k$)`，实测 `qwen-32k-chat` 被误归一成 `qwen`。改为 `(?:pattern)$`。

**3. modelnormalize：路由前缀「去尾 -」变体无词边界**
内置前缀即可触发：实测 `agentic-coder` → `ic-coder`、`anthropic.claude-sonnet-4-5` → `.claude-sonnet-4-5`。限定 base 以非字母数字结尾（`]`、`)` 等）才启用变体，`[官B]-` 场景不受影响。

### 中危

**4. modelnormalize：后缀匹配大小写回归** —— 旧版 `ToLower` 后比较，重构后字面/正则后缀均区分大小写，存量含大写的用户规则（如 `-Thinking`）静默失效。恢复大小写不敏感（正则加 `(?i)`）。

**5. errorlog：panic 记录用已取消的请求 ctx 写库**（`server.go`）—— 客户端断流（最常见 panic 诱因）时 ctx 已取消，最需要的崩溃记录恰好写库失败。改用 `context.Background()` + 5s 超时。

**6. errorlog：message/stack 按字节截断切坏 UTF-8**（`handlers/error_log.go`）—— MySQL/PostgreSQL 拒绝非法编码，含中文的超长堆栈永远写不进库。改用同文件现成的 `truncateStr`（按 rune）。

**7. price：0 价占位行短路分类兜底**（`price.go`）—— 渠道同步会为未知价模型插入四价全 0 的行，DB 命中即返回，价格分类兜底对它设计要覆盖的场景基本不生效。0 价行继续走兜底链，全部未命中时仍返回原行（调用方行为不变；「四价全 0 = 无价格」与 `LLMPriceDeleteFromDBWithNoPrice` 的既有语义一致）。

**8. price：分类缓存数据竞争**（`price_category.go`）—— 全局 slice 普通赋值写 vs 热路径并发读，race detector 必报。改 `atomic.Pointer`。

**9. price：分类规则匹配区分大小写** —— 模型名已小写但 `RuleValue` 未处理，用户录 `GPT-4` 永不命中，与注释声称的忽略大小写矛盾。匹配前 `ToLower` + `TrimSpace`。

**10. helper：探测回退绕过 SkipModelTest**（`channel_probe.go`）—— 手动测试渠道时对标记「低字节请求会扣费/封禁」（#98）的渠道按 baseURL×key 笛卡尔积发真实计费请求。回退前检查 `SkipModelTest`。

**11. helper：探测回退丢失 SuffixMode** —— 克隆渠道只带归一化后的 URL，二次归一化按默认规则拼接（如 volcengine 模式变成 `…/api/v3/v1/…`），非默认后缀模式渠道的回退必失败。携带原 SuffixMode（同模式下归一化幂等）。

**12. op：model market singleflight 绑定首个请求的 ctx**（`model_market.go`）—— 该客户端断开会让所有并发等待者集体收到 context.Canceled → 500。闭包内改用独立 ctx。

**13. web：代理凭据明文展示**（`ProxyPoolDialog.tsx`）—— `maskProxyURL` 只打码 URL password 位，但 trojan/ss/vless 的密钥在 userinfo 用户名位、vmess 整个 payload 是含 UUID 的 base64(JSON)，代理池列表全部明文可见。打码逻辑迁至 `scheme.ts` 并覆盖上述形态，附测试。

**14. web：错误上报的 401 静默登出 + 去重失效**（`error-report.ts` / `error-report-core.ts`）—— reportError 复用全局 apiClient，token 恰好过期时任意后台 JS 错误会把用户强制登出；改用裸 fetch。去重单槽位在两种错误交替时完全失效；改为带容量上限的多槽位 Map。

### 低危顺带修复

**proxyx：`VMESS://` 大写 scheme 解析失败**（`parse.go`）—— 校验层与其余协议均大小写不敏感，唯独 `parseVMess` 用大小写敏感 TrimPrefix，大写链接能保存但拨号报误导性 base64 错误。

**planprovider：ctx 取消误触发 DeepSeek 登录冷却**（`deepseek_login.go`）—— 用户刷新页面中断 ListProviders 即进入 5 分钟冷却，官方用量静默降级。`context.Canceled` 不再触发冷却。

## 审查中发现但未在本 PR 修复的问题（供参考）

这些问题涉及设计取舍或需要实测上游 API 语义，不适合在本 PR 里顺手改：

- `planprovider/service.go` RefreshProvider 尾部全量 `Save` 无并发守卫，自动刷新与用户更新凭据并发时会把旧凭据写回（lost update）
- `deepseek_login.go` usage 持续 401 时每次轮询都会绕过冷却真实登录控制台（风控风险）；「今日用量」按本地时区过滤 UTC 日桶，UTC+8 用户每天 0-8 点恒为 0
- `poolscheduler/auth_error_counter.go` 窗口重置的两步原子操作仍有竞态（本次改动只修了读侧），极端情况误禁账号
- `transformer/model/model.go` `Message.Content` 的 `omitzero` 在 jsoniter 下无效（与已修的 `store:null` 同类），assistant 纯 tool_calls 消息出站为 `"content":null`
- `openai/chat.go` ExtraBody 展平经 map 往返，>2^53 的 `seed` 丢精度

## 验证

- `go vet ./...` 通过，`go test ./...` 全量通过
- 前端 `pnpm lint`（0 errors）、`pnpm test:unit` 165/165 通过
- 新增回归测试：normalize 死循环/锚定/边界/大小写（5 个用例）、maskProxyURL（3 个用例）、去重多槽位（2 个用例）
