### PR TITLE
fix: 渠道代理池前端无入口且保存渠道静默清空 proxy_config_id（issue #195）

### DIFF
--- a/internal/op/channel/channel.go
+++ b/internal/op/channel/channel.go
@@ -339,9 +339,16 @@ func Update(req *model.ChannelUpdateRequest, ctx context.Context) (*model.Channe
 			legacyChannelProxy = req.ChannelProxy
 		}
 
-		// 仅传旧字段时，从 legacy 推导新模式
+		// 仅传旧字段时，从 legacy 推导新模式。
+		// issue #195：旧字段（proxy 开关 / channel_proxy 文本）表达不了代理池绑定，
+		// 已绑定代理池的渠道若被 legacy-only 请求推导覆盖，proxy_config_id 会被静默清成
+		// NULL 落库。此处保留原有 pool 绑定，解绑必须显式传 proxy_mode。
 		if req.ProxyMode == nil && (req.Proxy != nil || req.ChannelProxy != nil) {
-			mode, configID = deriveProxyModeFromLegacy(legacyProxy, legacyChannelProxy)
+			if current.ProxyMode == model.ProxyUsageModePool && current.ProxyConfigID != nil {
+				mode, configID = current.ProxyMode, current.ProxyConfigID
+			} else {
+				mode, configID = deriveProxyModeFromLegacy(legacyProxy, legacyChannelProxy)
+			}
 		}
 
 		tmp := model.Channel{

--- a/internal/op/channel/update_test.go
+++ b/internal/op/channel/update_test.go
@@ -131,3 +131,104 @@ func TestUpdatePatchSemanticsLeavesOtherFieldsUntouched(t *testing.T) {
 	}
 	assertAdvancedFields(t, &got, want)
 }
+
+// bindProxyPool 通过显式 proxy_mode=pool 为渠道绑定代理池配置。
+func bindProxyPool(t *testing.T, channelID, configID int) {
+	t.Helper()
+	poolMode := model.ProxyUsageModePool
+	req := &model.ChannelUpdateRequest{ID: channelID, ProxyMode: &poolMode, ProxyConfigID: &configID}
+	if _, err := Update(req, context.Background()); err != nil {
+		t.Fatalf("bind proxy pool failed: %v", err)
+	}
+}
+
+// assertProxyBinding 断言渠道（缓存返回值 + DB 读回值）的代理模式与配置绑定。
+func assertProxyBinding(t *testing.T, channelID int, wantMode model.ProxyUsageMode, wantConfigID *int) {
+	t.Helper()
+	var got model.Channel
+	if err := db.GetDB().First(&got, channelID).Error; err != nil {
+		t.Fatalf("reload from DB failed: %v", err)
+	}
+	if got.ProxyMode != wantMode {
+		t.Fatalf("ProxyMode = %q, want %q", got.ProxyMode, wantMode)
+	}
+	if wantConfigID == nil {
+		if got.ProxyConfigID != nil {
+			t.Fatalf("ProxyConfigID = %d, want nil", *got.ProxyConfigID)
+		}
+		return
+	}
+	if got.ProxyConfigID == nil || *got.ProxyConfigID != *wantConfigID {
+		t.Fatalf("ProxyConfigID = %v, want %d", got.ProxyConfigID, *wantConfigID)
+	}
+}
+
+// TestUpdateLegacyProxyFieldsPreservePoolBinding 回归测试 issue #195：
+// 已绑定代理池（proxy_mode=pool + proxy_config_id）的渠道，收到仅含旧字段
+//（proxy 开关 / channel_proxy 文本）的更新请求时，绑定必须保留，
+// 不得被 legacy 推导覆盖成 NULL 静默落库。
+func TestUpdateLegacyProxyFieldsPreservePoolBinding(t *testing.T) {
+	setupBatchGroupTest(t)
+	seedChannel(t, 1, 1)
+
+	configID := 3
+	bindProxyPool(t, 1, configID)
+	assertProxyBinding(t, 1, model.ProxyUsageModePool, &configID)
+
+	// 模拟旧前端：仅切换 proxy 开关为 false（issue #195 复现步骤 6）
+	proxyOff := false
+	if _, err := Update(&model.ChannelUpdateRequest{ID: 1, Proxy: &proxyOff}, context.Background()); err != nil {
+		t.Fatalf("legacy proxy-off Update returned error: %v", err)
+	}
+	assertProxyBinding(t, 1, model.ProxyUsageModePool, &configID)
+
+	// 模拟旧前端：在渠道代理输入框输入再清空（提交空串）
+	empty := ""
+	if _, err := Update(&model.ChannelUpdateRequest{ID: 1, ChannelProxy: &empty}, context.Background()); err != nil {
+		t.Fatalf("legacy channel-proxy-clear Update returned error: %v", err)
+	}
+	assertProxyBinding(t, 1, model.ProxyUsageModePool, &configID)
+
+	// 模拟旧前端：proxy 开关重新打开且填入自定义地址，绑定同样保留
+	proxyOn := true
+	customURL := "http://127.0.0.1:7890"
+	if _, err := Update(&model.ChannelUpdateRequest{ID: 1, Proxy: &proxyOn, ChannelProxy: &customURL}, context.Background()); err != nil {
+		t.Fatalf("legacy custom-url Update returned error: %v", err)
+	}
+	assertProxyBinding(t, 1, model.ProxyUsageModePool, &configID)
+}
+
+// TestUpdateExplicitProxyModeStillUnbindsPool 显式传 proxy_mode 时用户意图明确，
+// 仍可解除代理池绑定（direct 模式清空 proxy_config_id）。
+func TestUpdateExplicitProxyModeStillUnbindsPool(t *testing.T) {
+	setupBatchGroupTest(t)
+	seedChannel(t, 1, 1)
+
+	configID := 3
+	bindProxyPool(t, 1, configID)
+
+	directMode := model.ProxyUsageModeDirect
+	if _, err := Update(&model.ChannelUpdateRequest{ID: 1, ProxyMode: &directMode}, context.Background()); err != nil {
+		t.Fatalf("explicit direct Update returned error: %v", err)
+	}
+	assertProxyBinding(t, 1, model.ProxyUsageModeDirect, nil)
+}
+
+// TestUpdateLegacyDerivationStillWorksWithoutPoolBinding 未绑定代理池的渠道，
+// legacy 字段推导行为保持不变（proxy=true 无地址 → system；proxy=false → direct）。
+func TestUpdateLegacyDerivationStillWorksWithoutPoolBinding(t *testing.T) {
+	setupBatchGroupTest(t)
+	seedChannel(t, 1, 1)
+
+	proxyOn := true
+	if _, err := Update(&model.ChannelUpdateRequest{ID: 1, Proxy: &proxyOn}, context.Background()); err != nil {
+		t.Fatalf("legacy proxy-on Update returned error: %v", err)
+	}
+	assertProxyBinding(t, 1, model.ProxyUsageModeSystem, nil)
+
+	proxyOff := false
+	if _, err := Update(&model.ChannelUpdateRequest{ID: 1, Proxy: &proxyOff}, context.Background()); err != nil {
+		t.Fatalf("legacy proxy-off Update returned error: %v", err)
+	}
+	assertProxyBinding(t, 1, model.ProxyUsageModeDirect, nil)
+}

--- a/internal/server/handlers/channel.go
+++ b/internal/server/handlers/channel.go
@@ -371,6 +371,8 @@ type channelRequestPayload struct {
 	Keys                 []channelKeyRequestPayload  `json:"keys"`
 	Model                string                      `json:"model"`
 	CustomModel          string                      `json:"custom_model"`
+	ProxyMode            model.ProxyUsageMode        `json:"proxy_mode"`
+	ProxyConfigID        *int                        `json:"proxy_config_id"`
 	Proxy                bool                        `json:"proxy"`
 	AutoSync             bool                        `json:"auto_sync"`
 	AutoGroup            model.AutoGroupType         `json:"auto_group"`
@@ -411,8 +413,9 @@ func (p channelRequestPayload) toChannel() model.Channel {
 		})
 	}
 
-	// 兼容旧前端：proxy + channel_proxy；新前端可直接传 proxy_mode/proxy_config_id。
-	// 这里先写入旧字段，Create 内 normalizeChannelProxyFields 会推导 ProxyMode。
+	// 兼容旧前端：proxy + channel_proxy；新前端直接传 proxy_mode/proxy_config_id
+	//（issue #195）。proxy_mode 为空时，Create 内 normalizeChannelProxyFields 会从
+	// 旧字段推导 ProxyMode。
 	var channelProxy *string
 	if p.ChannelProxy != nil {
 		trimmed := strings.TrimSpace(*p.ChannelProxy)
@@ -430,6 +433,8 @@ func (p channelRequestPayload) toChannel() model.Channel {
 		Keys:                 keys,
 		Model:                p.Model,
 		CustomModel:          p.CustomModel,
+		ProxyMode:            p.ProxyMode,
+		ProxyConfigID:        p.ProxyConfigID,
 		Proxy:                p.Proxy,
 		AutoSync:             p.AutoSync,
 		SkipModelTest:        p.SkipModelTest,

--- a/web/src/api/endpoints/channel.ts
+++ b/web/src/api/endpoints/channel.ts
@@ -5,6 +5,12 @@ import { logger } from '@/lib/logger';
 import { formatCount, formatMoney, formatTime } from '@/lib/utils';
 import { StatsChannel, type StatsMetricsFormatted } from './stats';
 import { type GroupTestProgress } from './group';
+import type { ProxyMode } from './proxy-pool';
+
+/**
+ * 渠道代理模式（渠道无上级实体，不支持 inherit）
+ */
+export type ChannelProxyMode = Exclude<ProxyMode, 'inherit'>;
 /**
  * 渠道类型枚举
  */
@@ -106,6 +112,8 @@ export type Channel = {
     keys: ChannelKey[];
     model: string;
     custom_model: string;
+    proxy_mode: ChannelProxyMode;
+    proxy_config_id?: number | null;
     proxy: boolean;
     auto_sync: boolean;
     auto_group: AutoGroupType;
@@ -145,6 +153,8 @@ export type CreateChannelRequest = {
     keys: Array<Pick<ChannelKey, 'enabled' | 'channel_key' | 'priority' | 'remark'>>;
     model: string;
     custom_model?: string;
+    proxy_mode?: ChannelProxyMode;
+    proxy_config_id?: number | null;
     proxy?: boolean;
     auto_sync?: boolean;
     skip_model_test?: boolean;
@@ -173,6 +183,8 @@ export type UpdateChannelRequest = {
     base_urls?: BaseUrl[];
     model?: string;
     custom_model?: string;
+    proxy_mode?: ChannelProxyMode;
+    proxy_config_id?: number | null;
     proxy?: boolean;
     auto_sync?: boolean;
     key_selection_strategy?: string;
@@ -197,6 +209,8 @@ export type FetchModelRequest = {
     type: ChannelType;
     base_urls: BaseUrl[];
     keys: Array<Pick<ChannelKey, 'enabled' | 'channel_key'>>;
+    proxy_mode?: ChannelProxyMode;
+    proxy_config_id?: number | null;
     proxy?: boolean;
     channel_proxy?: string | null;
     match_regex?: string | null;

--- a/web/src/components/modules/channel/CardContent.tsx
+++ b/web/src/components/modules/channel/CardContent.tsx
@@ -47,6 +47,7 @@ import {
 } from '@/components/ui/select';
 import {
     ChannelForm,
+    deriveChannelProxyMode,
     getEffectiveRequestRewriteFormData,
     normalizeRequestRewriteFormData,
     type ChannelFormData,
@@ -151,7 +152,8 @@ export function CardContent({ channel, stats }: { channel: Channel; stats: Stats
             : [{ enabled: true, channel_key: '', priority: 0, remark: '' }],
         model: channel.model,
         custom_model: channel.custom_model,
-        proxy: channel.proxy,
+        proxy_mode: deriveChannelProxyMode(channel),
+        proxy_config_id: channel.proxy_config_id ?? null,
         auto_sync: channel.auto_sync,
         auto_group: channel.auto_group,
         skip_model_test: channel.skip_model_test,
@@ -163,6 +165,7 @@ export function CardContent({ channel, stats }: { channel: Channel; stats: Stats
         pool_id: channel.pool_id ?? 0,
     });
     const t = useTranslations('channel.detail');
+    const tProxy = useTranslations('proxyPool');
 
     const publicApiBaseUrl = settings?.find((item) => item.key === SettingKey.PublicAPIBaseURL)?.value?.trim() ?? '';
 
@@ -177,6 +180,11 @@ export function CardContent({ channel, stats }: { channel: Channel; stats: Stats
 
     const handleUpdate = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
+        // pool 模式必须选择代理配置（或在渠道代理框保留自定义地址），与后端校验一致
+        if (formData.proxy_mode === 'pool' && !formData.proxy_config_id && !formData.channel_proxy.trim()) {
+            toast.error(tProxy('selectRequired'));
+            return;
+        }
         const req: UpdateChannelRequest = { id: channel.id };
         const effectiveRequestRewrite = getEffectiveRequestRewriteFormData(formData.type, formData.request_rewrite);
 
@@ -194,7 +202,13 @@ export function CardContent({ channel, stats }: { channel: Channel; stats: Stats
         }
         if (formData.model !== channel.model) req.model = formData.model;
         if (formData.custom_model !== channel.custom_model) req.custom_model = formData.custom_model;
-        if (formData.proxy !== channel.proxy) req.proxy = formData.proxy;
+        const curProxyMode = deriveChannelProxyMode(channel);
+        const nextProxyConfigId = formData.proxy_mode === 'pool' ? formData.proxy_config_id : null;
+        if (formData.proxy_mode !== curProxyMode || nextProxyConfigId !== (channel.proxy_config_id ?? null)) {
+            // 显式发送 proxy_mode + proxy_config_id，后端不再走 legacy 推导（issue #195）
+            req.proxy_mode = formData.proxy_mode;
+            req.proxy_config_id = nextProxyConfigId;
+        }
         if (formData.auto_sync !== channel.auto_sync) req.auto_sync = formData.auto_sync;
         if (formData.skip_model_test !== channel.skip_model_test) req.skip_model_test = formData.skip_model_test;
         if (formData.disposable !== (channel.disposable ?? false)) req.disposable = formData.disposable;

--- a/web/src/components/modules/channel/Create.tsx
+++ b/web/src/components/modules/channel/Create.tsx
@@ -24,6 +24,7 @@ import {
 import { channelTemplates } from './templates';
 import { DEFAULT_CHANNEL_TYPE } from './type-options';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { toast } from '@/components/common/Toast';
 
 export function CreateDialogContent() {
     const { setIsOpen } = useMorphingDialog();
@@ -50,12 +51,14 @@ export function CreateDialogContent() {
         notif_channel_id: null,
         key_selection_strategy: '',
         enabled: true,
-        proxy: false,
+        proxy_mode: 'direct',
+        proxy_config_id: null,
         match_regex: '',
         pool_id: 0,
     });
     const t = useTranslations('channel.create');
     const tForm = useTranslations('channel.form');
+    const tProxy = useTranslations('proxyPool');
 
     const resetFormData = () => {
         setFormData({
@@ -78,7 +81,8 @@ export function CreateDialogContent() {
             notif_channel_id: null,
             key_selection_strategy: '',
             enabled: true,
-            proxy: false,
+            proxy_mode: 'direct',
+            proxy_config_id: null,
             match_regex: '',
             pool_id: 0,
         });
@@ -94,6 +98,11 @@ export function CreateDialogContent() {
 
     const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
+        // pool 模式必须选择代理配置（或填写自定义渠道代理地址），与后端校验一致
+        if (formData.proxy_mode === 'pool' && !formData.proxy_config_id && !formData.channel_proxy.trim()) {
+            toast.error(tProxy('selectRequired'));
+            return;
+        }
         const normalizedBaseUrls = (formData.base_urls ?? []).filter((u) => u.url.trim()).map((u) => ({
             url: u.url.trim(),
             delay: Number(u.delay || 0),
@@ -122,7 +131,9 @@ export function CreateDialogContent() {
                 keys: normalizedKeys,
                 model: formData.model,
                 custom_model: formData.custom_model,
-                proxy: formData.proxy,
+                proxy_mode: formData.proxy_mode,
+                proxy_config_id: formData.proxy_mode === 'pool' ? formData.proxy_config_id : null,
+                proxy: formData.proxy_mode !== 'direct',
                 auto_sync: formData.auto_sync,
                 auto_group: formData.auto_group,
                 key_selection_strategy: formData.key_selection_strategy,

--- a/web/src/components/modules/channel/Form.tsx
+++ b/web/src/components/modules/channel/Form.tsx
@@ -13,7 +13,9 @@ import {
     type KeyModelResult,
     useTestChannel,
     type TestChannelSummary,
+    type ChannelProxyMode,
 } from '@/api/endpoints/channel';
+import { ProxySelector } from '@/components/modules/proxy-pool/ProxySelector';
 import { useAlertNotifChannelList } from '@/api/endpoints/alert';
 import { useSettingList, SettingKey } from '@/api/endpoints/setting';
 import { usePoolList } from '@/api/endpoints/pool';
@@ -73,7 +75,8 @@ export interface ChannelFormData {
     model: string;
     custom_model: string;
     enabled: boolean;
-    proxy: boolean;
+    proxy_mode: ChannelProxyMode;
+    proxy_config_id: number | null;
     auto_sync: boolean;
     auto_group: AutoGroupType;
     skip_model_test: boolean;
@@ -83,6 +86,18 @@ export interface ChannelFormData {
     key_selection_strategy: string;
     match_regex: string;
     pool_id: number;
+}
+
+/**
+ * 从渠道数据推导表单展示用的代理模式，镜像后端 resolveChannelProxy 的兼容语义
+ *（issue #195）：历史数据可能 proxy_mode=direct 但旧 proxy 布尔仍为 true，
+ * 此时按 legacy 字段回退展示，避免"开关开着但地址为空"的误导状态。
+ */
+export function deriveChannelProxyMode(channel: Pick<Channel, 'proxy_mode' | 'proxy' | 'channel_proxy'>): ChannelProxyMode {
+    const mode = channel.proxy_mode;
+    if (mode && mode !== 'direct') return mode;
+    if (!channel.proxy) return 'direct';
+    return channel.channel_proxy?.trim() ? 'pool' : 'system';
 }
 
 export function createDefaultRequestRewriteFormData(): RequestRewriteConfig {
@@ -731,7 +746,9 @@ export function ChannelForm({
         keys: formData.keys
             .filter((k) => k.channel_key.trim())
             .map((k) => ({ enabled: k.enabled, channel_key: k.channel_key.trim(), remark: k.remark ?? '' })),
-        proxy: formData.proxy,
+        proxy_mode: formData.proxy_mode,
+        proxy_config_id: formData.proxy_mode === 'pool' ? formData.proxy_config_id : null,
+        proxy: formData.proxy_mode !== 'direct',
         channel_proxy: formData.channel_proxy?.trim() || '',
         match_regex: formData.match_regex.trim() || '',
         custom_header: normalizedHeaders,
@@ -797,7 +814,9 @@ export function ChannelForm({
             keys: formData.keys
                 .filter((k) => k.channel_key.trim())
                 .map((k) => ({ enabled: k.enabled, channel_key: k.channel_key.trim() })),
-            proxy: formData.proxy,
+            proxy_mode: formData.proxy_mode,
+            proxy_config_id: formData.proxy_mode === 'pool' ? formData.proxy_config_id : null,
+            proxy: formData.proxy_mode !== 'direct',
             channel_proxy: formData.channel_proxy?.trim() || '',
             match_regex: formData.match_regex.trim() || '',
             custom_header: normalizedHeaders,
@@ -1372,6 +1391,14 @@ export function ChannelForm({
                     </AccordionTrigger>
                     <AccordionContent className="pt-4">
                         <div className="space-y-4">
+                        <ProxySelector
+                            value={{ proxy_mode: formData.proxy_mode, proxy_config_id: formData.proxy_config_id }}
+                            onChange={(next) => onFormDataChange({
+                                ...formData,
+                                proxy_mode: next.proxy_mode as ChannelProxyMode,
+                                proxy_config_id: next.proxy_config_id ?? null,
+                            })}
+                        />
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <div className={fieldGroupClassName}>
                                 <label htmlFor={`${idPrefix}-auto-group`} className={labelClassName}>
@@ -1621,13 +1648,6 @@ export function ChannelForm({
                     <span className="text-sm font-medium text-card-foreground">{t('enabled')}</span>
                 </label>
                 <div className="flex flex-wrap items-center gap-x-6 gap-y-3 border-t border-border/10 pt-4">
-                    <label className="flex items-center gap-2 cursor-pointer">
-                        <Switch
-                            checked={formData.proxy}
-                            onCheckedChange={(checked) => onFormDataChange({ ...formData, proxy: checked })}
-                        />
-                        <span className="text-sm text-card-foreground">{t('proxy')}</span>
-                    </label>
                     <label className="flex items-center gap-2 cursor-pointer">
                         <Switch
                             checked={formData.auto_sync}


### PR DESCRIPTION
## 关联 Issue

Fixes #195

## 问题核实

issue 指认的三处问题均已在最新 master 上复核属实：

1. **数据丢失（核心 Bug）**：`internal/op/channel/channel.go` 中 Update 的 legacy 推导分支在仅收到旧字段（`proxy` / `channel_proxy`）时，会用 `deriveProxyModeFromLegacy` 的返回值覆盖 mode 与 configID，而该函数三个分支返回的 configID 恒为 `nil`；`proxy_config_id` 又在 selectFields 白名单内，NULL 会真实落库。旧前端永远只发旧字段，任何一次渠道编辑都会静默清空已绑定的代理池。
2. **前端无入口**：`ProxySelector` 组件已在站点/号池/套餐供应商 4 处使用，但渠道模块未接入；`channel.ts` 三个类型均无 `proxy_mode` / `proxy_config_id` 字段。
3. **误导显示**：pool 模式下后端强制 `proxy=true`，前端显示为「代理开关开 + 地址为空」，诱导用户改动后触发第 1 条。

## 修复内容

### 后端止血
- Update 的 legacy 推导不再覆盖已有 pool 绑定：渠道当前为 `pool` 且 `proxy_config_id` 非空时，legacy-only 请求保留原绑定；解绑必须显式传 `proxy_mode`（旧字段本就表达不了池绑定）。
- `channelRequestPayload` 补 `proxy_mode` / `proxy_config_id`，创建渠道与测试/拉模型接口支持新字段；`proxy_mode` 为空时仍走 legacy 推导，旧客户端行为不变。

### 前端完整修复
- 渠道表单（编辑 + 创建）在高级设置中接入既有 `ProxySelector`（direct / system / pool 三态），移除原 `proxy` 布尔开关；保留「渠道代理」地址输入框（pool 模式下无 config id 时作为自定义代理地址，与后端语义一致）。
- 表单初始化按后端 `resolveChannelProxy` 的兼容语义推导展示模式（`deriveChannelProxyMode`），历史数据（`proxy_mode=direct` 但旧 `proxy=true`）不再显示为误导状态。
- `Channel` / `CreateChannelRequest` / `UpdateChannelRequest` / `FetchModelRequest` 补 `proxy_mode`、`proxy_config_id`；更新/创建/测试渠道均显式发送新字段（同时保留 legacy `proxy` 布尔以兼容）。
- pool 模式未选代理配置且无自定义地址时，前端提交前拦截并提示（复用 `proxyPool.selectRequired` 文案，与站点模块一致），后端同样校验兜底。

## 回归测试

`internal/op/channel/update_test.go` 新增 3 个测试，且已验证在未修复的代码上会失败：
- `TestUpdateLegacyProxyFieldsPreservePoolBinding`：按 issue 复现步骤，legacy-only 请求（切开关 / 清空地址 / 填自定义地址）均不丢失池绑定
- `TestUpdateExplicitProxyModeStillUnbindsPool`：显式 `proxy_mode=direct` 仍可解绑
- `TestUpdateLegacyDerivationStillWorksWithoutPoolBinding`：未绑定池的渠道 legacy 推导行为不变

## 验证

- `go build ./...` / `go vet` 通过；`go test ./internal/op/... ./internal/server/... ./internal/helper/...` 全部通过
- 前端 `pnpm lint`（0 error）、`pnpm test:i18n`、`pnpm test:unit`（165 pass）、`next build` 全部通过