### PR TITLE
fix: 修复 HTTP 代理模式下 SSRF DNS-pin 误拼代理端口导致超时

### DIFF
--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -237,10 +237,12 @@ func clonedDefaultTransport() (*http.Transport, error) {
 	cloned.MaxIdleConns = httpMaxIdleConns
 	cloned.MaxIdleConnsPerHost = httpMaxIdleConnsPerHost
 	cloned.IdleConnTimeout = httpIdleConnTimeout
-	// SafeDialContext 从 context 读校验时钉入的安全 IP（AssertSafeRequestWithPin），
-	// 直连该 IP 杜绝 DNS rebinding；未携带时回退默认拨号。socks/ss/vmess 代理路径
-	// 自设 DialContext 覆盖此值，代理拨号不受影响（前置 AssertSafeHost 已校验目标）。
-	cloned.DialContext = xurl.SafeDialContext
+	// 此处不再无条件注入 SafeDialContext：SafeDialContext 会读 context 里
+	// AssertSafeRequestWithPin 钉入的上游安全 IP，并把拨号地址的 host 替换为它。
+	// HTTP 代理路径里 DialContext 收到的 addr 是「代理服务器地址」而非上游地址，
+	// 若沿用 SafeDialContext 会把上游 IP 拼上代理端口（上游IP:7890）导致拨号目标
+	// 错误、必超时。故仅直连路径在 newHTTPClientNoProxyWithTimeout 中注入；
+	// socks/ss/vmess 代理路径在各自分支自设 DialContext 覆盖。
 	return cloned, nil
 }
 
@@ -254,6 +256,9 @@ func newHTTPClientNoProxyWithTimeout(timeout time.Duration) (*http.Client, error
 		return nil, err
 	}
 	cloned.Proxy = nil
+	// 直连场景注入 SafeDialContext：从 context 读 AssertSafeRequestWithPin 钉入的
+	// 安全 IP，直连该 IP 彻底消除 DNS rebinding 窗口；未携带时回退默认拨号。
+	cloned.DialContext = xurl.SafeDialContext
 	return &http.Client{Transport: cloned, Timeout: timeout}, nil
 }
 
@@ -274,6 +279,9 @@ func newHTTPClientCustomProxyWithTimeout(proxyURLStr string, timeout time.Durati
 
 	switch proxyURL.Scheme {
 	case "http", "https":
+		// HTTP(S) 代理由代理端解析并连接上游域名，客户端只需连到代理地址。
+		// 这里保留 clonedDefaultTransport 的默认 DialContext（不注入 SafeDialContext），
+		// 避免上游钉住的 IP 被拼到代理地址上导致拨号目标错误。
 		cloned.Proxy = http.ProxyURL(proxyURL)
 	case "socks", "socks5":
 		socksDialer, err := proxy.FromURL(proxyURL, proxy.Direct)

--- a/internal/client/http_test.go
+++ b/internal/client/http_test.go
@@ -1,0 +1,137 @@
+package client
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/lingyuins/octopus/internal/utils/xurl"
+)
+
+// acceptOnce 启动一个只 accept 一次连接的 goroutine，把结果写入 done。
+// 用于验证拨号确实连到了本地 listener（而非被移到别的 host）。
+func acceptOnce(t *testing.T, ln net.Listener) chan net.Conn {
+	t.Helper()
+	done := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			done <- nil
+			return
+		}
+		done <- conn
+	}()
+	return done
+}
+
+// TestHTTPProxyTransportIgnoresPinnedIP 回归测试（HTTP 代理 SSRF DNS-pin bug）：
+// 走 HTTP 代理时，上游域名由代理端解析，客户端的 DialContext 收到的 addr 是代理
+// 地址。若误用 SafeDialContext，会把 context 里钉入的上游 IP 拼上代理端口（如
+// 上游IP:7890），导致拨号目标错误、必超时。此处验证 HTTP 代理 transport 即使
+// context 携带钉入 IP，也仍按传入的代理 addr 拨号。
+func TestHTTPProxyTransportIgnoresPinnedIP(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	accepted := acceptOnce(t, ln)
+	proxyAddr := ln.Addr().String()
+
+	// 用公网 IP 作为上游 target，AssertSafeRequestWithPin 会把它钉入 context（无 DNS）。
+	req, err := http.NewRequest(http.MethodPost, "https://8.8.8.8/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	safeCtx, err := xurl.AssertSafeRequestWithPin(req)
+	if err != nil {
+		t.Fatalf("AssertSafeRequestWithPin: %v", err)
+	}
+
+	client, err := newHTTPClientCustomProxyWithTimeout("http://"+proxyAddr, time.Second)
+	if err != nil {
+		t.Fatalf("newHTTPClientCustomProxyWithTimeout: %v", err)
+	}
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
+	}
+
+	// Go 的 HTTP 代理路径会调用 DialContext(ctx, "tcp", 代理地址)。
+	// 正确行为：连接 proxyAddr（本地 listener）；错误行为：连接 8.8.8.8:proxyPort。
+	ctx, cancel := context.WithTimeout(safeCtx, 3*time.Second)
+	defer cancel()
+	conn, err := tr.DialContext(ctx, "tcp", proxyAddr)
+	if err != nil {
+		t.Fatalf("HTTP proxy dial should connect to proxy addr %s, got: %v", proxyAddr, err)
+	}
+	conn.Close()
+
+	select {
+	case got := <-accepted:
+		if got == nil {
+			t.Fatal("listener closed without accepting a connection")
+		}
+		got.Close()
+	case <-time.After(2 * time.Second):
+		t.Fatal("dial did not reach the local listener (dialed wrong host?)")
+	}
+}
+
+// TestDirectTransportStillPinsIP 确保直连（无代理）路径仍然注入 SafeDialContext：
+// context 携带钉入 IP 时，DialContext 应直连该 IP 而非原 addr 中的 host。
+func TestDirectTransportStillPinsIP(t *testing.T) {
+	xurl.SetSSRFAllowPrivateForTest(true)
+	defer xurl.SetSSRFAllowPrivateForTest(false)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	accepted := acceptOnce(t, ln)
+
+	addr := ln.Addr().String()
+	ip, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+
+	// 钉入 listener 的 IP（测试环境放行私有地址），target 端口随意。
+	req, err := http.NewRequest(http.MethodPost, "http://"+ip+":9/v1", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	safeCtx, err := xurl.AssertSafeRequestWithPin(req)
+	if err != nil {
+		t.Fatalf("AssertSafeRequestWithPin: %v", err)
+	}
+
+	client, err := newHTTPClientNoProxyWithTimeout(time.Second)
+	if err != nil {
+		t.Fatalf("newHTTPClientNoProxyWithTimeout: %v", err)
+	}
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
+	}
+
+	// 原 addr 用不存在的 hostname + listener 端口；SafeDialContext 应改用钉入的 IP。
+	conn, err := tr.DialContext(safeCtx, "tcp", "nonexistent-host-xyz.invalid:"+port)
+	if err != nil {
+		t.Fatalf("direct transport should pin IP and dial it: %v", err)
+	}
+	conn.Close()
+
+	select {
+	case got := <-accepted:
+		if got == nil {
+			t.Fatal("listener closed without accepting a connection")
+		}
+		got.Close()
+	case <-time.After(2 * time.Second):
+		t.Fatal("dial did not reach the local listener (pin lost?)")
+	}
+}


### PR DESCRIPTION
﻿## 问题

HTTP 代理模式下 SSRF DNS-pin（`SafeDialContext`）把上游域名解析出的 IP 拼上代理端口，导致走代理的渠道必超时：

```
proxyconnect tcp: dial tcp 104.21.86.180:7890: connect: connection timed out
```

104.21.86.180 是渠道 base_url 域名解析出的真实 IP，7890 是代理（mihomo）端口——正常应连接 `代理地址:7890`（`172.18.0.1:7890`），却连成了 `上游IP:7890`。

## 根因

三个文件配合触发：

1. `internal/utils/xurl/safeguard.go` `SafeDialContext` 无条件把 `addr` 的 host 替换为 context 里钉入的安全 IP，仅保留端口。
2. `internal/client/http.go` `clonedDefaultTransport` 无条件注入 `SafeDialContext`。HTTP 代理路径 `newHTTPClientCustomProxy` 只设 `cloned.Proxy = http.ProxyURL(...)`，没覆盖 `DialContext`（作者注释已说明 socks/ss/vmess 会自设覆盖，但 HTTP 分支被遗漏）。
3. `internal/relay/relay.go` `sendRequest` 先 `AssertSafeRequestWithPin(req)` 把上游 IP 钉入 ctx。

于是 Go 连 HTTP 代理时调用 `DialContext(ctx, "tcp", "<代理IP>:7890")`，被 `SafeDialContext` 替换为 `<上游IP>:7890` → 超时。

## 修复

采用「在传输层收敛注入」的方案（等价于建议里的方案 3，比方案 1 覆盖更全）：`SafeDialContext` 只在**直连路径**注入，HTTP(S) 代理路径保留默认 `DialContext` 只连代理地址，由代理端解析上游域名。

- `clonedDefaultTransport` 不再无条件注入 `SafeDialContext`
- `newHTTPClientNoProxyWithTimeout`（直连）显式注入 `SafeDialContext`
- HTTP(S) 代理分支保留默认 `DialContext`

这样一处修复覆盖所有走 HTTP 代理的入口：relay 转发、media 转发、系统代理、号池代理。SSRF 校验（`AssertSafeRequestWithPin` 的地址校验）完全保留，仅代理路径不做 DNS-pin（代理端负责解析上游）。

## 测试

新增 `internal/client/http_test.go` 两个回归测试：

- `TestHTTPProxyTransportIgnoresPinnedIP`：HTTP 代理 transport 即使 context 携带钉入 IP，仍按代理地址拨号（bug 场景）
- `TestDirectTransportStillPinsIP`：直连 transport 仍使用钉入 IP 直连（确保 DNS-pin 未回退）

```
go test ./internal/client/... ./internal/utils/xurl/...
ok  github.com/lingyuins/octopus/internal/client  0.103s
ok  github.com/lingyuins/octopus/internal/utils/xurl  0.429s
```

/cc @lingyuins
