### PR TITLE
fix: route OAuth accounts to Cloud Code Assist（gemini）

### DIFF
--- a/internal/model/pool.go
+++ b/internal/model/pool.go
@@ -90,6 +90,10 @@ const (
 	PoolTypeSetupToken = "setup-token"
 )
 
+// OAuthTypeCodeAssist 是 PoolAccountExtra.OAuthType 的取值，标记 gemini OAuth
+// 账号走 Cloud Code Assist（cloudcode-pa）而非官方 Generative Language API。
+const OAuthTypeCodeAssist = "code_assist"
+
 // PoolAccountExtra 平台附加字段（Extra JSON 反序列化后的结构）
 // 敏感键（含 key/token/secret/cookie 字样的 header value）在写库前单独脱敏存储，
 // 但本 struct 只承载平台标识与路由相关字段，不直接放凭据。
@@ -273,6 +277,17 @@ func (c PoolCredential) EffectiveKeyWithExtra(platform string, extra PoolAccount
 				"account_id":    c.AccountID,
 				"refresh_token": c.RefreshToken,
 				"id_token":      c.IDToken,
+			})
+			return string(b)
+		}
+		// gemini 平台的 OAuth 账号走 Cloud Code Assist：出站需要 project_id，
+		// 且必须与官方 API key 区分开（后者用 ?key=，前者用 Bearer）。
+		// 裸 access_token 承载不了这两点，故与 openai 一样透传 JSON。
+		if platform == PoolPlatformGemini {
+			b, _ := json.Marshal(map[string]string{
+				"access_token": c.AccessToken,
+				"project_id":   extra.ProjectID,
+				"oauth_type":   OAuthTypeCodeAssist,
 			})
 			return string(b)
 		}

--- a/internal/op/pool/quota_impl.go
+++ b/internal/op/pool/quota_impl.go
@@ -106,7 +106,7 @@ func quotaSupported(platform, ctype string) bool {
 func quotaSupportedForAccount(acct *model.PoolAccount) bool {
 	if acct.Platform == model.PoolPlatformGemini {
 		extra := acct.GetExtra()
-		if extra.OAuthType == "code_assist" {
+		if extra.OAuthType == model.OAuthTypeCodeAssist {
 			return false
 		}
 	}

--- a/internal/pkg/geminicli/codeassist.go
+++ b/internal/pkg/geminicli/codeassist.go
@@ -1,0 +1,208 @@
+package geminicli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Cloud Code Assist（Gemini CLI 使用的后端）与官方 Generative Language API
+// 是两套不同的接入方式：
+//
+//	generativelanguage.googleapis.com  ->  API key，?key= query 参数
+//	cloudcode-pa.googleapis.com        ->  OAuth access_token，Authorization: Bearer
+//
+// OAuth 流程申请的 cloud-platform scope 只对后者有效，把 access_token 当作
+// ?key= 发给官方端点会直接 401/403。
+const (
+	// CodeAssistEndpoint 是 Cloud Code Assist 的默认接入点。
+	CodeAssistEndpoint = "https://cloudcode-pa.googleapis.com"
+
+	// CodeAssistAPIVersion 与 Gemini CLI 保持一致。
+	CodeAssistAPIVersion = "v1internal"
+
+	// codeAssistHTTPTimeout 用于 project 发现等元数据请求。
+	// 转发请求本身不走这里，由 relay 的客户端控制超时。
+	codeAssistHTTPTimeout = 30 * time.Second
+)
+
+// OAuthTypeCodeAssist 标记该 OAuth 账号走 Cloud Code Assist 而非官方 API。
+// 取值须与 model.OAuthTypeCodeAssist 一致（此处不 import model 以免依赖倒置）。
+const OAuthTypeCodeAssist = "code_assist"
+
+// CodeAssistCredential 是 gemini oauth 账号在出站时携带的凭据结构。
+//
+// 与 openai/codex 的做法一致：把出站需要的字段序列化成 JSON 作为 ChannelKey，
+// 供出站适配器解析。裸 access_token 无法区分「官方 API key」与「OAuth token」，
+// 也带不了 project_id。
+type CodeAssistCredential struct {
+	AccessToken string `json:"access_token"`
+	ProjectID   string `json:"project_id,omitempty"`
+	OAuthType   string `json:"oauth_type,omitempty"`
+}
+
+// IsCodeAssist 判断该凭据是否应走 Cloud Code Assist。
+func (c CodeAssistCredential) IsCodeAssist() bool {
+	return strings.TrimSpace(c.AccessToken) != "" && c.OAuthType == OAuthTypeCodeAssist
+}
+
+// MarshalCodeAssistCredential 构造出站凭据 JSON。
+func MarshalCodeAssistCredential(accessToken, projectID string) string {
+	b, _ := json.Marshal(CodeAssistCredential{
+		AccessToken: strings.TrimSpace(accessToken),
+		ProjectID:   strings.TrimSpace(projectID),
+		OAuthType:   OAuthTypeCodeAssist,
+	})
+	return string(b)
+}
+
+// ParseCodeAssistCredential 解析出站凭据。
+//
+// 非 JSON（裸 token 或官方 API key）返回 ok=false，调用方应回退到官方 API 行为，
+// 保证既有 apikey 渠道不受影响。
+func ParseCodeAssistCredential(raw string) (CodeAssistCredential, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || !strings.HasPrefix(raw, "{") {
+		return CodeAssistCredential{}, false
+	}
+	var cred CodeAssistCredential
+	if err := json.Unmarshal([]byte(raw), &cred); err != nil {
+		return CodeAssistCredential{}, false
+	}
+	if !cred.IsCodeAssist() {
+		return CodeAssistCredential{}, false
+	}
+	return cred, true
+}
+
+// loadCodeAssistResponse 是 :loadCodeAssist 的响应子集。
+type loadCodeAssistResponse struct {
+	CurrentTier *struct {
+		ID string `json:"id"`
+	} `json:"currentTier"`
+	AllowedTiers []struct {
+		ID         string `json:"id"`
+		IsDefault  bool   `json:"isDefault"`
+		UserDefine bool   `json:"userDefinedCloudaicompanionProject"`
+	} `json:"allowedTiers"`
+	CloudaicompanionProject string `json:"cloudaicompanionProject"`
+}
+
+// onboardUserResponse 是 :onboardUser 长操作的响应子集。
+type onboardUserResponse struct {
+	Done     bool `json:"done"`
+	Response *struct {
+		CloudaicompanionProject *struct {
+			ID string `json:"id"`
+		} `json:"cloudaicompanionProject"`
+	} `json:"response"`
+}
+
+// DiscoverProject 解析该账号可用的 Cloud Code Assist project id。
+//
+// 流程与 Gemini CLI 一致：先 :loadCodeAssist 拿现有 project；没有则按默认 tier
+// 调 :onboardUser 完成开通。免费 tier 由服务端分配 project，无需用户提供。
+//
+// 返回空字符串且 error 为 nil 表示服务端未分配 project（部分 tier 允许省略
+// project 字段），此时出站请求不带 project 也能工作。
+func DiscoverProject(ctx context.Context, httpClient *http.Client, accessToken, endpoint string) (string, error) {
+	if strings.TrimSpace(accessToken) == "" {
+		return "", fmt.Errorf("geminicli: access token is required")
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: codeAssistHTTPTimeout}
+	}
+	base := strings.TrimSuffix(strings.TrimSpace(endpoint), "/")
+	if base == "" {
+		base = CodeAssistEndpoint
+	}
+
+	load, err := callCodeAssist[loadCodeAssistResponse](ctx, httpClient, accessToken, base, "loadCodeAssist", map[string]any{
+		"metadata": map[string]string{
+			"ideType":     "IDE_UNSPECIFIED",
+			"platform":    "PLATFORM_UNSPECIFIED",
+			"pluginType":  "GEMINI",
+			"duetProject": "",
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if project := strings.TrimSpace(load.CloudaicompanionProject); project != "" {
+		return project, nil
+	}
+
+	// 未开通：按默认 tier 走 onboarding。
+	tierID := ""
+	for _, tier := range load.AllowedTiers {
+		if tier.IsDefault {
+			tierID = tier.ID
+			break
+		}
+	}
+	if tierID == "" && load.CurrentTier != nil {
+		tierID = load.CurrentTier.ID
+	}
+	if tierID == "" {
+		// 无可用 tier 信息时不阻断：让出站请求以无 project 方式尝试。
+		return "", nil
+	}
+
+	onboard, err := callCodeAssist[onboardUserResponse](ctx, httpClient, accessToken, base, "onboardUser", map[string]any{
+		"tierId":                  tierID,
+		"cloudaicompanionProject": nil,
+		"metadata": map[string]string{
+			"ideType":    "IDE_UNSPECIFIED",
+			"platform":   "PLATFORM_UNSPECIFIED",
+			"pluginType": "GEMINI",
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if onboard.Response != nil && onboard.Response.CloudaicompanionProject != nil {
+		return strings.TrimSpace(onboard.Response.CloudaicompanionProject.ID), nil
+	}
+	return "", nil
+}
+
+// callCodeAssist 调用 Cloud Code Assist 的 :method 接口并解析 JSON 响应。
+func callCodeAssist[T any](ctx context.Context, client *http.Client, accessToken, base, method string, payload map[string]any) (*T, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("geminicli: marshal %s payload: %w", method, err)
+	}
+
+	url := fmt.Sprintf("%s/%s:%s", base, CodeAssistAPIVersion, method)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("geminicli: build %s request: %w", method, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("geminicli: %s request failed: %w", method, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("geminicli: read %s response: %w", method, err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("geminicli: %s returned %d: %s", method, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var out T
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("geminicli: decode %s response: %w", method, err)
+	}
+	return &out, nil
+}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -643,6 +643,8 @@ func (ra *relayAttempt) forward() (int, error) {
 //   - openai-oauth 且非 codex 适配器：ChannelKey 是 OAuth JSON，适配器无法解析，
 //     手动设置 Authorization: Bearer {access_token} + chatgpt-account-id: {account_id}。
 //     codex 适配器自身解析 OAuth JSON，无需覆盖。
+//   - gemini-oauth：ChannelKey 是 code_assist 凭据 JSON，由 gemini 出站适配器
+//     自行解析并设置 Bearer（同时切到 cloudcode-pa 端点），这里不覆盖。
 //   - 其他 oauth/apikey/upstream：适配器默认 Bearer 行为正确，无需覆盖。
 //   - P3 header overrides：符合资格条件时叠加自定义请求头（跳过黑名单与安全头）。
 func (ra *relayAttempt) applyPoolCredentialHeaders(req *http.Request) {

--- a/internal/server/handlers/pool_oauth.go
+++ b/internal/server/handlers/pool_oauth.go
@@ -247,8 +247,16 @@ func oauthCallback(c *gin.Context) {
 		oauthRedirectResult(c, false, poolID, "dedupe lookup failed: "+err.Error())
 		return
 	}
+	// gemini OAuth 必须记录 code_assist 标记与 project id，否则出站会退化成
+	// 「把 OAuth token 当官方 API key 的 ?key= 参数」，必然 401/403。
+	var geminiExtra *model.PoolAccountExtra
+	if platform == model.PoolPlatformGemini {
+		e := discoverGeminiExtra(c.Request.Context(), cred.AccessToken)
+		geminiExtra = &e
+	}
+
 	if existingID > 0 {
-		if err := refreshExistingOAuthAccount(poolID, existingID, credJSON, expiresAt); err != nil {
+		if err := refreshExistingOAuthAccount(poolID, existingID, credJSON, expiresAt, geminiExtra); err != nil {
 			oauthRedirectResult(c, false, poolID, "update account failed: "+err.Error())
 			return
 		}
@@ -266,6 +274,9 @@ func oauthCallback(c *gin.Context) {
 		Status:         "active",
 		Schedulable:    true,
 		TokenExpiresAt: expiresAt,
+	}
+	if geminiExtra != nil {
+		acct.SetExtra(*geminiExtra)
 	}
 	if err := pool.CreateAccount(&acct); err != nil {
 		oauthRedirectResult(c, false, poolID, "create account failed: "+err.Error())
@@ -321,7 +332,10 @@ func findExistingOAuthAccount(poolID int, platform string, cred model.PoolCreden
 
 // refreshExistingOAuthAccount 复用已有账号：更新凭据/过期时间并复位状态，
 // 同时清除刷新失败退避（授权成功视为账号恢复）。
-func refreshExistingOAuthAccount(poolID, accountID int, credJSON string, expiresAt int64) error {
+//
+// platformExtra 非空时把平台字段（如 gemini 的 code_assist project）合并进 Extra，
+// 其余字段保持原样。
+func refreshExistingOAuthAccount(poolID, accountID int, credJSON string, expiresAt int64, platformExtra *model.PoolAccountExtra) error {
 	updates := map[string]interface{}{
 		"credentials":      pool.EncryptCredentials(credJSON),
 		"token_expires_at": expiresAt,
@@ -331,12 +345,28 @@ func refreshExistingOAuthAccount(poolID, accountID int, credJSON string, expires
 	}
 	if acct, err := pool.GetAccount(poolID, accountID); err == nil {
 		var extra model.PoolAccountExtra
-		if json.Unmarshal([]byte(acct.Extra), &extra) == nil &&
-			(extra.RefreshFailureCount != 0 || extra.NextRefreshAllowedAt != 0) {
-			extra.RefreshFailureCount = 0
-			extra.NextRefreshAllowedAt = 0
-			if b, err := json.Marshal(extra); err == nil {
-				updates["extra"] = string(b)
+		if json.Unmarshal([]byte(acct.Extra), &extra) == nil {
+			changed := false
+			if extra.RefreshFailureCount != 0 || extra.NextRefreshAllowedAt != 0 {
+				extra.RefreshFailureCount = 0
+				extra.NextRefreshAllowedAt = 0
+				changed = true
+			}
+			if platformExtra != nil {
+				if platformExtra.OAuthType != "" && extra.OAuthType != platformExtra.OAuthType {
+					extra.OAuthType = platformExtra.OAuthType
+					changed = true
+				}
+				// project 探测失败时保留原值，避免把已可用的 project 抹掉。
+				if platformExtra.ProjectID != "" && extra.ProjectID != platformExtra.ProjectID {
+					extra.ProjectID = platformExtra.ProjectID
+					changed = true
+				}
+			}
+			if changed {
+				if b, err := json.Marshal(extra); err == nil {
+					updates["extra"] = string(b)
+				}
 			}
 		}
 	}
@@ -462,6 +492,22 @@ func handleGeminiCallback(ctx context.Context, sessionID, state, code string) (i
 	credBytes, _ := json.Marshal(cred)
 	expiresAt := time.Now().Unix() + tok.ExpiresIn
 	return session.PoolID, string(credBytes), expiresAt, nil
+}
+
+// discoverGeminiExtra 探测 gemini OAuth 账号的 Cloud Code Assist project，
+// 组装为账号 Extra。出站请求体需要 project id（见 transformer/outbound/gemini）。
+//
+// 探测失败不阻断授权：project 为空时出站仍按无 project 方式尝试，
+// 用户也可后续在账号详情里手工补填。
+func discoverGeminiExtra(ctx context.Context, accessToken string) model.PoolAccountExtra {
+	projectID, err := geminicli.DiscoverProject(ctx, nil, accessToken, geminicli.CodeAssistEndpoint)
+	if err != nil {
+		log.Warnf("gemini oauth: discover code assist project failed: %v", err)
+	}
+	return model.PoolAccountExtra{
+		ProjectID: projectID,
+		OAuthType: model.OAuthTypeCodeAssist,
+	}
 }
 
 func handleGrokCallback(ctx context.Context, sessionID, state, code string) (int, string, int64, error) {

--- a/internal/server/handlers/pool_oauth_dedupe_test.go
+++ b/internal/server/handlers/pool_oauth_dedupe_test.go
@@ -179,7 +179,7 @@ func TestRefreshExistingOAuthAccount_ResetsState(t *testing.T) {
 	newCredJSON := `{"access_token":"new-token","refresh_token":"new-refresh","id_token":"` +
 		makeJWT(t, map[string]interface{}{"sub": "user-1"}) + `"}`
 	expiresAt := int64(2000000000)
-	if err := refreshExistingOAuthAccount(poolObj.ID, acct.ID, newCredJSON, expiresAt); err != nil {
+	if err := refreshExistingOAuthAccount(poolObj.ID, acct.ID, newCredJSON, expiresAt, nil); err != nil {
 		t.Fatalf("refresh existing: %v", err)
 	}
 

--- a/internal/transformer/outbound/gemini/codeassist.go
+++ b/internal/transformer/outbound/gemini/codeassist.go
@@ -1,0 +1,124 @@
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/lingyuins/octopus/internal/pkg/geminicli"
+	"github.com/lingyuins/octopus/internal/transformer"
+	"github.com/lingyuins/octopus/internal/transformer/model"
+)
+
+// Cloud Code Assist（cloudcode-pa.googleapis.com）是 Gemini CLI 的后端，
+// 与官方 Generative Language API 在三处不兼容：
+//
+//	鉴权   ?key=<api_key>            ->  Authorization: Bearer <access_token>
+//	路径   /v1beta/models/{m}:{op}   ->  /v1internal:{op}
+//	报文   {contents:[...]}          ->  {model, project, request:{contents:[...]}}
+//	          响应同构                ->  {response:{...}} 外层包装
+//
+// OAuth 账号只能走后者：cloud-platform scope 的 access_token 传给官方端点的
+// ?key= 参数会被拒。因此这里按凭据形态分流，OAuth JSON 走 Code Assist，
+// 裸 key 仍走官方路径，apikey 渠道行为不变。
+
+// codeAssistRequest 是 Code Assist 的请求包装。
+type codeAssistRequest struct {
+	Model   string                              `json:"model"`
+	Project string                              `json:"project,omitempty"`
+	Request *model.GeminiGenerateContentRequest `json:"request"`
+}
+
+// codeAssistResponse 是 Code Assist 的响应包装。
+// 用 RawMessage 承载内层，剥壳时可直接返回原始字节，
+// 不经过结构体往返（避免丢弃未建模字段）。
+type codeAssistResponse struct {
+	Response json.RawMessage `json:"response"`
+}
+
+// transformCodeAssistRequest 构造 Cloud Code Assist 的出站请求。
+func transformCodeAssistRequest(
+	ctx context.Context,
+	request *model.InternalLLMRequest,
+	baseUrl string,
+	cred geminicli.CodeAssistCredential,
+) (*http.Request, error) {
+	geminiReq := convertLLMToGeminiRequest(request)
+
+	// Code Assist 在包装层携带模型名，内层不再重复。
+	modelName := strings.TrimPrefix(strings.TrimSpace(request.Model), "models/")
+
+	body, err := transformer.Marshal(&codeAssistRequest{
+		Model:   modelName,
+		Project: cred.ProjectID,
+		Request: geminiReq,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal code assist request: %w", err)
+	}
+
+	isStream := request.Stream != nil && *request.Stream
+	op := "generateContent"
+	if isStream {
+		op = "streamGenerateContent"
+	}
+
+	endpoint := strings.TrimSuffix(strings.TrimSpace(baseUrl), "/")
+	if endpoint == "" || isOfficialGeminiEndpoint(endpoint) {
+		// 渠道 base_url 指向官方端点（或留空）时改用 Code Assist 端点，
+		// 避免把 OAuth 请求发到不认 Bearer 的官方域名。
+		endpoint = geminicli.CodeAssistEndpoint
+	}
+
+	parsedUrl, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse base url: %w", err)
+	}
+	// Code Assist 的操作挂在版本号上，不带 /models/{model} 段。
+	parsedUrl.Path = fmt.Sprintf("%s/%s:%s",
+		strings.TrimSuffix(parsedUrl.Path, "/"), geminicli.CodeAssistAPIVersion, op)
+
+	if isStream {
+		q := parsedUrl.Query()
+		q.Set("alt", "sse")
+		parsedUrl.RawQuery = q.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, parsedUrl.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+cred.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+// isOfficialGeminiEndpoint 判断是否为官方 Generative Language API 域名。
+func isOfficialGeminiEndpoint(endpoint string) bool {
+	lower := strings.ToLower(endpoint)
+	return strings.Contains(lower, "generativelanguage.googleapis.com")
+}
+
+// unwrapCodeAssistPayload 剥掉 {"response":{...}} 外层包装。
+//
+// 未包装的报文原样返回，因此对官方格式同样安全。
+func unwrapCodeAssistPayload(payload []byte) []byte {
+	trimmed := bytes.TrimSpace(payload)
+	if !bytes.HasPrefix(trimmed, []byte(`{"response"`)) && !bytes.Contains(trimmed, []byte(`"response"`)) {
+		return payload
+	}
+	var wrapper codeAssistResponse
+	if err := transformer.Unmarshal(trimmed, &wrapper); err != nil {
+		return payload
+	}
+	inner := bytes.TrimSpace(wrapper.Response)
+	if len(inner) == 0 || !bytes.HasPrefix(inner, []byte("{")) {
+		return payload
+	}
+	return inner
+}

--- a/internal/transformer/outbound/gemini/codeassist_test.go
+++ b/internal/transformer/outbound/gemini/codeassist_test.go
@@ -1,0 +1,204 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/lingyuins/octopus/internal/pkg/geminicli"
+	"github.com/lingyuins/octopus/internal/transformer/model"
+)
+
+func codeAssistKey(t *testing.T, accessToken, projectID string) string {
+	t.Helper()
+	return geminicli.MarshalCodeAssistCredential(accessToken, projectID)
+}
+
+func newLLMRequest(modelName string, stream bool) *model.InternalLLMRequest {
+	text := "hi"
+	return &model.InternalLLMRequest{
+		Model:  modelName,
+		Stream: &stream,
+		Messages: []model.Message{
+			{Role: "user", Content: model.MessageContent{Content: &text}},
+		},
+	}
+}
+
+// TransformRequest 拿到 OAuth 凭据时必须切到 Cloud Code Assist：
+// Bearer 鉴权、v1internal 路径、请求体带 model/project 包装，且不带 ?key=。
+func TestTransformRequest_CodeAssistCredential(t *testing.T) {
+	out := &MessagesOutbound{}
+	key := codeAssistKey(t, "ya29.token", "proj-123")
+
+	req, err := out.TransformRequest(context.Background(), newLLMRequest("gemini-2.5-pro", false), "", key)
+	if err != nil {
+		t.Fatalf("TransformRequest: %v", err)
+	}
+
+	if got := req.Header.Get("Authorization"); got != "Bearer ya29.token" {
+		t.Fatalf("Authorization = %q, want Bearer ya29.token", got)
+	}
+	if req.URL.Query().Get("key") != "" {
+		t.Fatalf("OAuth 请求不应带 ?key=，got %q", req.URL.String())
+	}
+	if req.URL.Host != "cloudcode-pa.googleapis.com" {
+		t.Fatalf("host = %q, want cloudcode-pa.googleapis.com", req.URL.Host)
+	}
+	if req.URL.Path != "/v1internal:generateContent" {
+		t.Fatalf("path = %q, want /v1internal:generateContent", req.URL.Path)
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var wrapped struct {
+		Model   string          `json:"model"`
+		Project string          `json:"project"`
+		Request json.RawMessage `json:"request"`
+	}
+	if err := json.Unmarshal(body, &wrapped); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if wrapped.Model != "gemini-2.5-pro" {
+		t.Fatalf("model = %q, want gemini-2.5-pro", wrapped.Model)
+	}
+	if wrapped.Project != "proj-123" {
+		t.Fatalf("project = %q, want proj-123", wrapped.Project)
+	}
+	if len(wrapped.Request) == 0 || !strings.Contains(string(wrapped.Request), "contents") {
+		t.Fatalf("request 包装缺少 contents: %s", string(wrapped.Request))
+	}
+}
+
+// 流式请求走 streamGenerateContent 且带 alt=sse。
+func TestTransformRequest_CodeAssistStream(t *testing.T) {
+	out := &MessagesOutbound{}
+	req, err := out.TransformRequest(context.Background(),
+		newLLMRequest("gemini-2.5-flash", true), "", codeAssistKey(t, "tok", "p1"))
+	if err != nil {
+		t.Fatalf("TransformRequest: %v", err)
+	}
+	if req.URL.Path != "/v1internal:streamGenerateContent" {
+		t.Fatalf("path = %q, want /v1internal:streamGenerateContent", req.URL.Path)
+	}
+	if req.URL.Query().Get("alt") != "sse" {
+		t.Fatalf("alt = %q, want sse", req.URL.Query().Get("alt"))
+	}
+}
+
+// 渠道 base_url 指向官方端点时也必须改用 Code Assist 端点，
+// 否则 OAuth token 会被发到不认 Bearer 的官方域名。
+func TestTransformRequest_CodeAssistOverridesOfficialBaseURL(t *testing.T) {
+	out := &MessagesOutbound{}
+	req, err := out.TransformRequest(context.Background(),
+		newLLMRequest("gemini-2.5-pro", false),
+		"https://generativelanguage.googleapis.com/v1beta",
+		codeAssistKey(t, "tok", ""))
+	if err != nil {
+		t.Fatalf("TransformRequest: %v", err)
+	}
+	if req.URL.Host != "cloudcode-pa.googleapis.com" {
+		t.Fatalf("host = %q, want cloudcode-pa.googleapis.com", req.URL.Host)
+	}
+}
+
+// 自建代理（非官方域名）应当被保留，只替换路径与鉴权方式。
+func TestTransformRequest_CodeAssistKeepsCustomBaseURL(t *testing.T) {
+	out := &MessagesOutbound{}
+	req, err := out.TransformRequest(context.Background(),
+		newLLMRequest("gemini-2.5-pro", false),
+		"https://relay.example.com/gemini",
+		codeAssistKey(t, "tok", ""))
+	if err != nil {
+		t.Fatalf("TransformRequest: %v", err)
+	}
+	if req.URL.Host != "relay.example.com" {
+		t.Fatalf("host = %q, want relay.example.com", req.URL.Host)
+	}
+	if req.URL.Path != "/gemini/v1internal:generateContent" {
+		t.Fatalf("path = %q, want /gemini/v1internal:generateContent", req.URL.Path)
+	}
+}
+
+// 裸 API key（apikey 渠道）行为必须保持不变：?key= + 官方路径 + 无 Authorization。
+func TestTransformRequest_PlainAPIKeyUnchanged(t *testing.T) {
+	out := &MessagesOutbound{}
+	req, err := out.TransformRequest(context.Background(),
+		newLLMRequest("gemini-2.5-pro", false),
+		"https://generativelanguage.googleapis.com/v1beta",
+		"AIzaSyPlainKey")
+	if err != nil {
+		t.Fatalf("TransformRequest: %v", err)
+	}
+	if got := req.URL.Query().Get("key"); got != "AIzaSyPlainKey" {
+		t.Fatalf("key = %q, want AIzaSyPlainKey", got)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("apikey 渠道不应带 Authorization，got %q", got)
+	}
+	if req.URL.Path != "/v1beta/models/gemini-2.5-pro:generateContent" {
+		t.Fatalf("path = %q", req.URL.Path)
+	}
+}
+
+func TestUnwrapCodeAssistPayload(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "wrapped",
+			in:   `{"response":{"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}}`,
+			want: `{"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}`,
+		},
+		{
+			// 官方格式没有 response 包装，必须原样返回。
+			name: "official passthrough",
+			in:   `{"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}`,
+			want: `{"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}`,
+		},
+		{
+			// 业务字段恰好叫 response 但不是包装层，也不能误剥。
+			name: "non-object response field",
+			in:   `{"response":"text"}`,
+			want: `{"response":"text"}`,
+		},
+		{
+			name: "invalid json",
+			in:   `not-json`,
+			want: `not-json`,
+		},
+		{
+			name: "empty",
+			in:   ``,
+			want: ``,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.TrimSpace(string(unwrapCodeAssistPayload([]byte(tc.in))))
+			if got != tc.want {
+				t.Fatalf("unwrap = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsOfficialGeminiEndpoint(t *testing.T) {
+	cases := map[string]bool{
+		"https://generativelanguage.googleapis.com/v1beta": true,
+		"https://GenerativeLanguage.googleapis.com":        true,
+		"https://cloudcode-pa.googleapis.com":              false,
+		"https://relay.example.com/gemini":                 false,
+	}
+	for endpoint, want := range cases {
+		if got := isOfficialGeminiEndpoint(endpoint); got != want {
+			t.Fatalf("isOfficialGeminiEndpoint(%q) = %v, want %v", endpoint, got, want)
+		}
+	}
+}

--- a/internal/transformer/outbound/gemini/messages.go
+++ b/internal/transformer/outbound/gemini/messages.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/lingyuins/octopus/internal/pkg/geminicli"
 	"github.com/lingyuins/octopus/internal/transformer/model"
 	"github.com/lingyuins/octopus/internal/utils/log"
 	"github.com/lingyuins/octopus/internal/utils/xurl"
@@ -21,6 +22,11 @@ type MessagesOutbound struct{}
 func (o *MessagesOutbound) TransformRequest(ctx context.Context, request *model.InternalLLMRequest, baseUrl, key string) (*http.Request, error) {
 	if request == nil {
 		return nil, fmt.Errorf("request is nil")
+	}
+
+	// OAuth（Gemini CLI）凭据走 Cloud Code Assist：报文/路径/鉴权与官方 API 均不同。
+	if cred, ok := geminicli.ParseCodeAssistCredential(key); ok {
+		return transformCodeAssistRequest(ctx, request, baseUrl, cred)
 	}
 
 	// Convert internal request to Gemini format
@@ -109,7 +115,7 @@ func (o *MessagesOutbound) TransformResponse(ctx context.Context, response *http
 	}
 
 	var geminiResp model.GeminiGenerateContentResponse
-	if err := transformer.Unmarshal(body, &geminiResp); err != nil {
+	if err := transformer.Unmarshal(unwrapCodeAssistPayload(body), &geminiResp); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal gemini response: %w", err)
 	}
 
@@ -127,7 +133,7 @@ func (o *MessagesOutbound) TransformStream(ctx context.Context, eventData []byte
 
 	// Parse Gemini streaming response
 	var geminiResp model.GeminiGenerateContentResponse
-	if err := transformer.Unmarshal(eventData, &geminiResp); err != nil {
+	if err := transformer.Unmarshal(unwrapCodeAssistPayload(eventData), &geminiResp); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal gemini stream chunk: %w", err)
 	}
 


### PR DESCRIPTION
## 问题

Gemini OAuth 采集到的 token 发不出去。

`internal/pkg/geminicli/oauth.go` 的 PKCE 流程、`pool_oauth.go` 的四平台 initiate/callback、`pooltokenrefresh` 的自动刷新都已具备，但出站这一环缺失：`internal/transformer/outbound/gemini/messages.go` 只会构造官方 Generative Language API 请求，把 OAuth access_token 当成 `?key=` 参数发给 `generativelanguage.googleapis.com`，必然 401/403。

OAuth 流程申请的是 `cloud-platform` scope，只对 Cloud Code Assist（`cloudcode-pa.googleapis.com`，即 Gemini CLI 的后端）有效。两套后端有三处独立差异，原代码一处都没处理：

| | 官方 Generative Language API | Cloud Code Assist |
|---|---|---|
| 鉴权 | `?key={api_key}` | `Authorization: Bearer {token}` |
| 路径 | `/v1beta/models/{model}:{op}` | `/v1internal:{op}` |
| 报文 | `{contents:[...]}` | `{model, project, request:{contents:[...]}}`，响应外包一层 `{response:{...}}` |

另有一处配套缺口：`relay.go` 的 `applyPoolCredentialHeaders` 中 OAuth 分支带平台条件 `poolPlatform == PoolPlatformOpenAI`，Gemini 走进 `case PoolTypeOAuth` 后一行都不执行，所以即便手工改 base_url 也拿不到 Bearer 头。

`PoolAccountExtra` 早已预留 `project_id` / `oauth_type` 字段（注释写着 "gemini code_assist"），但全仓库没有任何代码写入或读取过它们，`oauth_type == "code_assist"` 仅在 `quota_impl.go` 用于跳过额度查询。也就是说这条路径从来没接通。

## 改动

- **新增 Cloud Code Assist 客户端**（`internal/pkg/geminicli/codeassist.go`）：凭据结构与序列化，以及 `:loadCodeAssist` → `:onboardUser` 的 project 发现流程，与 Gemini CLI 行为一致。免费 tier 由服务端分配 project，无需用户填写。
- **新增出站适配器**（`internal/transformer/outbound/gemini/codeassist.go`）：请求体包装、`{"response":{...}}` 剥壳、Bearer 头、端点切换。
- **按凭据形态分流**：`TransformRequest` 收到 JSON 凭据走 Code Assist，裸 key 保持官方 API 行为完全不变，既有 apikey 渠道零影响。沿用 codex adapter 的既有范式，不新增 OutboundType，用户侧无需任何配置改动。
- **`EffectiveKeyWithExtra` 为 gemini oauth 输出凭据 JSON**，与 openai/codex 传结构化凭据的做法对齐（裸 access_token 既带不了 project_id，也无法与官方 API key 区分）。
- **OAuth callback 探测并持久化 project id**，复用已有账号时合并进 Extra。探测失败不阻断授权，也不会覆盖已有的可用 project。

自建代理的 base_url 会被保留（只改路径和鉴权）；指向官方 API 的 base_url 会被重定向到 Code Assist，因为该域名不接受 Bearer。

## 测试

新增 8 个测试，覆盖凭据分流、请求包装、响应剥壳、端点选择，以及 apikey 行为不变的回归保护。

```
ok  github.com/lingyuins/octopus/internal/transformer/outbound/gemini
ok  github.com/lingyuins/octopus/internal/server/handlers
ok  github.com/lingyuins/octopus/internal/model
ok  github.com/lingyuins/octopus/internal/relay
```

`go build ./...`、`go vet`、`gofmt` 均通过。基于最新 master（`82f6e338`）验证。

与 #197（stream session 内存上限）是彼此独立的问题。
