### PR TITLE
fix: 修复渠道全部不可用时 key 重试自旋死循环与 relay log attempts 无限增长（#192）

### DIFF
--- a/internal/relay/balancer/iterator.go
+++ b/internal/relay/balancer/iterator.go
@@ -22,8 +22,27 @@ type Iterator struct {
 	modelName  string // 请求模型名（用于熔断检查）
 
 	// 内嵌追踪
-	attempts []model.ChannelAttempt
-	count    int
+	attempts     []model.ChannelAttempt
+	count        int
+	skipCount    int // 已保留明细的跳过/熔断记录数
+	omittedSkips int // 超出 maxSkipAttemptRecords 后未保留明细的跳过记录数
+}
+
+// maxSkipAttemptRecords 限制单个迭代器保留的跳过/熔断明细条数。跳过记录不发起
+// 真实请求，异常场景下（如重试逻辑缺陷、大量渠道同时熔断）可能高频产生；
+// 无上限时曾出现单条 relay log 数百 MB、写爆数据库的事故（issue #192）。
+// 超限后只累计条数，Attempts() 以一条汇总记录补充说明。真实转发记录不受限
+// （其数量受路由轮次 × 渠道数 × Key 重试数约束），ForwardedAttempts 语义不变。
+const maxSkipAttemptRecords = 200
+
+// appendSkipAttempt 追加一条跳过类记录，超限后只计数不存明细。
+func (it *Iterator) appendSkipAttempt(attempt model.ChannelAttempt) {
+	if it.skipCount >= maxSkipAttemptRecords {
+		it.omittedSkips++
+		return
+	}
+	it.skipCount++
+	it.attempts = append(it.attempts, attempt)
 }
 
 // NewIterator 创建负载均衡迭代器
@@ -111,7 +130,7 @@ func (it *Iterator) Index() int {
 // Skip 记录当前通道被跳过（通道禁用、无Key、类型不兼容等）
 func (it *Iterator) Skip(channelID, channelKeyID int, channelName, msg string) {
 	it.count++
-	it.attempts = append(it.attempts, model.ChannelAttempt{
+	it.appendSkipAttempt(model.ChannelAttempt{
 		ChannelID:    channelID,
 		ChannelKeyID: channelKeyID,
 		ChannelName:  channelName,
@@ -134,7 +153,7 @@ func (it *Iterator) SkipCircuitBreak(channelID, channelKeyID int, channelName, m
 		msg = fmt.Sprintf("circuit breaker tripped, remaining cooldown: %ds", int(remaining.Seconds()))
 	}
 	it.count++
-	it.attempts = append(it.attempts, model.ChannelAttempt{
+	it.appendSkipAttempt(model.ChannelAttempt{
 		ChannelID:    channelID,
 		ChannelKeyID: channelKeyID,
 		ChannelName:  channelName,
@@ -164,9 +183,19 @@ func (it *Iterator) StartAttempt(channelID, channelKeyID int, channelName, model
 	}
 }
 
-// Attempts 返回所有决策记录（交给日志模块持久化）
+// Attempts 返回所有决策记录（交给日志模块持久化）。
+// 跳过明细超限时追加一条汇总记录说明省略数量，保证日志读者知道有截断。
 func (it *Iterator) Attempts() []model.ChannelAttempt {
-	return it.attempts
+	if it.omittedSkips == 0 {
+		return it.attempts
+	}
+	out := make([]model.ChannelAttempt, len(it.attempts), len(it.attempts)+1)
+	copy(out, it.attempts)
+	return append(out, model.ChannelAttempt{
+		AttemptNum: it.count,
+		Status:     model.AttemptSkipped,
+		Msg:        fmt.Sprintf("%d skip/circuit-break records omitted (cap %d per route round)", it.omittedSkips, maxSkipAttemptRecords),
+	})
 }
 
 // ForwardedAttempts 返回真实发往上游的尝试次数，不包含跳过和熔断拒绝。

--- a/internal/relay/balancer/iterator_skip_cap_test.go
+++ b/internal/relay/balancer/iterator_skip_cap_test.go
@@ -1,0 +1,103 @@
+package balancer
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/lingyuins/octopus/internal/model"
+)
+
+func newTestIterator(t *testing.T) *Iterator {
+	t.Helper()
+	group := model.Group{
+		Items: []model.GroupItem{{ChannelID: 1, ModelName: "gpt-4o"}},
+	}
+	it := NewIterator(group, 0, "gpt-4o", nil)
+	if !it.Next() {
+		t.Fatal("iterator has no candidates")
+	}
+	return it
+}
+
+// 跳过明细超过 maxSkipAttemptRecords 后不再膨胀，Attempts 以一条汇总记录
+// 说明省略数量（issue #192：无上限时单条 relay log 曾膨胀到数百 MB）。
+func TestIterator_SkipRecordsCapped(t *testing.T) {
+	it := newTestIterator(t)
+
+	const total = maxSkipAttemptRecords + 500
+	for i := 0; i < total; i++ {
+		it.Skip(1, 1, "ch", "no available key")
+	}
+
+	attempts := it.Attempts()
+	if len(attempts) != maxSkipAttemptRecords+1 {
+		t.Fatalf("len(attempts) = %d, want %d (cap + 1 条汇总)", len(attempts), maxSkipAttemptRecords+1)
+	}
+	last := attempts[len(attempts)-1]
+	if !strings.Contains(last.Msg, fmt.Sprintf("%d", total-maxSkipAttemptRecords)) {
+		t.Fatalf("汇总记录未包含省略条数: %q", last.Msg)
+	}
+	if last.AttemptNum != total {
+		t.Fatalf("汇总记录 AttemptNum = %d, want %d（保留总计数）", last.AttemptNum, total)
+	}
+}
+
+// 未超限时 Attempts 不追加汇总记录，行为与旧版一致。
+func TestIterator_SkipRecordsUnderCapUnchanged(t *testing.T) {
+	it := newTestIterator(t)
+	for i := 0; i < 10; i++ {
+		it.Skip(1, 1, "ch", "reason")
+	}
+	if got := len(it.Attempts()); got != 10 {
+		t.Fatalf("len(attempts) = %d, want 10", got)
+	}
+}
+
+// 跳过截断不影响真实转发记录与 ForwardedAttempts 语义
+// （最大总尝试次数配额只数真实转发）。
+func TestIterator_ForwardedAttemptsUnaffectedByCap(t *testing.T) {
+	it := newTestIterator(t)
+
+	for i := 0; i < maxSkipAttemptRecords+50; i++ {
+		it.Skip(1, 1, "ch", "skip")
+	}
+	for i := 0; i < 3; i++ {
+		span := it.StartAttempt(1, 1, "ch", "gpt-4o")
+		span.End(model.AttemptFailed, 500, "upstream error")
+	}
+
+	if got := it.ForwardedAttempts(); got != 3 {
+		t.Fatalf("ForwardedAttempts() = %d, want 3", got)
+	}
+	// 真实转发记录必须保留在明细里（跳过截断只丢跳过记录）。
+	forwarded := 0
+	for _, a := range it.Attempts() {
+		if a.Status == model.AttemptFailed {
+			forwarded++
+		}
+	}
+	if forwarded != 3 {
+		t.Fatalf("明细中的真实转发记录 = %d, want 3", forwarded)
+	}
+}
+
+// SkipCircuitBreak 与 Skip 共享同一上限。
+func TestIterator_CircuitBreakRecordsShareCap(t *testing.T) {
+	it := newTestIterator(t)
+
+	// 连续失败超过默认阈值（5）触发熔断。
+	for i := 0; i < 6; i++ {
+		RecordFailure(9101, 9102, "gpt-4o")
+	}
+	defer RecordSuccess(9101, 9102, "gpt-4o")
+
+	for i := 0; i < maxSkipAttemptRecords+20; i++ {
+		if !it.SkipCircuitBreak(9101, 9102, "ch", "gpt-4o") {
+			t.Fatal("SkipCircuitBreak 应返回 true（已熔断）")
+		}
+	}
+	if got := len(it.Attempts()); got != maxSkipAttemptRecords+1 {
+		t.Fatalf("len(attempts) = %d, want %d", got, maxSkipAttemptRecords+1)
+	}
+}

--- a/internal/relay/issue192_retry_loop_test.go
+++ b/internal/relay/issue192_retry_loop_test.go
@@ -1,0 +1,44 @@
+package relay
+
+import (
+	"testing"
+
+	dbmodel "github.com/lingyuins/octopus/internal/model"
+	"github.com/lingyuins/octopus/internal/relay/balancer"
+)
+
+// issue #192 回归：渠道内 key 循环的终止性依赖「被跳过（失败提示/熔断）的 key
+// 进入 failedKeyIDs 后，重选必须排除它们，全部排除后返回空并 break」。
+// 修复前 keyRound == 1 的重选不排除 failedKeyIDs，确定性选 key 策略会选回
+// 刚被跳过的同一个 key，造成无限自旋，attempts 记录无限增长
+// （实测单条 relay log 440 万条记录 / 805MB）。
+func TestPrepareCandidateForRetry_AllKeysExcludedReturnsEmpty(t *testing.T) {
+	channel := &dbmodel.Channel{
+		ID: 9201,
+		Keys: []dbmodel.ChannelKey{
+			{ID: 1, ChannelKey: "sk-a", Enabled: true},
+			{ID: 2, ChannelKey: "sk-b", Enabled: true},
+		},
+	}
+	iter := balancer.NewIterator(dbmodel.Group{
+		Items: []dbmodel.GroupItem{{ChannelID: 9201, ModelName: "gpt-4o"}},
+	}, 0, "gpt-4o", nil)
+	if !iter.Next() {
+		t.Fatal("iterator has no candidates")
+	}
+
+	// 部分排除：仍能选出未排除的 key。
+	usedKey, _ := PrepareCandidateForRetry(channel, []int{1}, iter, 300, "gpt-4o")
+	if usedKey.ID != 2 {
+		t.Fatalf("排除 key 1 后应选 key 2，got %d", usedKey.ID)
+	}
+
+	// 全部排除：返回空 key，key 循环据此 break，保证不会自旋。
+	usedKey, reason := PrepareCandidateForRetry(channel, []int{1, 2}, iter, 300, "gpt-4o")
+	if usedKey.ChannelKey != "" {
+		t.Fatalf("全部 key 被排除后应返回空，got key ID %d", usedKey.ID)
+	}
+	if reason != "no more keys to retry" {
+		t.Fatalf("reason = %q, want 'no more keys to retry'", reason)
+	}
+}

--- a/internal/relay/media_relay.go
+++ b/internal/relay/media_relay.go
@@ -226,7 +226,10 @@ func MediaHandler(endpointType MediaEndpointType, c *gin.Context) {
 				}
 
 				var usedKey dbmodel.ChannelKey
-				if keyRound == 1 {
+				// keyRound == 1 但 failedKeyIDs 非空 = 熔断跳过后的重选（跳过分支
+				// keyRound-- 不消耗配额），必须排除已失败 key，否则确定性选 key
+				// 会选回同一个 key 造成死循环（issue #192，与 relay.go 同因）。
+				if keyRound == 1 && len(failedKeyIDs) == 0 {
 					usedKey = channel.GetChannelKeyWithCooldown(resolvedModel, ratelimitCooldown)
 				} else {
 					usedKey = channel.GetChannelKeyExcludingWithCooldown(failedKeyIDs, resolvedModel, ratelimitCooldown)

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -1532,7 +1532,12 @@ func executeRelay(req *relayRequest, group dbmodel.Group, requestModel string, m
 						Priority:   acct.Priority,
 					}
 				} else {
-					if keyRound == 1 {
+					// keyRound == 1 但 failedKeyIDs 非空 = 失败提示/熔断跳过后的重选
+					// （跳过分支 keyRound-- 不消耗配额）。此时必须走排除路径：
+					// 无排除的选 key 是确定性的，会选回刚被跳过的同一个 key，
+					// 造成「跳过 → 重选同 key → 再跳过」的死循环，attempts 记录
+					// 无限增长（issue #192，实测单条 relay log 440 万条记录）。
+					if keyRound == 1 && len(failedKeyIDs) == 0 {
 						usedKey = channel.GetChannelKeyWithCooldown(resolvedModelName, ratelimitCooldown)
 					} else {
 						usedKey, _ = PrepareCandidateForRetry(channel, failedKeyIDs, routeIter, ratelimitCooldown, resolvedModelName)


### PR DESCRIPTION
Fixes #192

## 根因

#192 报告的「渠道全部不可用时单请求无限重试、`relay_logs.attempts` 单条爆到 805MB」，直接原因不是 `relay_max_total_attempts = 0`，而是 key 重试循环里的一个自旋缺陷：

`executeRelay` 的失败提示/熔断跳过分支通过 `keyRound--` 实现「跳过不消耗重试配额」，但 `keyRound == 1` 的重选走 `GetChannelKeyWithCooldown`——它**不排除 `failedKeyIDs`**。cost/priority 等选 key 策略是确定性的，会精确选回刚被跳过的那个 key：

```
选 key A → A 有失败提示/已熔断 → Skip 记录 + failedKeyIDs+=A + keyRound-- → keyRound 仍为 1
        → 再选 key A（不排除）→ 再 Skip → …… 直到提示 TTL / 熔断冷却结束
```

每圈向内存中的 `iter.attempts` 追加一条 ~180B 记录，最终整体序列化进 `relay_logs.attempts`——即 issue 中实测的 440 万条 `"status":"circuit_break"` 记录。冷却到期后一次真实转发失败又会重新触发提示/熔断，自旋跨周期持续数小时至数天（`use_time` 12.7 天）。

`relay_max_total_attempts` 对此无约束力：`ForwardedAttempts()` 明确排除 skip/circuit_break 记录，自旋不占「最大总尝试次数」配额。issue 作者把上限设为 50 有效，是因为它让请求在 50 次真实转发后尽早结束，间接缩短了自旋窗口。

`media_relay.go` 的 key 循环有完全同型的自旋（熔断跳过 + `keyRound--` + 无排除重选）。

## 修复

1. **根治自旋**（`relay.go` / `media_relay.go`）：重选条件改为 `keyRound == 1 && len(failedKeyIDs) == 0`。被跳过的 key 已进入 `failedKeyIDs`，重选走排除路径；全部排除后返回空 key，正常 break 换渠道。每个 key 每次渠道访问至多被跳过一次，循环严格有界。
2. **纵深防御**（`balancer/iterator.go`）：跳过/熔断明细单迭代器上限 200 条，超限只累计条数，`Attempts()` 追加一条汇总记录（`"N skip/circuit-break records omitted"`）说明省略数量。即使未来出现新的高频跳过路径，relay log 单行体积也有硬上限（~40KB 级）。真实转发记录不受限，`ForwardedAttempts` / 最大总尝试次数语义不变。

关于 issue 建议的「`relay_max_total_attempts = 0` 时给默认上限」：这是产品语义变更（现有注释明确 0 = 不限制），本 PR 不改动，留给维护者决策；根治自旋后，0 值下请求也会在遍历完可用渠道后正常返回 502。

## 验证

- 新增回归测试：
  - `iterator_skip_cap_test.go`：跳过明细上限、汇总记录、`ForwardedAttempts` 不受截断影响、SkipCircuitBreak 共享上限（4 个用例）
  - `issue192_retry_loop_test.go`：key 排除耗尽返回空（自旋终止性依赖的路径）
- `go vet ./...` 通过，`go test ./...` 全量通过
