### PR TITLE
fix: AI Route 出站链路补全 SSRF 防护 + sitesync 响应体限流（issue #221）

### DIFF
--- a/internal/op/airoute/route.go
+++ b/internal/op/airoute/route.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lingyuins/octopus/internal/utils/log"
 	"github.com/lingyuins/octopus/internal/utils/proxyx"
 	"github.com/lingyuins/octopus/internal/utils/xstrings"
+	"github.com/lingyuins/octopus/internal/utils/xurl"
 	"golang.org/x/net/proxy"
 	"golang.org/x/sync/semaphore"
 )
@@ -692,6 +693,16 @@ func generateAIRoutesForBucketWithService(
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(service.APIKey))
+
+	// SSRF 防护（issue #221）：AI Route 的 BaseURL 来自 settings，editor 可改。
+	// 与 relay 主链路对齐：校验最终出站 URL 并把安全 IP 钉入 context，
+	// 配合 transport 的 SafeDialContext 杜绝 DNS rebinding。
+	safeCtx, err := xurl.AssertSafeRequestWithPin(req)
+	if err != nil {
+		log.Warnf("ssrf check failed for %s: %v", req.URL.Redacted(), err)
+		return nil, fmt.Errorf("AI 路由模型地址不允许访问: %w", err)
+	}
+	req = req.WithContext(safeCtx)
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -1780,6 +1791,10 @@ func newAIRouteHTTPClient(proxyURLStr string) (*http.Client, error) {
 	}
 
 	cloned := transport.Clone()
+	// SafeDialContext 从 context 读校验时钉入的安全 IP（AssertSafeRequestWithPin），
+	// 直连该 IP 杜绝 DNS rebinding；未携带时回退默认拨号。socks/ss/vmess 代理路径
+	// 自设 DialContext 覆盖此值，与 internal/client/http.go 的做法一致。
+	cloned.DialContext = xurl.SafeDialContext
 	if proxyURLStr == "" {
 		cloned.Proxy = nil
 		return &http.Client{Transport: cloned}, nil

--- a/internal/op/airoute/route_ssrf_test.go
+++ b/internal/op/airoute/route_ssrf_test.go
@@ -1,0 +1,33 @@
+package airoute
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// issue #221 回归测试：AI Route 的 BaseURL 指向内网/元数据地址时，
+// 出站请求必须在拨号前被 SSRF 校验拒绝。
+func TestGenerateAIRoutesRejectsDisallowedBaseURL(t *testing.T) {
+	cases := []string{
+		"http://169.254.169.254",
+		"http://127.0.0.1:8080",
+		"http://localhost:1234",
+		"http://10.0.0.5/v1",
+	}
+	for _, baseURL := range cases {
+		_, err := generateAIRoutesForBucketWithService(
+			context.Background(),
+			aiRouteService{Name: "test", BaseURL: baseURL, APIKey: "sk-test", Model: "test-model"},
+			aiRoutePromptBucket{PromptEndpointType: "openai"},
+			"test-group",
+			0, 1, nil,
+		)
+		if err == nil {
+			t.Fatalf("baseURL %s: expected ssrf rejection, got nil error", baseURL)
+		}
+		if !strings.Contains(err.Error(), "不允许访问") {
+			t.Fatalf("baseURL %s: expected ssrf rejection error, got: %v", baseURL, err)
+		}
+	}
+}

--- a/internal/sitesync/anyrouter.go
+++ b/internal/sitesync/anyrouter.go
@@ -809,7 +809,7 @@ func anyRouterRequestJSONWithCookies(ctx context.Context, siteRecord *model.Site
 			return nil, cookieHeader, err
 		}
 
-		bodyBytes, readErr := io.ReadAll(resp.Body)
+		bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, maxSiteResponseBytes))
 		resp.Body.Close()
 		if readErr != nil {
 			return nil, cookieHeader, readErr

--- a/internal/sitesync/http.go
+++ b/internal/sitesync/http.go
@@ -15,6 +15,11 @@ import (
 	"github.com/lingyuins/octopus/internal/op"
 )
 
+// maxSiteResponseBytes 限制站点同步响应体的最大读取字节数（issue #221）：
+// 对端站点被劫持或异常时返回超大 body 会直接吃内存，与 detect.go 的
+// LimitReader 做法对齐。站点同步的模型/定价 JSON 远小于此上限。
+const maxSiteResponseBytes = 8 << 20
+
 func siteHTTPClient(ctx context.Context, siteRecord *model.Site, accounts ...*model.SiteAccount) (*http.Client, error) {
 	if siteRecord == nil {
 		return nil, fmt.Errorf("site is nil")
@@ -89,7 +94,7 @@ func requestJSON(ctx context.Context, siteRecord *model.Site, method string, req
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxSiteResponseBytes))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #221

## 根因

208e15167 那轮 SSRF 修复覆盖了 relay 主链路和管理面出站请求，但漏掉了两条路径：

1. **AI Route 出站链路**：`internal/op/airoute/route.go` 的 `httpClient.Do` 前没有任何 SSRF 校验，`getAIRouteHTTPClient` 也是直接 clone `http.DefaultTransport`，未接 `SafeDialContext`。而 BaseURL 来自 settings（`servicepool.go` 拼 `AIRouteServiceConfig`），属于 editor 可控配置——入口 `/api/v1/route/ai-generate` 只需 `PermGroupsWrite`。按 #219 确立的信任模型（editor 可触达的配置不可信），BaseURL 被改成 `http://169.254.169.254/` 之类后，触发 AI Route 生成即可打云元数据端点等内网地址，且存在 DNS rebinding 窗口。
2. **sitesync 响应体无大小限制**：`internal/sitesync/http.go` 与 `anyrouter.go` 各有一处 `io.ReadAll(resp.Body)` 未限制大小（同目录 `detect.go` 已用 `LimitReader`，属遗漏）。对端站点被劫持或异常时返回超大 body 会直接吃内存。

## 修复

1. **airoute**（`route.go`）：
   - `httpClient.Do(req)` 前接入 `xurl.AssertSafeRequestWithPin`，校验最终出站 URL 并把解析到的安全 IP 钉入 context；
   - `newAIRouteHTTPClient` 的 transport 接入 `xurl.SafeDialContext`，拨号直连钉入的 IP，杜绝 DNS rebinding。socks/ss/vmess 代理路径自设 `DialContext` 覆盖此值，与 `internal/client/http.go` 的既有做法完全一致。
2. **sitesync**（`http.go` / `anyrouter.go`）：两处 `io.ReadAll` 套 `io.LimitReader`，共享 8MB 上限常量 `maxSiteResponseBytes`（站点同步的模型/定价 JSON 远小于此），与 `detect.go` 对齐。

## 验证

- 新增回归测试 `route_ssrf_test.go`：BaseURL 为 `169.254.169.254` / `127.0.0.1` / `localhost` / `10.0.0.5` 时，出站请求在拨号前被拒绝
- `go build ./...`、`go vet` 通过；`internal/op/airoute`、`internal/sitesync`、`internal/utils/xurl` 全量测试通过
