### PR TITLE
fix: bound stream session memory to prevent OOM

### DIFF
--- a/internal/model/setting.go
+++ b/internal/model/setting.go
@@ -85,6 +85,7 @@ const (
 	SettingKeyStreamSessionTTLMinutes              SettingKey = "stream_session_ttl_minutes"               // 流会话TTL（分钟）
 	SettingKeyStreamSessionMaxEvents               SettingKey = "stream_session_max_events"                // 流会话最大事件数
 	SettingKeyStreamSessionMaxBytesMB              SettingKey = "stream_session_max_bytes_mb"              // 流会话最大字节数（MB）
+	SettingKeyStreamSessionMaxSessions             SettingKey = "stream_session_max_sessions"              // 流会话全局并发上限（超限驱逐最旧会话；内存上限≈本值×最大字节数）
 	SettingKeyNotifyHTTPTimeoutSeconds             SettingKey = "notify_http_timeout_seconds"              // 通知HTTP请求超时（秒）
 	SettingKeyFailureHintTTLUnauthorized           SettingKey = "failure_hint_ttl_unauthorized"            // 认证失败提示缓存TTL（秒）
 	SettingKeyFailureHintTTLRateLimit              SettingKey = "failure_hint_ttl_rate_limit"              // 限流失败提示缓存TTL（秒）
@@ -187,6 +188,7 @@ func DefaultSettings() []Setting {
 		{Key: SettingKeyStreamSessionTTLMinutes, Value: "30"},    // 默认30分钟
 		{Key: SettingKeyStreamSessionMaxEvents, Value: "4096"},   // 默认4096条
 		{Key: SettingKeyStreamSessionMaxBytesMB, Value: "4"},     // 默认4MB
+		{Key: SettingKeyStreamSessionMaxSessions, Value: "512"},  // 默认512个并发流会话（512×4MB≈2GB 最坏内存上限）
 		{Key: SettingKeyNotifyHTTPTimeoutSeconds, Value: "10"},   // 默认10秒
 		{Key: SettingKeyFailureHintTTLUnauthorized, Value: "10"}, // 默认10秒
 		{Key: SettingKeyFailureHintTTLRateLimit, Value: "5"},     // 默认5秒
@@ -252,6 +254,7 @@ func (s *Setting) Validate() error {
 		SettingKeyJWTDefaultExpiryMinutes, SettingKeyJWTRememberMeExpiryDays,
 		SettingKeyLoginRateLimitWindow, SettingKeyLoginRateLimitMaxFailed,
 		SettingKeyStreamSessionTTLMinutes, SettingKeyStreamSessionMaxEvents, SettingKeyStreamSessionMaxBytesMB,
+		SettingKeyStreamSessionMaxSessions,
 		SettingKeyNotifyHTTPTimeoutSeconds,
 		SettingKeyFailureHintTTLUnauthorized, SettingKeyFailureHintTTLRateLimit, SettingKeyFailureHintTTLNetwork,
 		SettingKeyPoolTokenRefreshInterval, SettingKeyPoolQuotaSyncInterval, SettingKeyPlanProviderRefreshInterval,
@@ -269,6 +272,10 @@ func (s *Setting) Validate() error {
 		}
 		if (s.Key == SettingKeyRatelimitCooldown || s.Key == SettingKeyRelayMaxTotalAttempts) && v < 0 {
 			return fmt.Errorf("setting value must be greater than or equal to 0")
+		}
+		// 允许设为 0：0 表示不限制流会话总数（不推荐，最坏情况会吃光内存）。
+		if s.Key == SettingKeyStreamSessionMaxSessions && v < 0 {
+			return fmt.Errorf("stream session max sessions must be greater than or equal to 0")
 		}
 		if (s.Key == SettingKeyRateLimitHoldInterval || s.Key == SettingKeyRateLimitHoldMaxWait) && v < 1 {
 			return fmt.Errorf("rate limit hold setting must be greater than 0")

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -936,6 +936,10 @@ func (ra *relayAttempt) handleStreamResponse(ctx context.Context, response *http
 		}
 		clientDisconnected = true
 		clientDone = nil
+		// 启动断连宽限计时。带 stream session 时循环会继续读上游（以支持断线
+		// 重连重放），这段时间里会话既不是 done、也无法被驱逐，其缓冲会一直占
+		// 着内存。宽限期到后由下面的 clientGoneTicker 强制收尾（issue #196）。
+		ra.streamSession.MarkClientGone()
 	}
 	logClientDisconnected := func() {
 		if !clientDisconnected || clientDisconnectLogged {
@@ -999,6 +1003,16 @@ func (ra *relayAttempt) handleStreamResponse(ctx context.Context, response *http
 	heartbeatTicker := time.NewTicker(conf.SSEHeartbeatInterval)
 	defer heartbeatTicker.Stop()
 
+	// 客户端断连后的宽限期检查。仅在存在 stream session 时有意义：没有 session
+	// 的请求在客户端断连时会直接返回。周期远小于宽限期，保证及时收尾。
+	var clientGoneTicker *time.Ticker
+	var clientGoneC <-chan time.Time
+	if ra.streamSession != nil {
+		clientGoneTicker = time.NewTicker(relayStreamClientGoneCheckInterval)
+		clientGoneC = clientGoneTicker.C
+		defer clientGoneTicker.Stop()
+	}
+
 	for {
 		select {
 		case <-clientDone:
@@ -1007,6 +1021,30 @@ func (ra *relayAttempt) handleStreamResponse(ctx context.Context, response *http
 				return errClientDisconnected
 			}
 			markClientDisconnected()
+		case <-clientGoneC:
+			// 客户端已断连且上游在宽限期内仍未结束：强制结束会话并停止读取上游，
+			// 避免断连会话的 replay 缓冲长期占用内存（issue #196 的 OOM 主因）。
+			if !clientDisconnected {
+				continue
+			}
+			// 重连的读取者接入时 Subscribe 会清掉宽限计时；它再次离开后这里负责
+			// 重新起表。原请求的 clientCtx 早已 Done，无法再次触发 clientDone 分支，
+			// 因此以「当前是否有订阅者」作为客户端是否在读的判据。
+			if ra.streamSession.HasSubscribers() {
+				continue
+			}
+			ra.streamSession.MarkClientGone()
+			if !ra.streamSession.ClientGoneGraceExceeded() {
+				continue
+			}
+			logClientDisconnected()
+			log.Warnf("client gone and upstream still streaming after %s, closing stream session to release buffer",
+				relayStreamClientGoneGrace)
+			if err := response.Body.Close(); err != nil {
+				log.Warnf("failed to close response body on client-gone grace timeout: %v", err)
+			}
+			ra.streamSession.Finish(errRelayStreamClientGone)
+			return errClientDisconnected
 		case <-firstTokenC:
 			logClientDisconnected()
 			log.Warnf("first token timeout (%ds), switching channel", ra.firstTokenTimeOutSec)

--- a/internal/relay/stream_session.go
+++ b/internal/relay/stream_session.go
@@ -19,15 +19,25 @@ import (
 	dbmodel "github.com/lingyuins/octopus/internal/model"
 	"github.com/lingyuins/octopus/internal/op/setting"
 	"github.com/lingyuins/octopus/internal/server/resp"
+	"github.com/lingyuins/octopus/internal/utils/log"
 )
 
 var (
 	errRelayConversationBusy    = errors.New("conversation already has an active generation")
 	errRelayReplayWindowExpired = errors.New("relay stream replay window expired")
 
-	overrideStreamSessionTTL       *time.Duration
-	overrideStreamSessionMaxEvents *int
-	overrideStreamSessionMaxBytes  *int
+	// errRelayStreamSessionEvicted 表示会话因为会话总数超过硬上限而被强制驱逐。
+	// 只会发生在内存保护兜底路径上（见 enforceSessionLimitLocked）。
+	errRelayStreamSessionEvicted = errors.New("relay stream session evicted: too many concurrent sessions")
+
+	// errRelayStreamClientGone 表示客户端断连后上游在宽限期内仍未结束，会话被
+	// 强制结束以释放缓冲（见 relayStreamClientGoneGrace）。
+	errRelayStreamClientGone = errors.New("relay stream session closed: client gone and upstream exceeded grace period")
+
+	overrideStreamSessionTTL         *time.Duration
+	overrideStreamSessionMaxEvents   *int
+	overrideStreamSessionMaxBytes    *int
+	overrideStreamSessionMaxSessions *int
 )
 
 const (
@@ -39,10 +49,50 @@ const (
 	// 压缩一个数量级，同时保留断线重连重放语义。
 	relayStreamDoneRetention = 2 * time.Minute
 
-	// relayStreamMaxSessions 是全局会话 map 的硬上限。超过时主动驱逐最旧的已完成
-	// 会话，防止 map 在会话获取频率低、清理迟滞时无界增长。
-	relayStreamMaxSessions = 4096
+	// relayStreamMaxSessions 是全局会话 map 的默认硬上限，可由设置
+	// stream_session_max_sessions 覆盖。超过时优先驱逐最旧的已完成会话；仍然
+	// 超限时按最旧优先驱逐活跃会话（见 relayStreamActiveEvictFactor）。
+	//
+	// 默认值从 4096 下调到 512：4096 × 单会话 4MB 缓冲的理论上限是 16GB，对
+	// 自建部署（常见 8~16GB 内存）来说等于没有上限。512 × 4MB = 2GB，仍然远
+	// 大于正常并发所需，同时把最坏情况压到可控范围（见 issue #196 的 OOM）。
+	relayStreamMaxSessions = 512
+
+	// relayStreamActiveEvictFactor 是活跃会话开始被驱逐的宽限倍数：会话总数超过
+	// maxSessions × factor 时，最旧的活跃会话也会被驱逐。
+	//
+	// 之前只驱逐 done 会话，活跃会话「永不驱逐」——注释写的是「活跃会话的 buffer
+	// 受单会话上限约束，且会在 Finish 后释放」，但客户端中途断连时会话会一直保持
+	// 活跃直到上游结束，于是 map 可以无界增长到把内存吃光（issue #196：16GB 主机
+	// 上 RSS 涨到 13.8GB 被内核 OOM killer 杀掉两次）。留一倍宽限是为了尽量不打断
+	// 正在进行的生成，只在确实要 OOM 的方向上才动活跃会话。
+	relayStreamActiveEvictFactor = 2
+
+	// relayStreamClientGoneGrace 是客户端断连后允许上游继续生成的宽限时长。
+	// 到期仍未结束则强制 Finish 该会话并停止读取上游，把「断连会话」占用的
+	// 缓冲内存窗口限制在这个量级内，而不是跟随上游的完整生成时长。
+	//
+	// 保留一段宽限而不是立刻结束，是为了不破坏断线重连重放语义：客户端网络抖动后
+	// 重连仍能拿到这段时间内继续生成的内容。
+	relayStreamClientGoneGrace = 30 * time.Second
+
+	// relayStreamClientGoneCheckInterval 是断连宽限期的轮询间隔。取远小于宽限期
+	// 的值，保证宽限期一到就能及时收尾；同时不必太小——它只在有 stream session
+	// 的流式请求上跑一个 ticker。
+	relayStreamClientGoneCheckInterval = 5 * time.Second
 )
+
+// getStreamSessionMaxSessions 返回全局会话 map 的硬上限。
+// 设置为 0 或负数表示不限制（与旧行为一致，仅供明确知晓风险的部署使用）。
+func getStreamSessionMaxSessions() int {
+	if overrideStreamSessionMaxSessions != nil {
+		return *overrideStreamSessionMaxSessions
+	}
+	if v, err := setting.GetInt(dbmodel.SettingKeyStreamSessionMaxSessions); err == nil && v >= 0 {
+		return v
+	}
+	return relayStreamMaxSessions
+}
 
 func getStreamSessionTTL() time.Duration {
 	if overrideStreamSessionTTL != nil {
@@ -91,6 +141,8 @@ type relayStreamSession struct {
 	updatedAt        time.Time
 	done             bool
 	err              error
+	clientGoneAt     time.Time // 客户端断连时刻；零值表示客户端仍在
+	clientGoneActive bool      // 客户端断连后是否已开始强制结束计时（见 MarkClientGone）
 	nextSeq          int64
 	droppedBeforeSeq int64
 	bufferBytes      int
@@ -160,48 +212,102 @@ func acquireRelayStreamSession(conversationID string, apiKeyID int, requestHash 
 	return session, true, nil
 }
 
-// enforceSessionLimitLocked 在会话总数超过 relayStreamMaxSessions 时，驱逐最旧的
-// 已完成会话，防止全局 map 在清理迟滞时无界增长。调用方必须持有 store.mu 写锁。
-// 只驱逐 done 会话，避免中断正在进行的生成；若全是活跃会话则不驱逐（活跃会话的
-// buffer 受单会话上限约束，且会在 Finish 后释放）。
+// enforceSessionLimitLocked 在会话总数超过上限时驱逐旧会话，防止全局 map 无界
+// 增长。调用方必须持有 store.mu 写锁。
+//
+// 驱逐分两级：
+//  1. 优先驱逐最旧的已完成（done）会话——它们只等清理，驱逐没有副作用。
+//  2. 当会话数超过 limit × relayStreamActiveEvictFactor 时，继续按最旧优先驱逐
+//     活跃会话，并 Finish 它们释放缓冲。
+//
+// 第 2 级是这次修复的核心：旧实现「若全是活跃会话则不驱逐」，而客户端中途断连的
+// 会话会一直保持活跃直到上游结束，导致硬上限在最需要它的负载下完全失效，map 可以
+// 涨到吃光整台机器的内存（issue #196）。丢弃活跃会话确实会打断该会话的重放，但相
+// 比整个进程被 OOM killer 杀掉（所有在途请求一起失败）是明显更小的代价。
 func (s *relayStreamSessionStore) enforceSessionLimitLocked() {
-	if relayStreamMaxSessions <= 0 || len(s.byKey) <= relayStreamMaxSessions {
+	limit := getStreamSessionMaxSessions()
+	if limit <= 0 || len(s.byKey) <= limit {
 		return
 	}
 
-	type doneSession struct {
+	type candidate struct {
 		key       string
 		scope     string
+		session   *relayStreamSession
 		updatedAt time.Time
 	}
-	doneList := make([]doneSession, 0, len(s.byKey))
+	doneList := make([]candidate, 0, len(s.byKey))
+	activeList := make([]candidate, 0, len(s.byKey))
 	for key, session := range s.byKey {
 		session.mu.RLock()
 		done := session.done
 		updatedAt := session.updatedAt
 		scope := session.conversationScope
 		session.mu.RUnlock()
+		c := candidate{key: key, scope: scope, session: session, updatedAt: updatedAt}
 		if done {
-			doneList = append(doneList, doneSession{key: key, scope: scope, updatedAt: updatedAt})
+			doneList = append(doneList, c)
+		} else {
+			activeList = append(activeList, c)
 		}
 	}
-	sort.Slice(doneList, func(i, j int) bool {
-		return doneList[i].updatedAt.Before(doneList[j].updatedAt)
-	})
+	byOldestFirst := func(list []candidate) func(i, j int) bool {
+		return func(i, j int) bool { return list[i].updatedAt.Before(list[j].updatedAt) }
+	}
+	sort.Slice(doneList, byOldestFirst(doneList))
+	sort.Slice(activeList, byOldestFirst(activeList))
 
-	excess := len(s.byKey) - relayStreamMaxSessions
-	for i := 0; i < len(doneList) && excess > 0; i++ {
-		d := doneList[i]
-		session, ok := s.byKey[d.key]
+	evict := func(c candidate) bool {
+		session, ok := s.byKey[c.key]
 		if !ok {
+			return false
+		}
+		delete(s.byKey, c.key)
+		if activeKey, ok := s.activeByConversation[c.scope]; ok && activeKey == session.key {
+			delete(s.activeByConversation, c.scope)
+		}
+		return true
+	}
+
+	excess := len(s.byKey) - limit
+	for i := 0; i < len(doneList) && excess > 0; i++ {
+		if evict(doneList[i]) {
+			excess--
+		}
+	}
+
+	// 已完成会话清空后仍然超限：说明积压的全是活跃会话。只有在超出宽限阈值
+	// （limit × factor）时才动它们，避免正常波动打断正在进行的生成。
+	activeLimit := limit
+	if relayStreamActiveEvictFactor > 1 {
+		activeLimit = limit * relayStreamActiveEvictFactor
+	}
+	if len(s.byKey) <= activeLimit {
+		return
+	}
+	activeExcess := len(s.byKey) - activeLimit
+	evicted := make([]*relayStreamSession, 0, activeExcess)
+	for i := 0; i < len(activeList) && activeExcess > 0; i++ {
+		if !evict(activeList[i]) {
 			continue
 		}
-		delete(s.byKey, d.key)
-		if activeKey, ok := s.activeByConversation[d.scope]; ok && activeKey == session.key {
-			delete(s.activeByConversation, d.scope)
-		}
-		excess--
+		evicted = append(evicted, activeList[i].session)
+		activeExcess--
 	}
+	if len(evicted) == 0 {
+		return
+	}
+
+	// Finish 会取 store.mu 写锁，而这里正持有它 —— 必须异步调用避免自死锁。
+	// 会话已从 map 中摘除，异步 Finish 只影响其订阅者与缓冲释放。
+	go func(sessions []*relayStreamSession) {
+		for _, session := range sessions {
+			session.Finish(errRelayStreamSessionEvicted)
+		}
+	}(evicted)
+	log.Warnf("relay stream session store over hard limit (%d), evicted %d active sessions; "+
+		"consider lowering stream_session_max_bytes_mb or raising stream_session_max_sessions",
+		activeLimit, len(evicted))
 }
 
 // doneSessionRetention 返回已完成会话条目在 map 中的保留时长：取
@@ -281,6 +387,45 @@ func (s *relayStreamSession) IsDone() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.done
+}
+
+// MarkClientGone 记录「客户端已断连、但上游仍在生成」的时刻，开始宽限计时。
+// 重复调用只有第一次生效，保证宽限期从第一次断连算起。
+func (s *relayStreamSession) MarkClientGone() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.clientGoneActive || s.done {
+		return
+	}
+	s.clientGoneActive = true
+	s.clientGoneAt = time.Now()
+}
+
+// HasSubscribers 报告当前是否有读取者订阅该会话（即客户端是否已重连回来读）。
+func (s *relayStreamSession) HasSubscribers() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.subscribers) > 0
+}
+
+// ClientGoneGraceExceeded 报告客户端断连后的宽限期是否已耗尽。
+// 调用方据此强制结束会话并停止读取上游，把断连会话的缓冲驻留时间限定在宽限期内。
+func (s *relayStreamSession) ClientGoneGraceExceeded() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.clientGoneActive || s.done {
+		return false
+	}
+	return time.Since(s.clientGoneAt) >= relayStreamClientGoneGrace
 }
 
 func (s *relayStreamSession) AddPayload(payload []byte) []relayStreamEvent {
@@ -389,6 +534,11 @@ func (s *relayStreamSession) Subscribe() (<-chan struct{}, func()) {
 		return ch, func() {}
 	}
 	s.subscribers[ch] = struct{}{}
+	// 有订阅者接入意味着客户端已经重连回来读这个会话，撤销断连宽限计时，
+	// 否则原转发协程仍会在宽限期到点时把这个「有人在读」的会话强行结束
+	// （原请求的 context 早已 Done，无法自行感知重连）。
+	s.clientGoneActive = false
+	s.clientGoneAt = time.Time{}
 	s.mu.Unlock()
 
 	var once sync.Once
@@ -610,9 +760,14 @@ func ActiveSessionCount() int {
 // cleanup does not depend solely on a new session being acquired (lazy
 // cleanupLocked) or on per-session AfterFunc timers. This bounds the global
 // session map under sustained streaming load (see issue #46).
+//
+// 它同时执行会话总数硬上限（enforceSessionLimitLocked）。之前硬上限只在获取新会话
+// 时检查，而 OOM 场景恰恰是会话只增不减、旧会话又都处于活跃状态——把检查放到周期
+// 任务里，保证超限积压总能被收敛，不依赖新请求到达。
 func PurgeExpiredStreamSessions() {
 	store := &relayStreamSessions
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	store.cleanupLocked(time.Now())
+	store.enforceSessionLimitLocked()
 }

--- a/internal/relay/stream_session_test.go
+++ b/internal/relay/stream_session_test.go
@@ -460,3 +460,193 @@ func TestEnforceSessionLimitEvictsOldestDoneSessions(t *testing.T) {
 		t.Fatalf("session count = %d, want <= %d", remaining, relayStreamMaxSessions)
 	}
 }
+
+// 活跃会话在超过宽限阈值（limit × factor）后也必须被驱逐。
+// 旧实现「若全是活跃会话则不驱逐」，客户端中途断连时会话会一直保持活跃，
+// 导致硬上限完全失效、map 无界增长直到进程被 OOM killer 杀掉（issue #196）。
+func TestEnforceSessionLimitEvictsOldestActiveSessionsBeyondGrace(t *testing.T) {
+	relayStreamSessions = relayStreamSessionStore{
+		byKey:                make(map[string]*relayStreamSession),
+		activeByConversation: make(map[string]string),
+	}
+	store := &relayStreamSessions
+
+	limit := 8
+	overrideStreamSessionMaxSessions = &limit
+	t.Cleanup(func() { overrideStreamSessionMaxSessions = nil })
+
+	activeLimit := limit * relayStreamActiveEvictFactor
+	total := activeLimit + 5
+	base := time.Now().Add(-time.Hour)
+	store.mu.Lock()
+	for i := 0; i < total; i++ {
+		key := "active-" + strconv.Itoa(i)
+		store.byKey[key] = &relayStreamSession{
+			store:             store,
+			key:               key,
+			conversationScope: key,
+			done:              false, // 全部为活跃会话
+			updatedAt:         base.Add(time.Duration(i) * time.Millisecond),
+			subscribers:       make(map[chan struct{}]struct{}),
+		}
+		store.activeByConversation[key] = key
+	}
+	store.enforceSessionLimitLocked()
+	remaining := len(store.byKey)
+	_, oldestStillPresent := store.byKey["active-0"]
+	_, newestStillPresent := store.byKey["active-"+strconv.Itoa(total-1)]
+	store.mu.Unlock()
+
+	if remaining > activeLimit {
+		t.Fatalf("session count = %d, want <= %d (active sessions must be evicted past grace)", remaining, activeLimit)
+	}
+	if oldestStillPresent {
+		t.Fatal("oldest active session should have been evicted first")
+	}
+	if !newestStillPresent {
+		t.Fatal("newest active session should be kept")
+	}
+}
+
+// 未超过宽限阈值时不应驱逐活跃会话，避免正常波动打断正在进行的生成。
+func TestEnforceSessionLimitKeepsActiveSessionsWithinGrace(t *testing.T) {
+	relayStreamSessions = relayStreamSessionStore{
+		byKey:                make(map[string]*relayStreamSession),
+		activeByConversation: make(map[string]string),
+	}
+	store := &relayStreamSessions
+
+	limit := 8
+	overrideStreamSessionMaxSessions = &limit
+	t.Cleanup(func() { overrideStreamSessionMaxSessions = nil })
+
+	// 超过 limit 但未超过 limit × factor：活跃会话应全部保留。
+	total := limit + 2
+	base := time.Now().Add(-time.Hour)
+	store.mu.Lock()
+	for i := 0; i < total; i++ {
+		key := "active-" + strconv.Itoa(i)
+		store.byKey[key] = &relayStreamSession{
+			store:             store,
+			key:               key,
+			conversationScope: key,
+			done:              false,
+			updatedAt:         base.Add(time.Duration(i) * time.Millisecond),
+			subscribers:       make(map[chan struct{}]struct{}),
+		}
+	}
+	store.enforceSessionLimitLocked()
+	remaining := len(store.byKey)
+	store.mu.Unlock()
+
+	if remaining != total {
+		t.Fatalf("session count = %d, want %d (active sessions within grace must be kept)", remaining, total)
+	}
+}
+
+func TestClientGoneGraceExceeded(t *testing.T) {
+	relayStreamSessions = relayStreamSessionStore{
+		byKey:                make(map[string]*relayStreamSession),
+		activeByConversation: make(map[string]string),
+	}
+
+	session, created, err := acquireRelayStreamSession("conv-gone", 1, 1)
+	if err != nil || !created || session == nil {
+		t.Fatalf("acquireRelayStreamSession() = (%v, %t, %v)", session, created, err)
+	}
+
+	// 客户端未断连时不应触发。
+	if session.ClientGoneGraceExceeded() {
+		t.Fatal("ClientGoneGraceExceeded() = true before client disconnect")
+	}
+
+	session.MarkClientGone()
+	if session.ClientGoneGraceExceeded() {
+		t.Fatal("ClientGoneGraceExceeded() = true immediately after disconnect, want grace period")
+	}
+
+	// 把断连时刻回拨到宽限期之外，模拟上游长时间未结束。
+	session.mu.Lock()
+	session.clientGoneAt = time.Now().Add(-relayStreamClientGoneGrace - time.Second)
+	session.mu.Unlock()
+
+	if !session.ClientGoneGraceExceeded() {
+		t.Fatal("ClientGoneGraceExceeded() = false after grace period elapsed")
+	}
+
+	// 会话结束后不再触发，避免重复收尾。
+	session.Finish(nil)
+	if session.ClientGoneGraceExceeded() {
+		t.Fatal("ClientGoneGraceExceeded() = true after session finished")
+	}
+}
+
+// 客户端重连（Subscribe）必须撤销断连宽限计时，否则原转发协程会在宽限期到点时
+// 把一个「正有人在读」的会话强行结束——原请求的 context 早已 Done，无法自行感知重连。
+func TestSubscribeCancelsClientGoneGrace(t *testing.T) {
+	relayStreamSessions = relayStreamSessionStore{
+		byKey:                make(map[string]*relayStreamSession),
+		activeByConversation: make(map[string]string),
+	}
+
+	session, _, err := acquireRelayStreamSession("conv-reconnect", 1, 1)
+	if err != nil || session == nil {
+		t.Fatalf("acquireRelayStreamSession() error: %v", err)
+	}
+
+	session.MarkClientGone()
+	// 回拨到宽限期之外：若不撤销计时，此时已满足强制结束条件。
+	session.mu.Lock()
+	session.clientGoneAt = time.Now().Add(-relayStreamClientGoneGrace - time.Second)
+	session.mu.Unlock()
+	if !session.ClientGoneGraceExceeded() {
+		t.Fatal("precondition failed: grace should be exceeded before reconnect")
+	}
+
+	_, unsubscribe := session.Subscribe()
+	if session.ClientGoneGraceExceeded() {
+		t.Fatal("ClientGoneGraceExceeded() = true after client reconnected via Subscribe")
+	}
+	if !session.HasSubscribers() {
+		t.Fatal("HasSubscribers() = false while a subscriber is attached")
+	}
+
+	// 重连的读取者离开后，宽限计时应能重新起表。
+	unsubscribe()
+	if session.HasSubscribers() {
+		t.Fatal("HasSubscribers() = true after unsubscribe")
+	}
+	session.MarkClientGone()
+	if session.ClientGoneGraceExceeded() {
+		t.Fatal("grace should restart from the new disconnect time, not the original one")
+	}
+}
+
+// MarkClientGone 重复调用时宽限期应从第一次断连算起。
+func TestMarkClientGoneIsIdempotent(t *testing.T) {
+	relayStreamSessions = relayStreamSessionStore{
+		byKey:                make(map[string]*relayStreamSession),
+		activeByConversation: make(map[string]string),
+	}
+
+	session, _, err := acquireRelayStreamSession("conv-gone-twice", 1, 1)
+	if err != nil || session == nil {
+		t.Fatalf("acquireRelayStreamSession() error: %v", err)
+	}
+
+	session.MarkClientGone()
+	session.mu.RLock()
+	first := session.clientGoneAt
+	session.mu.RUnlock()
+
+	time.Sleep(5 * time.Millisecond)
+	session.MarkClientGone()
+
+	session.mu.RLock()
+	second := session.clientGoneAt
+	session.mu.RUnlock()
+
+	if !first.Equal(second) {
+		t.Fatalf("clientGoneAt changed on repeated MarkClientGone: %v -> %v", first, second)
+	}
+}

--- a/internal/transformer/body.go
+++ b/internal/transformer/body.go
@@ -1,0 +1,37 @@
+package transformer
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// MaxResponseBodyBytes 是非流式上游响应体的读取上限（50MB）。
+//
+// 之前 outbound transformer 的成功路径直接 io.ReadAll(response.Body)，没有任何
+// 上限：单个畸形或异常巨大的上游响应（例如批量 embedding）就能让进程分配任意大
+// 的 buffer。高并发下这些瞬时尖峰会互相叠加，和流会话缓冲一起把内存推向 OOM。
+//
+// 50MB 对正常响应来说绰绰有余——即使是大批量 embedding 响应通常也在个位数 MB
+// 量级；同时它把单次读取的最坏内存占用限制在一个可控的常数上。错误路径本来就
+// 已经用 io.LimitReader 做了限制（见 relay 层的 maxErrorBodyBytes）。
+const MaxResponseBodyBytes = 50 << 20
+
+// ReadResponseBody 读取上游响应体，并把读取量限制在 MaxResponseBodyBytes 内。
+// 超限时返回错误而不是静默截断——截断的 JSON 反序列化后会得到语义错误的结果，
+// 明确失败比返回错误数据更安全。
+//
+// 多读 1 字节用于区分「刚好等于上限」和「超过上限」。
+func ReadResponseBody(response *http.Response) ([]byte, error) {
+	if response == nil || response.Body == nil {
+		return nil, fmt.Errorf("response body is nil")
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, MaxResponseBodyBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if len(body) > MaxResponseBodyBytes {
+		return nil, fmt.Errorf("upstream response body too large: exceeds %d bytes", MaxResponseBodyBytes)
+	}
+	return body, nil
+}

--- a/internal/transformer/outbound/anthropic/messages.go
+++ b/internal/transformer/outbound/anthropic/messages.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/lingyuins/octopus/internal/transformer"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -79,9 +78,9 @@ func (o *MessageOutbound) TransformResponse(ctx context.Context, response *http.
 		return nil, fmt.Errorf("response is nil")
 	}
 
-	body, err := io.ReadAll(response.Body)
+	body, err := transformer.ReadResponseBody(response)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, err
 	}
 
 	if len(body) == 0 {

--- a/internal/transformer/outbound/cloudflare/chat.go
+++ b/internal/transformer/outbound/cloudflare/chat.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/lingyuins/octopus/internal/transformer"
-	"io"
 	"net/http"
 	"strings"
 
@@ -100,9 +99,9 @@ func (o *ChatOutbound) TransformResponse(ctx context.Context, response *http.Res
 	if response == nil {
 		return nil, fmt.Errorf("response is nil")
 	}
-	body, err := io.ReadAll(response.Body)
+	body, err := transformer.ReadResponseBody(response)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, err
 	}
 	if len(body) == 0 {
 		return nil, fmt.Errorf("response body is empty")

--- a/internal/transformer/outbound/gemini/messages.go
+++ b/internal/transformer/outbound/gemini/messages.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/lingyuins/octopus/internal/transformer"
-	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -78,9 +77,9 @@ func (o *MessagesOutbound) TransformResponse(ctx context.Context, response *http
 		return nil, fmt.Errorf("response is nil")
 	}
 
-	body, err := io.ReadAll(response.Body)
+	body, err := transformer.ReadResponseBody(response)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, err
 	}
 
 	if len(body) == 0 {

--- a/internal/transformer/outbound/openai/chat.go
+++ b/internal/transformer/outbound/openai/chat.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/lingyuins/octopus/internal/transformer"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -338,9 +337,9 @@ func (o *ChatOutbound) TransformResponse(ctx context.Context, response *http.Res
 		return nil, fmt.Errorf("response is nil")
 	}
 
-	body, err := io.ReadAll(response.Body)
+	body, err := transformer.ReadResponseBody(response)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, err
 	}
 
 	if len(body) == 0 {

--- a/internal/transformer/outbound/openai/embedding.go
+++ b/internal/transformer/outbound/openai/embedding.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/lingyuins/octopus/internal/transformer"
-	"io"
 	"net/http"
 	"net/url"
 
@@ -94,9 +93,9 @@ func (o *EmbeddingOutbound) TransformResponse(ctx context.Context, response *htt
 		return nil, fmt.Errorf("response is nil")
 	}
 
-	body, err := io.ReadAll(response.Body)
+	body, err := transformer.ReadResponseBody(response)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, err
 	}
 
 	if len(body) == 0 {

--- a/internal/transformer/outbound/openai/response.go
+++ b/internal/transformer/outbound/openai/response.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/lingyuins/octopus/internal/transformer"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -69,9 +68,9 @@ func (o *ResponseOutbound) TransformResponse(ctx context.Context, response *http
 		return nil, fmt.Errorf("response is nil")
 	}
 
-	body, err := io.ReadAll(response.Body)
+	body, err := transformer.ReadResponseBody(response)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, err
 	}
 
 	if len(body) == 0 {

--- a/web/src/api/endpoints/setting.ts
+++ b/web/src/api/endpoints/setting.ts
@@ -90,6 +90,7 @@ export const SettingKey = {
     StreamSessionTTLMinutes: 'stream_session_ttl_minutes',
     StreamSessionMaxEvents: 'stream_session_max_events',
     StreamSessionMaxBytesMB: 'stream_session_max_bytes_mb',
+    StreamSessionMaxSessions: 'stream_session_max_sessions',
     NotifyHTTPTimeoutSeconds: 'notify_http_timeout_seconds',
     FailureHintTTLUnauthorized: 'failure_hint_ttl_unauthorized',
     FailureHintTTLRateLimit: 'failure_hint_ttl_rate_limit',


### PR DESCRIPTION
## 问题

流会话（stream session）存储没有内存上界，会把宿主机内存吃光。一台 16 GB 的 NAS 在一小时内被内核 OOM killer 杀了两次，relay 进程 RSS 达到约 13.8 GB。

注意 `docker inspect` 里 `OOMKilled=false` 具有误导性——它只追踪 cgroup 级别的 OOM。这里是内核全局 OOM，需要看 dmesg：

```
oom-kill: constraint=CONSTRAINT_NONE ... anon-rss:13800000kB
```

## 根因

三个独立的缺口叠加，把所有上界都消掉了：

### 1. 客户端断开后会话永远保持 ACTIVE

`internal/relay/relay.go` 的转发循环收到 `<-clientDone` 时，如果存在 stream session，只调用 `markClientDisconnected()` 把客户端通道置空，然后**继续循环**读取上游 SSE 帧并写入 replay buffer。没有任何东西会关闭这个会话——它比自己的客户端活得更久，直到 TTL（默认 30 分钟）到期。

### 2. 会话数上限形同虚设

`enforceSessionLimitLocked()`（`internal/relay/stream_session.go`）只收集 DONE 会话来驱逐，注释也写明「若全是活跃会话则不驱逐」。结合缺口 1，会话几乎不会变成 DONE，于是上限在最需要它的时候完全失效。

`cleanupLocked()` 有同样的盲点，通过 `if !done { continue }` 直接跳过所有活跃会话。

### 3. 上限硬编码为 4096

`relayStreamMaxSessions = 4096`，每个会话的 replay buffer 上限 4 MB（`stream_session_max_bytes_mb`）。4096 × 4 MB = **16 GB**，恰好等于宿主机全部内存，而且不可配置。OOM 时的 13.8 GB 约对应 3450 个活跃会话，与这个模型吻合。

## 改动

同时堵上三个缺口：

- **客户端断开时加宽限期。** 客户端离开后，超过宽限期就强制 `Finish()` 会话并停止读取上游。`Subscribe`（重连信号）会重置计时器，所以断线重连 + replay 仍然正常工作；转发循环还会根据订阅者是否存在通过 ticker 重新武装计时器，覆盖「重连后再次离开」的场景。
- **允许驱逐活跃会话。** 超过高水位阈值后按最旧优先驱逐，即使一个 DONE 会话都没有，上限也能守住。
- **上限可配置，默认值下调。** 新增 `stream_session_max_sessions`，默认从 4096 降到 **512**（512 × 4 MB ≈ 2 GB 最坏上限）。设置未加载时回退到原常量。设为 0 表示不限制。
- **周期任务也执行上限。** 把限额检查接入周期性清理任务，这样即使没有新会话进来也能回收内存。
- **修正驱逐计数。** `evict` 现在返回是否成功，key 缺失时不会再静默跳过计数器。

## 附带修复：非流式路径的无界读取

各 outbound transformer 的 `TransformResponse` 成功分支直接对上游响应体调用 `io.ReadAll`，没有任何上限——一个超大响应就能造成瞬时内存尖峰。错误分支（`relay.go`）本来就用了 `io.LimitReader`，成功分支反而没有。

新增 `internal/transformer/body.go` 里的共享辅助函数 `ReadResponseBody`（基于 `io.LimitReader`，上限可配置），应用到 openai（chat / response / embedding）、anthropic、gemini、cloudflare 六处。

## 影响与兼容性

- 默认最坏内存占用从 16 GB 降到约 2 GB。
- 对正常用户无感知：宽限期只在客户端确实断开后才触发，重连会重置它。
- 上限从硬编码变为可配置，遇到高并发场景的用户可以自行调高，不必再改代码重新编译。

## 测试

- 新增测试覆盖驱逐行为、客户端离开时的强制 finish 路径、以及「重连重置宽限期」的行为（`internal/relay/stream_session_test.go`）。
- `go vet` 通过；relay 及受影响包的测试全部通过。
- 竞态检测未能运行：`-race` 需要 cgo，我这边环境不具备。并发正确性是通过代码审查确认的（沿用既有的 `*Locked` 命名约定与锁粒度），如果 CI 能跑 `-race` 会更保险。

## 备注

新的设置键已加入 `web/src/api/endpoints/setting.ts` 的常量表，但和既有的几个 `stream_session_*` 键一样，暂未在设置页面暴露 UI——保持了当前的一致做法。

在无法立即升级的情况下，临时缓解办法是把 `stream_session_replay_enabled` 关掉，或者把 `stream_session_max_bytes_mb` 调小。
