### PR TITLE
feat: SenseNova 套餐监控适配官方新版额度面板

### DIFF
--- a/internal/db/migrate/047.go
+++ b/internal/db/migrate/047.go
@@ -1,0 +1,35 @@
+package migrate
+
+import (
+	"fmt"
+
+	"github.com/lingyuins/octopus/internal/model"
+	"gorm.io/gorm"
+)
+
+func init() {
+	RegisterAfterAutoMigration(Migration{
+		Version: 47,
+		Up:      migratePlanProviderPoolsJSON,
+	})
+}
+
+// 047: 为 plan_providers 增加 pools_json 列
+// （SenseNova 新版 pool-usage 接口返回分池明细，前端按官方新版额度面板
+// 分池展示需要逐池的 window_5h/window_7d/grant_balance 数据）。
+// 与 039 同模式：GORM AutoMigrate 通常也会加列，这里幂等兜底，确保跨方言
+// （SQLite/MySQL/Postgres）以及运行时切换 DB 类型后该列存在。
+func migratePlanProviderPoolsJSON(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("db is nil")
+	}
+	if !db.Migrator().HasTable(&model.PlanProvider{}) {
+		return nil
+	}
+	if !db.Migrator().HasColumn(&model.PlanProvider{}, "PoolsJSON") {
+		if err := db.Migrator().AddColumn(&model.PlanProvider{}, "PoolsJSON"); err != nil {
+			return fmt.Errorf("add column pools_json: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/db/migrate/053.go
+++ b/internal/db/migrate/053.go
@@ -9,12 +9,12 @@ import (
 
 func init() {
 	RegisterAfterAutoMigration(Migration{
-		Version: 47,
+		Version: 53,
 		Up:      migratePlanProviderPoolsJSON,
 	})
 }
 
-// 047: 为 plan_providers 增加 pools_json 列
+// 053: 为 plan_providers 增加 pools_json 列
 // （SenseNova 新版 pool-usage 接口返回分池明细，前端按官方新版额度面板
 // 分池展示需要逐池的 window_5h/window_7d/grant_balance 数据）。
 // 与 039 同模式：GORM AutoMigrate 通常也会加列，这里幂等兜底，确保跨方言

--- a/internal/model/plan_provider.go
+++ b/internal/model/plan_provider.go
@@ -264,6 +264,9 @@ type PlanProvider struct {
 	FiveHourTotal   float64    `json:"five_hour_total" gorm:"default:0"`
 	FiveHourUsed    float64    `json:"five_hour_used" gorm:"default:0"`
 	FiveHourResetAt *time.Time `json:"five_hour_reset_at"`
+	// PoolsJSON 分池明细（仅 sensenova_plan 新版 pool-usage 接口返回），
+	// JSON 数组字符串（TokenPlanPoolUsage），空表示无分池数据。
+	PoolsJSON string `json:"-" gorm:"type:text;default:''"`
 	// RefreshIntervalMin 自动刷新间隔（分钟），0 表示跟随全局默认设置
 	// SettingKeyPlanProviderRefreshInterval。
 	RefreshIntervalMin int `json:"refresh_interval_min" gorm:"not null;default:0"`
@@ -291,12 +294,37 @@ type PlanChannelStats struct {
 	Source string `json:"source,omitempty"`
 }
 
+// TokenPlanPoolUsage 单积分池明细（sensenova_plan 新版 pool-usage 接口）。
+// 数值已由 query 层从官方字符串转换为 float64；时间字段为 Unix 秒转换。
+type TokenPlanPoolUsage struct {
+	ID       string   `json:"id"`
+	Name     string   `json:"name"`
+	PoolType string   `json:"pool_type"` // default（通用池）| dedicated（专属池）
+	ModelIDs []string `json:"model_ids"`
+	// FiveHour 5 小时窗口
+	FiveHourLimit    float64    `json:"five_hour_limit"`
+	FiveHourUsed     float64    `json:"five_hour_used"`
+	FiveHourRemain   float64    `json:"five_hour_remaining"`
+	FiveHourResetAt  *time.Time `json:"five_hour_reset_at"`
+	// SevenDay 7 天窗口（本周余额）
+	SevenDayLimit    float64    `json:"seven_day_limit"`
+	SevenDayUsed     float64    `json:"seven_day_used"`
+	SevenDayRemain   float64    `json:"seven_day_remaining"`
+	SevenDayResetAt  *time.Time `json:"seven_day_reset_at"`
+	// 授权余额（活动固定积分）
+	GrantBalance            float64    `json:"grant_balance"`
+	NearestGrantExpiry      *time.Time `json:"nearest_grant_expiry"`
+	NearestGrantExpiringBal float64    `json:"nearest_grant_expiring_balance"`
+}
+
 // PlanProviderListItem 列表响应
 type PlanProviderListItem struct {
 	PlanProvider
 	Models         string `json:"models"`       // 从 Channel 继承的模型
 	ChannelName    string `json:"channel_name"` // 关联渠道名称
 	ChannelEnabled bool   `json:"channel_enabled"`
+	// Pools 分池明细（PoolsJSON 反序列化，sensenova_plan 等返回）
+	Pools []TokenPlanPoolUsage `json:"pools,omitempty"`
 	// LoginConfigured 是否已配置账号密码自动登录（sensenova_plan 等支持账号登录的厂商）
 	LoginConfigured bool `json:"login_configured"`
 	// BalanceDelta 上次刷新到本次刷新之间的余额减少额（balance 类，充值导致的负值按 0）

--- a/internal/model/plan_provider.go
+++ b/internal/model/plan_provider.go
@@ -159,7 +159,7 @@ var PlanProviderCategories = []PlanProviderCategoryInfo{
 		Type:        PlanProviderTypeTokenPlan,
 		BaseURL:     "https://platform.sensenova.cn",
 		Models:      "sensenova-6.7-flash-lite,sensenova-u1-fast,deepseek-v4-flash",
-		Description: "SenseNova Coding Plan 套餐用量查询（控制台 Bearer Token 必填，约 3 小时有效期）。可选填 API Key 自动创建/复用转发渠道（接入点 token.sensenova.cn/v1）",
+		Description: "SenseNova Coding Plan 套餐用量查询（新版 pool-usage 接口，控制台 Bearer Token 必填，约 3 小时有效期；可配账号密码自动续期）。可选填 API Key 自动创建/复用转发渠道（接入点 token.sensenova.cn/v1）",
 		HelpURL:     "https://platform.sensenova.cn/console",
 	},
 	{

--- a/internal/planprovider/query.go
+++ b/internal/planprovider/query.go
@@ -90,6 +90,8 @@ type TokenPlanResult struct {
 	FiveHourResetAt *time.Time `json:"five_hour_reset_at"`
 	// 各模型明细
 	Models []TokenPlanModelUsage `json:"models,omitempty"`
+	// Pools 分池明细（仅 sensenova_plan 新版 pool-usage 接口返回）
+	Pools []model.TokenPlanPoolUsage `json:"pools,omitempty"`
 }
 
 // TokenPlanModelUsage 单个模型用量
@@ -742,6 +744,7 @@ func querySenseNovaPlanTokenPlan(ctx context.Context, token string) (*TokenPlanR
 			ID         string           `json:"id"`
 			Name       string           `json:"name"`
 			PoolType   string           `json:"pool_type"`
+			ModelIDs   []string         `json:"model_ids"`
 			Window5H   *senseNovaWindow `json:"window_5h"`
 			Window7D   *senseNovaWindow `json:"window_7d"`
 			GrantBalance            string `json:"grant_balance"`
@@ -773,24 +776,42 @@ func querySenseNovaPlanTokenPlan(ctx context.Context, token string) (*TokenPlanR
 	var fiveReset, weeklyReset *time.Time
 	var nearestExpiry *time.Time
 	for _, p := range data.Pools {
+		pool := model.TokenPlanPoolUsage{
+			ID:       p.ID,
+			Name:     p.Name,
+			PoolType: p.PoolType,
+			ModelIDs: p.ModelIDs,
+		}
 		if p.Window5H != nil {
-			result.FiveHourTotal += parseF(p.Window5H.Limit)
-			result.FiveHourUsed += parseF(p.Window5H.Used)
-			if r := parseReset(p.Window5H.ResetAt); r != nil && (fiveReset == nil || r.After(*fiveReset)) {
+			pool.FiveHourLimit = parseF(p.Window5H.Limit)
+			pool.FiveHourUsed = parseF(p.Window5H.Used)
+			pool.FiveHourRemain = parseF(p.Window5H.Remaining)
+			pool.FiveHourResetAt = parseReset(p.Window5H.ResetAt)
+			result.FiveHourTotal += pool.FiveHourLimit
+			result.FiveHourUsed += pool.FiveHourUsed
+			if r := pool.FiveHourResetAt; r != nil && (fiveReset == nil || r.After(*fiveReset)) {
 				fiveReset = r
 			}
 		}
 		if p.Window7D != nil {
-			result.WeeklyTotal += parseF(p.Window7D.Limit)
-			result.WeeklyUsed += parseF(p.Window7D.Used)
-			if r := parseReset(p.Window7D.ResetAt); r != nil && (weeklyReset == nil || r.After(*weeklyReset)) {
+			pool.SevenDayLimit = parseF(p.Window7D.Limit)
+			pool.SevenDayUsed = parseF(p.Window7D.Used)
+			pool.SevenDayRemain = parseF(p.Window7D.Remaining)
+			pool.SevenDayResetAt = parseReset(p.Window7D.ResetAt)
+			result.WeeklyTotal += pool.SevenDayLimit
+			result.WeeklyUsed += pool.SevenDayUsed
+			if r := pool.SevenDayResetAt; r != nil && (weeklyReset == nil || r.After(*weeklyReset)) {
 				weeklyReset = r
 			}
 		}
-		result.QuotaTotal += parseF(p.GrantBalance)
-		if r := parseReset(p.NearestGrantExpiry); r != nil && (nearestExpiry == nil || r.Before(*nearestExpiry)) {
+		pool.GrantBalance = parseF(p.GrantBalance)
+		pool.NearestGrantExpiry = parseReset(p.NearestGrantExpiry)
+		pool.NearestGrantExpiringBal = parseF(p.NearestGrantExpiringBal)
+		result.QuotaTotal += pool.GrantBalance
+		if r := pool.NearestGrantExpiry; r != nil && (nearestExpiry == nil || r.Before(*nearestExpiry)) {
 			nearestExpiry = r
 		}
+		result.Pools = append(result.Pools, pool)
 	}
 	result.FiveHourResetAt = fiveReset
 	result.WeeklyResetAt = weeklyReset

--- a/internal/planprovider/query.go
+++ b/internal/planprovider/query.go
@@ -679,40 +679,43 @@ func decodeStepFunWebID(oasisToken string) string {
 
 // --- SenseNova 套餐用量（商汤日日新 Coding Plan）---
 //
-// 与 StepFun Plan 类似，使用控制台 token 鉴权查询套餐用量，但更简单：
-//   - 标准 Bearer JWT 鉴权（非 Cookie + 自定义头）
-//   - Token 有效期约 3 小时（比 StepFun 的 30 分钟长）
-//   - GET 请求，URL 参数带 account_id 和 model_ids
-//   - 响应是每模型剩余百分比（非绝对值）
+// 新版额度面板（2026-09 起官方改版）：
+//   - 接口：GET /lite/console/v1/tokenplan/pool-usage（无查询参数）
+//   - 鉴权：标准 Bearer JWT（控制台 access_token，约 3 小时有效期）
+//   - 响应：{plan, pools[]}，每池含 window_5h / window_7d 窗口额度
+//     + grant_balance 授权余额 + nearest_grant_expiry 最近到期时间
+//   - 所有数值字段均为字符串；reset_at / nearest_grant_expiry 为 Unix 秒
 //
-// account_id 从 JWT payload 的 ext.tenant_id 字段自动解码。
-var senseNovaPlanURL = "https://platform.sensenova.cn/lite/console/v1/user/coding-plan/usages"
+// 映射到 Octopus 三档（与官方新版面板对齐）：
+//   - five_hour ← window_5h（近 5 小时窗口）
+//   - weekly    ← window_7d（近 7 天窗口）
+//   - quota     ← grant_balance（授权余额，重置时间 = 最近授权到期）
+//
+// 多池（default 通用池 + dedicated 专用池）汇总：各窗口与授权余额求和，
+// 重置时间取最晚。
+var senseNovaPlanURL = "https://platform.sensenova.cn/lite/console/v1/tokenplan/pool-usage"
+
+// senseNovaWindow 官方 pool-usage 响应中的窗口额度（数值均为字符串）。
+type senseNovaWindow struct {
+	Limit     string `json:"limit"`
+	Used      string `json:"used"`
+	Remaining string `json:"remaining"`
+	ResetAt   string `json:"reset_at"`
+}
 
 func querySenseNovaPlanTokenPlan(ctx context.Context, token string) (*TokenPlanResult, error) {
 	if token == "" {
 		return nil, fmt.Errorf("sensenova_plan: token is required")
 	}
 
-	// 从 JWT 解码 tenant_id 作为 account_id
-	accountID := decodeSenseNovaAccountID(token)
-	if accountID == "" {
-		return nil, fmt.Errorf("sensenova_plan: 无法从 Token 解码 account_id，请检查 Token 是否完整")
-	}
-
-	// 构造 URL：account_id + 固定模型列表
-	u := senseNovaPlanURL + "?account_id=" + accountID
-	for _, m := range senseNovaPlanModels {
-		u += "&model_ids=" + m
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, senseNovaPlanURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("sensenova_plan: create request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/json, text/plain, */*")
 	req.Header.Set("Referer", "https://platform.sensenova.cn/console")
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36")
 
 	client := &http.Client{Timeout: requestTimeout}
 	resp, err := client.Do(req)
@@ -731,70 +734,68 @@ func querySenseNovaPlanTokenPlan(ctx context.Context, token string) (*TokenPlanR
 	}
 
 	var data struct {
-		ModelRemainingPercent map[string]float64 `json:"model_remaining_percent"`
+		Plan struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"plan"`
+		Pools []struct {
+			ID         string           `json:"id"`
+			Name       string           `json:"name"`
+			PoolType   string           `json:"pool_type"`
+			Window5H   *senseNovaWindow `json:"window_5h"`
+			Window7D   *senseNovaWindow `json:"window_7d"`
+			GrantBalance            string `json:"grant_balance"`
+			NearestGrantExpiry      string `json:"nearest_grant_expiry"`
+			NearestGrantExpiringBal string `json:"nearest_grant_expiring_balance"`
+		} `json:"pools"`
 	}
 	if err := json.Unmarshal(body, &data); err != nil {
 		return nil, fmt.Errorf("sensenova_plan: parse response: %w", err)
 	}
-
-	// 响应是每模型剩余百分比，汇总为总量/已用
-	// 百分比无法直接换算成绝对额度，用百分比作为 total=100, used=100-pct
-	result := &TokenPlanResult{
-		QuotaTotal: 100,
-	}
-	var models []TokenPlanModelUsage
-	for _, modelName := range senseNovaPlanModels {
-		remaining := data.ModelRemainingPercent[modelName]
-		models = append(models, TokenPlanModelUsage{
-			ModelName:  modelName,
-			QuotaTotal: 100,
-			QuotaUsed:  max(0, 100-remaining),
-		})
+	if len(data.Pools) == 0 {
+		return nil, fmt.Errorf("sensenova_plan: 响应中无 pools 数据")
 	}
 
-	// 汇总：取所有模型中已用比例最高的作为总体已用
-	maxUsed := 0.0
-	for _, m := range models {
-		if m.QuotaUsed > maxUsed {
-			maxUsed = m.QuotaUsed
+	parseF := func(s string) float64 {
+		v, _ := strconv.ParseFloat(s, 64)
+		return v
+	}
+	parseReset := func(s string) *time.Time {
+		ts, err := strconv.ParseInt(s, 10, 64)
+		if err != nil || ts <= 0 {
+			return nil
+		}
+		t := time.Unix(ts, 0)
+		return &t
+	}
+
+	result := &TokenPlanResult{}
+	var fiveReset, weeklyReset *time.Time
+	var nearestExpiry *time.Time
+	for _, p := range data.Pools {
+		if p.Window5H != nil {
+			result.FiveHourTotal += parseF(p.Window5H.Limit)
+			result.FiveHourUsed += parseF(p.Window5H.Used)
+			if r := parseReset(p.Window5H.ResetAt); r != nil && (fiveReset == nil || r.After(*fiveReset)) {
+				fiveReset = r
+			}
+		}
+		if p.Window7D != nil {
+			result.WeeklyTotal += parseF(p.Window7D.Limit)
+			result.WeeklyUsed += parseF(p.Window7D.Used)
+			if r := parseReset(p.Window7D.ResetAt); r != nil && (weeklyReset == nil || r.After(*weeklyReset)) {
+				weeklyReset = r
+			}
+		}
+		result.QuotaTotal += parseF(p.GrantBalance)
+		if r := parseReset(p.NearestGrantExpiry); r != nil && (nearestExpiry == nil || r.Before(*nearestExpiry)) {
+			nearestExpiry = r
 		}
 	}
-	result.QuotaUsed = maxUsed
-	result.Models = models
+	result.FiveHourResetAt = fiveReset
+	result.WeeklyResetAt = weeklyReset
+	result.QuotaResetAt = nearestExpiry
 	return result, nil
-}
-
-// senseNovaPlanModels 是 SenseNova Coding Plan 支持的模型列表。
-// 查询时需要传入 model_ids 参数，服务端返回每模型的剩余百分比。
-var senseNovaPlanModels = []string{
-	"sensenova-6.7-flash-lite",
-	"sensenova-u1-fast",
-	"deepseek-v4-flash",
-}
-
-// decodeSenseNovaAccountID 从 SenseNova JWT 的 payload 中解码 ext.tenant_id。
-func decodeSenseNovaAccountID(token string) string {
-	parts := strings.Split(token, ".")
-	if len(parts) < 2 {
-		return ""
-	}
-	payload := parts[1]
-	decoded, err := base64.URLEncoding.DecodeString(payload)
-	if err != nil {
-		decoded, err = base64.RawURLEncoding.DecodeString(payload)
-		if err != nil {
-			return ""
-		}
-	}
-	var claims struct {
-		Ext struct {
-			TenantID string `json:"tenant_id"`
-		} `json:"ext"`
-	}
-	if err := json.Unmarshal(decoded, &claims); err != nil {
-		return ""
-	}
-	return claims.Ext.TenantID
 }
 
 // --- MiMo Token Plan (小米 MiMo Coding Plan) ---

--- a/internal/planprovider/sensenova_login_test.go
+++ b/internal/planprovider/sensenova_login_test.go
@@ -233,10 +233,6 @@ func TestSenseNovaOIDCLogin(t *testing.T) {
 	if sess.accessToken == "" || sess.refreshToken != "refresh-token-1" {
 		t.Errorf("会话 = %+v, want access_token 非空 + refresh_token=refresh-token-1", sess)
 	}
-	// access_token 应包含 tenant_id（供用量查询解码 account_id）
-	if tid := decodeSenseNovaAccountID(sess.accessToken); tid != "tenant-1" {
-		t.Errorf("decodeSenseNovaAccountID() = %q, want tenant-1", tid)
-	}
 	if !sess.expiresAt.After(time.Now().Add(2 * time.Hour)) {
 		t.Errorf("expiresAt = %v, 应约为 3 小时后", sess.expiresAt)
 	}

--- a/internal/planprovider/service.go
+++ b/internal/planprovider/service.go
@@ -2,6 +2,7 @@ package planprovider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -99,6 +100,32 @@ func MigrateLegacyDeepSeekChannels(ctx context.Context) (int, error) {
 	return migrated, nil
 }
 
+// marshalPlanPools 把分池明细序列化为落库 JSON 字符串（无分池数据时返回空串）。
+func marshalPlanPools(pools []model.TokenPlanPoolUsage) string {
+	if len(pools) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(pools)
+	if err != nil {
+		log.Warnf("planprovider: marshal pools failed: %v", err)
+		return ""
+	}
+	return string(b)
+}
+
+// unmarshalPlanPools 反序列化 PoolsJSON 为分池明细（空串/解析失败返回 nil）。
+func unmarshalPlanPools(poolsJSON string) []model.TokenPlanPoolUsage {
+	if poolsJSON == "" {
+		return nil
+	}
+	var pools []model.TokenPlanPoolUsage
+	if err := json.Unmarshal([]byte(poolsJSON), &pools); err != nil {
+		log.Warnf("planprovider: unmarshal pools failed: %v", err)
+		return nil
+	}
+	return pools
+}
+
 // ListProviders 列出所有 Plan Provider
 func ListProviders(ctx context.Context, providerType model.PlanProviderType) ([]model.PlanProviderListItem, error) {
 	var providers []model.PlanProvider
@@ -115,6 +142,7 @@ func ListProviders(ctx context.Context, providerType model.PlanProviderType) ([]
 		item.APIKey = ""
 		item.ForwardAPIKey = ""
 		item.LoginConfigured = p.LoginUsername != "" && p.LoginPasswordEnc != ""
+		item.Pools = unmarshalPlanPools(p.PoolsJSON)
 		// 本次与上次检测之间的消费增量：
 		// balance 类 = 上次余额 − 本次余额（充值导致的负值按 0）；
 		// tokenplan 类 = 本次已用 − 上次已用（周期重置导致的负值按 0）。
@@ -289,6 +317,7 @@ func AddProvider(ctx context.Context, category model.PlanProviderCategory, apiKe
 	var quotaTotal, quotaUsed, weeklyTotal, weeklyUsed float64
 	var fiveHourTotal, fiveHourUsed float64
 	var quotaResetAt, weeklyResetAt, fiveHourResetAt *string
+	var pools []model.TokenPlanPoolUsage
 
 	if info.Type == model.PlanProviderTypeBalance {
 		result, err := QueryBalance(ctx, category, apiKey, info.BaseURL)
@@ -320,6 +349,7 @@ func AddProvider(ctx context.Context, category model.PlanProviderCategory, apiKe
 			s := result.FiveHourResetAt.Format("2006-01-02 15:04:05")
 			fiveHourResetAt = &s
 		}
+		pools = result.Pools
 	}
 
 	// 2. 渠道创建/复用
@@ -429,6 +459,7 @@ func AddProvider(ctx context.Context, category model.PlanProviderCategory, apiKe
 		WeeklyUsed:    weeklyUsed,
 		FiveHourTotal: fiveHourTotal,
 		FiveHourUsed:  fiveHourUsed,
+		PoolsJSON:     marshalPlanPools(pools),
 	}
 
 	if quotaResetAt != nil {
@@ -520,6 +551,7 @@ func RefreshProvider(ctx context.Context, id int) (*model.PlanProvider, error) {
 		provider.FiveHourTotal = result.FiveHourTotal
 		provider.FiveHourUsed = result.FiveHourUsed
 		provider.FiveHourResetAt = result.FiveHourResetAt
+		provider.PoolsJSON = marshalPlanPools(result.Pools)
 	}
 
 	now := time.Now()
@@ -669,6 +701,7 @@ func UpdateProviderCredentials(ctx context.Context, id int, newAPIKey, newForwar
 		provider.FiveHourTotal = result.FiveHourTotal
 		provider.FiveHourUsed = result.FiveHourUsed
 		provider.FiveHourResetAt = result.FiveHourResetAt
+		provider.PoolsJSON = marshalPlanPools(result.Pools)
 	}
 
 	now := time.Now()

--- a/internal/planprovider/stepfun_plan_test.go
+++ b/internal/planprovider/stepfun_plan_test.go
@@ -162,39 +162,7 @@ func TestQueryStepFunPlanTokenPlan_EmptyToken(t *testing.T) {
 	}
 }
 
-// --- SenseNova Plan 测试 ---
-
-// makeTestSenseNovaToken 构造一个合法的 SenseNova Bearer JWT，
-// payload 含 ext.tenant_id。内容不参与签名校验（测试用）。
-func makeTestSenseNovaToken(t *testing.T, tenantID string) string {
-	t.Helper()
-	payload, _ := json.Marshal(map[string]any{
-		"client_id": "nova",
-		"exp":       9999999999,
-		"ext": map[string]any{
-			"tenant_id":    tenantID,
-			"principal_id": "test-principal",
-			"username":     "testuser",
-		},
-	})
-	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
-	return "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." + encodedPayload + ".sig"
-}
-
-func TestDecodeSenseNovaAccountID(t *testing.T) {
-	token := makeTestSenseNovaToken(t, "tenant-abc-123")
-	accountID := decodeSenseNovaAccountID(token)
-	if accountID != "tenant-abc-123" {
-		t.Errorf("decodeSenseNovaAccountID() = %q, want %q", accountID, "tenant-abc-123")
-	}
-}
-
-func TestDecodeSenseNovaAccountID_EmptyToken(t *testing.T) {
-	accountID := decodeSenseNovaAccountID("invalid")
-	if accountID != "" {
-		t.Errorf("decodeSenseNovaAccountID() = %q, want empty", accountID)
-	}
-}
+// --- SenseNova Plan 测试（新版 pool-usage 接口）---
 
 func TestQuerySenseNovaPlanTokenPlan_Success(t *testing.T) {
 	var gotAuth, gotMethod string
@@ -202,19 +170,48 @@ func TestQuerySenseNovaPlanTokenPlan_Success(t *testing.T) {
 		gotMethod = r.Method
 		gotAuth = r.Header.Get("Authorization")
 
-		// 校验 URL 参数
-		if !strings.Contains(r.URL.RawQuery, "account_id=test-tenant-id") {
-			t.Errorf("URL missing account_id: %s", r.URL.RawQuery)
-		}
-		if !strings.Contains(r.URL.RawQuery, "model_ids=sensenova-6.7-flash-lite") {
-			t.Errorf("URL missing model_ids: %s", r.URL.RawQuery)
+		// 新版接口无查询参数（不再需要 account_id / model_ids）
+		if r.URL.RawQuery != "" {
+			t.Errorf("unexpected query params: %s", r.URL.RawQuery)
 		}
 
 		resp := map[string]any{
-			"model_remaining_percent": map[string]any{
-				"deepseek-v4-flash":        100,
-				"sensenova-6.7-flash-lite": 80,
-				"sensenova-u1-fast":        50,
+			"plan": map[string]any{
+				"id":   "free",
+				"name": "Free Plan",
+				"type": "TOKEN_PLAN_PLAN_TYPE_FREE",
+			},
+			"pools": []any{
+				map[string]any{
+					"id":        "pool_default",
+					"name":      "通用积分池",
+					"pool_type": "default",
+					"model_ids": []string{"deepseek-v4-flash", "sensenova-6.7-flash-lite"},
+					"window_5h": map[string]any{
+						"limit": "60000", "used": "0", "remaining": "60000", "reset_at": "1788523830",
+					},
+					"window_7d": map[string]any{
+						"limit": "600000", "used": "354.84768", "remaining": "599645.15232", "reset_at": "1788948630",
+					},
+					"grant_balance":                  "1908.9024",
+					"nearest_grant_expiry":           "1791025200",
+					"nearest_grant_expiring_balance": "0.602",
+				},
+				map[string]any{
+					"id":        "pool_dedicated",
+					"name":      "Flash-Lite积分池",
+					"pool_type": "dedicated",
+					"model_ids": []string{"sensenova-6.7-flash-lite", "sensenova-6.8-flash-lite"},
+					"window_5h": map[string]any{
+						"limit": "60000", "used": "5716.0492", "remaining": "54283.9508", "reset_at": "1788523830",
+					},
+					"window_7d": map[string]any{
+						"limit": "600000", "used": "5716.6512", "remaining": "594283.3488", "reset_at": "1788948630",
+					},
+					"grant_balance":                  "0",
+					"nearest_grant_expiry":           "0",
+					"nearest_grant_expiring_balance": "0",
+				},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -226,8 +223,7 @@ func TestQuerySenseNovaPlanTokenPlan_Success(t *testing.T) {
 	senseNovaPlanURL = ts.URL
 	defer func() { senseNovaPlanURL = origURL }()
 
-	token := makeTestSenseNovaToken(t, "test-tenant-id")
-	result, err := querySenseNovaPlanTokenPlan(context.Background(), token)
+	result, err := querySenseNovaPlanTokenPlan(context.Background(), "test-bearer-token")
 	if err != nil {
 		t.Fatalf("querySenseNovaPlanTokenPlan() error = %v", err)
 	}
@@ -240,34 +236,35 @@ func TestQuerySenseNovaPlanTokenPlan_Success(t *testing.T) {
 		t.Errorf("Authorization = %q, want Bearer", gotAuth)
 	}
 
-	// 校验解析结果
-	if result.QuotaTotal != 100 {
-		t.Errorf("QuotaTotal = %f, want 100", result.QuotaTotal)
+	// 校验解析结果：双池汇总
+	if result.FiveHourTotal != 120000 {
+		t.Errorf("FiveHourTotal = %f, want 120000 (双池求和)", result.FiveHourTotal)
 	}
-	// 最高已用 = 100-50 = 50
-	if result.QuotaUsed != 50 {
-		t.Errorf("QuotaUsed = %f, want 50", result.QuotaUsed)
+	if result.FiveHourUsed != 5716.0492 {
+		t.Errorf("FiveHourUsed = %f, want 5716.0492", result.FiveHourUsed)
 	}
-	// 校验模型明细
-	if len(result.Models) != 3 {
-		t.Fatalf("Models len = %d, want 3", len(result.Models))
+	if result.WeeklyTotal != 1200000 {
+		t.Errorf("WeeklyTotal = %f, want 1200000 (双池求和)", result.WeeklyTotal)
 	}
-	for _, m := range result.Models {
-		var wantUsed float64
-		switch m.ModelName {
-		case "deepseek-v4-flash":
-			wantUsed = 0 // 100-100=0
-		case "sensenova-6.7-flash-lite":
-			wantUsed = 20 // 100-80=20
-		case "sensenova-u1-fast":
-			wantUsed = 50 // 100-50=50
-		default:
-			t.Errorf("unexpected model: %s", m.ModelName)
-			continue
-		}
-		if m.QuotaUsed != wantUsed {
-			t.Errorf("model %s: QuotaUsed = %f, want %f", m.ModelName, m.QuotaUsed, wantUsed)
-		}
+	if result.WeeklyUsed != 6071.49888 {
+		t.Errorf("WeeklyUsed = %f, want 6071.49888", result.WeeklyUsed)
+	}
+	if result.QuotaTotal != 1908.9024 {
+		t.Errorf("QuotaTotal = %f, want 1908.9024 (grant 求和)", result.QuotaTotal)
+	}
+	if result.QuotaUsed != 0 {
+		t.Errorf("QuotaUsed = %f, want 0", result.QuotaUsed)
+	}
+	// 重置时间：Unix 秒
+	if result.FiveHourResetAt == nil || result.FiveHourResetAt.Unix() != 1788523830 {
+		t.Errorf("FiveHourResetAt = %v, want 1788523830", result.FiveHourResetAt)
+	}
+	if result.WeeklyResetAt == nil || result.WeeklyResetAt.Unix() != 1788948630 {
+		t.Errorf("WeeklyResetAt = %v, want 1788948630", result.WeeklyResetAt)
+	}
+	// 授权到期：取最早的 grant 到期
+	if result.QuotaResetAt == nil || result.QuotaResetAt.Unix() != 1791025200 {
+		t.Errorf("QuotaResetAt = %v, want 1791025200", result.QuotaResetAt)
 	}
 }
 
@@ -281,13 +278,26 @@ func TestQuerySenseNovaPlanTokenPlan_EmptyToken(t *testing.T) {
 	}
 }
 
-func TestQuerySenseNovaPlanTokenPlan_InvalidToken(t *testing.T) {
-	// Token 无法解码出 account_id
-	_, err := querySenseNovaPlanTokenPlan(context.Background(), "invalid.token")
+func TestQuerySenseNovaPlanTokenPlan_NoPools(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"plan":  map[string]any{"id": "free", "name": "Free Plan"},
+			"pools": []any{},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	origURL := senseNovaPlanURL
+	senseNovaPlanURL = ts.URL
+	defer func() { senseNovaPlanURL = origURL }()
+
+	_, err := querySenseNovaPlanTokenPlan(context.Background(), "token")
 	if err == nil {
-		t.Fatal("expected error for invalid token, got nil")
+		t.Fatal("expected error for empty pools, got nil")
 	}
-	if !strings.Contains(err.Error(), "account_id") {
-		t.Errorf("error = %q, want 'account_id'", err.Error())
+	if !strings.Contains(err.Error(), "pools") {
+		t.Errorf("error = %q, want mention of pools", err.Error())
 	}
 }

--- a/internal/planprovider/stepfun_plan_test.go
+++ b/internal/planprovider/stepfun_plan_test.go
@@ -266,6 +266,36 @@ func TestQuerySenseNovaPlanTokenPlan_Success(t *testing.T) {
 	if result.QuotaResetAt == nil || result.QuotaResetAt.Unix() != 1791025200 {
 		t.Errorf("QuotaResetAt = %v, want 1791025200", result.QuotaResetAt)
 	}
+	// 分池明细：2 池
+	if len(result.Pools) != 2 {
+		t.Fatalf("Pools len = %d, want 2", len(result.Pools))
+	}
+	p0 := result.Pools[0]
+	if p0.ID != "pool_default" || p0.Name != "通用积分池" || p0.PoolType != "default" {
+		t.Errorf("pool[0] = %+v, want default 通用积分池", p0)
+	}
+	if p0.SevenDayLimit != 600000 || p0.SevenDayUsed != 354.84768 || p0.SevenDayRemain != 599645.15232 {
+		t.Errorf("pool[0] SevenDay = %+v", p0)
+	}
+	if p0.FiveHourLimit != 60000 || p0.FiveHourRemain != 60000 {
+		t.Errorf("pool[0] FiveHour = %+v", p0)
+	}
+	if p0.GrantBalance != 1908.9024 || p0.NearestGrantExpiringBal != 0.602 {
+		t.Errorf("pool[0] grant = %+v", p0)
+	}
+	if p0.NearestGrantExpiry == nil || p0.NearestGrantExpiry.Unix() != 1791025200 {
+		t.Errorf("pool[0] NearestGrantExpiry = %v, want 1791025200", p0.NearestGrantExpiry)
+	}
+	if len(p0.ModelIDs) != 2 || p0.ModelIDs[0] != "deepseek-v4-flash" {
+		t.Errorf("pool[0] ModelIDs = %v", p0.ModelIDs)
+	}
+	p1 := result.Pools[1]
+	if p1.PoolType != "dedicated" || p1.Name != "Flash-Lite积分池" {
+		t.Errorf("pool[1] = %+v, want dedicated Flash-Lite积分池", p1)
+	}
+	if p1.GrantBalance != 0 || p1.NearestGrantExpiry != nil {
+		t.Errorf("pool[1] grant = %+v, want 0/nil", p1)
+	}
 }
 
 func TestQuerySenseNovaPlanTokenPlan_EmptyToken(t *testing.T) {

--- a/web/src/api/endpoints/plan-provider.ts
+++ b/web/src/api/endpoints/plan-provider.ts
@@ -20,6 +20,28 @@ export interface PlanChannelStats {
     source?: 'official' | 'local';
 }
 
+// 单积分池明细（sensenova_plan 新版 pool-usage 接口）
+export interface TokenPlanPool {
+    id: string;
+    name: string;
+    pool_type: string; // default（通用池）| dedicated（专属池）
+    model_ids: string[];
+    // 5 小时窗口
+    five_hour_limit: number;
+    five_hour_used: number;
+    five_hour_remaining: number;
+    five_hour_reset_at: string | null;
+    // 7 天窗口（本周余额）
+    seven_day_limit: number;
+    seven_day_used: number;
+    seven_day_remaining: number;
+    seven_day_reset_at: string | null;
+    // 授权余额（活动固定积分）
+    grant_balance: number;
+    nearest_grant_expiry: string | null;
+    nearest_grant_expiring_balance: number;
+}
+
 export interface PlanProvider {
     id: number;
     name: string;
@@ -49,6 +71,7 @@ export interface PlanProvider {
     balance_delta: number;
     quota_used_delta: number;
     channel_stats?: PlanChannelStats | null;
+    pools?: TokenPlanPool[]; // 分池明细（sensenova_plan 新版接口）
     status: string;
     last_refresh: string | null;
     channel_name: string;

--- a/web/src/components/modules/plan-provider/PlanProviderSection.tsx
+++ b/web/src/components/modules/plan-provider/PlanProviderSection.tsx
@@ -40,6 +40,7 @@ import {
     useDeletePlanProvider,
     type PlanProvider,
     type PlanProviderCategoryInfo,
+    type TokenPlanPool,
 } from '@/api/endpoints/plan-provider';
 import { ProxySelector } from '@/components/modules/proxy-pool/ProxySelector';
 import type { ProxyMode } from '@/api/endpoints/proxy-pool';
@@ -47,6 +48,8 @@ import { useSettingList, SettingKey } from '@/api/endpoints/setting';
 
 // 与后端 model.PlanProviderDeepSeek 对应的类别标识（DeepSeek 专属统计展示）
 const DEEPSEEK_PLAN_CATEGORY = 'deepseek';
+// SenseNova 分池定制卡片的类别标识
+const SENSENOVA_PLAN_CATEGORY = 'sensenova_plan';
 
 // --- Balance Section ---
 
@@ -612,6 +615,145 @@ const formatTime = (val: string | null) => {
     }
 };
 
+// formatPoolNumber 官方面板数值格式：千分位 + 保留原始小数精度（积分池余额可能到 5 位小数）
+const formatPoolNumber = (val: number) => {
+    if (!val || Number.isNaN(val)) return '0';
+    // 绝对值 >= 1 时保留最多 5 位小数（去尾零），< 1 时按原值展示
+    const s = val.toLocaleString('en-US', { maximumFractionDigits: 5 });
+    return s;
+};
+
+// poolResetLabel 官方面板时间格式：M月D日 HH:mm
+const poolResetLabel = (val: string | null) => {
+    if (!val) return '';
+    const d = new Date(val);
+    if (Number.isNaN(d.getTime())) return val;
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getMonth() + 1}月${d.getDate()}日 ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+};
+
+// poolDateLabel 官方面板日期格式：YYYY-MM-DD（授权到期）
+const poolDateLabel = (val: string | null) => {
+    if (!val) return '';
+    const d = new Date(val);
+    if (Number.isNaN(d.getTime())) return val;
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+};
+
+// SenseNova 专属积分池卡片（官方新版额度面板样式）
+// 每池一张卡：本周余额大字 + 5h 窗口进度条 + 周额度 + 活动固定积分
+function SenseNovaPoolCard({ pool }: { pool: TokenPlanPool }) {
+    const isDefault = pool.pool_type === 'default';
+    // 主题色：default 紫色系 / dedicated 橙色系（与官方面板一致）
+    const dotColor = isDefault ? 'bg-[#5b5bd6]' : 'bg-[#f0663f]';
+    const barColor = isDefault ? 'bg-[#5b5bd6]' : 'bg-[#f0663f]';
+    const badgeText = isDefault
+        ? '所有 Free 模型可用'
+        : `仅 ${(pool.model_ids?.[0] || '').split('-').slice(0, 2).join('-')} 系列模型可用`;
+
+    const fivePct = pool.five_hour_limit > 0
+        ? Math.min(100, (pool.five_hour_remaining / pool.five_hour_limit) * 100)
+        : 0;
+
+    const showGrant = pool.grant_balance > 0 || pool.nearest_grant_expiry != null;
+
+    return (
+        <div className="rounded-xl border border-border bg-card p-4">
+            {/* 头部：池名 + 可用范围 */}
+            <div className="flex items-center justify-between gap-2 mb-3">
+                <div className="flex items-center gap-1.5 min-w-0">
+                    <span className={`size-2 shrink-0 rounded-full ${dotColor}`} />
+                    <h4 className="font-semibold text-sm truncate">{pool.name}</h4>
+                </div>
+                <span className="text-[11px] text-muted-foreground shrink-0 truncate">{badgeText}</span>
+            </div>
+
+            {/* 本周余额（主数字） */}
+            <div className="mb-3">
+                <p className="text-[11px] text-muted-foreground mb-0.5">周期刷新 · 本周余额</p>
+                <p className="text-2xl font-bold leading-tight tabular-nums">{formatPoolNumber(pool.seven_day_remaining)}</p>
+            </div>
+
+            {/* 5h 窗口 */}
+            <div className="rounded-lg bg-muted/50 p-2.5 mb-2">
+                <div className="flex items-center justify-between mb-1.5">
+                    <span className="text-xs text-muted-foreground">5h 窗口可用</span>
+                    {pool.five_hour_reset_at && (
+                        <span className="text-[11px] text-muted-foreground tabular-nums">
+                            5h窗口重置:{poolResetLabel(pool.five_hour_reset_at)}
+                        </span>
+                    )}
+                </div>
+                <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+                    <div
+                        className={`h-full rounded-full ${barColor} transition-all`}
+                        style={{ width: `${fivePct}%` }}
+                    />
+                </div>
+                <div className="flex items-center justify-between mt-1.5 text-[11px] text-muted-foreground tabular-nums">
+                    <span>
+                        {formatPoolNumber(pool.five_hour_remaining)} / {formatPoolNumber(pool.five_hour_limit)}
+                    </span>
+                    <span>{fivePct.toFixed(1)}%</span>
+                </div>
+            </div>
+
+            {/* 周额度 + 下次重置 */}
+            <div className="grid grid-cols-2 gap-2">
+                <div className="rounded-lg bg-muted/50 p-2.5">
+                    <p className="text-[11px] text-muted-foreground mb-0.5">周额度</p>
+                    <p className="text-sm font-semibold tabular-nums">{formatPoolNumber(pool.seven_day_limit)}</p>
+                </div>
+                <div className="rounded-lg bg-muted/50 p-2.5">
+                    <p className="text-[11px] text-muted-foreground mb-0.5">下次重置</p>
+                    <p className="text-sm font-semibold tabular-nums">{poolResetLabel(pool.seven_day_reset_at)}</p>
+                </div>
+            </div>
+
+            {/* 活动固定积分 */}
+            {showGrant && (
+                <div className={`mt-2 rounded-lg p-2.5 ${isDefault ? 'bg-[#f2f3ff]' : 'bg-[#fff4e9]'}`}>
+                    <div className="flex items-center gap-1.5 mb-2">
+                        <span className={`size-1.5 shrink-0 rounded-full ${dotColor}`} />
+                        <p className="text-xs font-semibold">活动固定积分</p>
+                    </div>
+                    <div className="grid grid-cols-2 gap-2">
+                        <div>
+                            <p className="text-[11px] text-muted-foreground">总量余额</p>
+                            <p className="text-lg font-bold leading-none tabular-nums mt-1">{formatPoolNumber(pool.grant_balance)}</p>
+                        </div>
+                        <div className="border-l border-border pl-2">
+                            <div className="flex flex-wrap items-center gap-1">
+                                <p className="text-[11px] text-muted-foreground">最近一次到期</p>
+                                {pool.nearest_grant_expiry && (
+                                    <span className="inline-flex rounded bg-[#fff4d6] px-1.5 py-0.5 text-[11px] font-medium text-[#c47a1a] tabular-nums">
+                                        {poolDateLabel(pool.nearest_grant_expiry)}
+                                    </span>
+                                )}
+                            </div>
+                            <p className="text-lg font-bold leading-none tabular-nums mt-1 text-[#4f56d8]">
+                                {formatPoolNumber(pool.nearest_grant_expiring_balance)}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+// SenseNova 分池卡片容器：provider 级包裹，多池竖排
+function SenseNovaPoolCards({ pools }: { pools: TokenPlanPool[] }) {
+    return (
+        <div className="grid grid-cols-1 gap-2">
+            {pools.map((pool) => (
+                <SenseNovaPoolCard key={pool.id} pool={pool} />
+            ))}
+        </div>
+    );
+}
+
 // 单档配额卡片（官网三档样式：标题 + 倒计时 + 已用/总量 + 进度条百分比）
 function QuotaTier({
     label,
@@ -843,6 +985,8 @@ function ProviderCard({
                         </p>
                     </div>
                 </div>
+            ) : !compact && provider.category === SENSENOVA_PLAN_CATEGORY && provider.pools && provider.pools.length > 0 ? (
+                <SenseNovaPoolCards pools={provider.pools} />
             ) : compact ? (
                 <div className="flex items-center gap-4 flex-wrap text-xs">
                     <QuotaTier

--- a/web/src/components/modules/plan-provider/PlanProviderSection.tsx
+++ b/web/src/components/modules/plan-provider/PlanProviderSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Plus, RefreshCw, Trash2, Key, LayoutList, ExternalLink, Loader2 } from 'lucide-react';
+import { Plus, RefreshCw, Trash2, Key, LayoutList, ExternalLink, Loader2, ChevronDown } from 'lucide-react';
 import { useCallback, useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
@@ -642,8 +642,10 @@ const poolDateLabel = (val: string | null) => {
 };
 
 // SenseNova 专属积分池卡片（官方新版额度面板样式）
-// 每池一张卡：本周余额大字 + 5h 窗口进度条 + 周额度 + 活动固定积分
-function SenseNovaPoolCard({ pool }: { pool: TokenPlanPool }) {
+// 每池一张卡：默认折叠为单行摘要（池名 + 本周余额），点击展开完整详情
+// 深色模式：活动固定积分等浅色块均提供 dark: 变体
+function SenseNovaPoolCard({ pool, defaultOpen = false }: { pool: TokenPlanPool; defaultOpen?: boolean }) {
+    const [open, setOpen] = useState(defaultOpen);
     const isDefault = pool.pool_type === 'default';
     // 主题色：default 紫色系 / dedicated 橙色系（与官方面板一致）
     const dotColor = isDefault ? 'bg-[#5b5bd6]' : 'bg-[#f0663f]';
@@ -659,96 +661,118 @@ function SenseNovaPoolCard({ pool }: { pool: TokenPlanPool }) {
     const showGrant = pool.grant_balance > 0 || pool.nearest_grant_expiry != null;
 
     return (
-        <div className="rounded-xl border border-border bg-card p-4">
-            {/* 头部：池名 + 可用范围 */}
-            <div className="flex items-center justify-between gap-2 mb-3">
-                <div className="flex items-center gap-1.5 min-w-0">
+        <div className="rounded-xl border border-border bg-card">
+            {/* 折叠头：点击展开/收起，收起时右侧显示本周余额摘要 */}
+            <button
+                type="button"
+                onClick={() => setOpen((v) => !v)}
+                className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left transition-colors hover:bg-muted/20"
+            >
+                <span className="flex items-center gap-1.5 min-w-0">
                     <span className={`size-2 shrink-0 rounded-full ${dotColor}`} />
-                    <h4 className="font-semibold text-sm truncate">{pool.name}</h4>
-                </div>
-                <span className="text-[11px] text-muted-foreground shrink-0 truncate">{badgeText}</span>
-            </div>
-
-            {/* 本周余额（主数字） */}
-            <div className="mb-3">
-                <p className="text-[11px] text-muted-foreground mb-0.5">周期刷新 · 本周余额</p>
-                <p className="text-2xl font-bold leading-tight tabular-nums">{formatPoolNumber(pool.seven_day_remaining)}</p>
-            </div>
-
-            {/* 5h 窗口 */}
-            <div className="rounded-lg bg-muted/50 p-2.5 mb-2">
-                <div className="flex items-center justify-between mb-1.5">
-                    <span className="text-xs text-muted-foreground">5h 窗口可用</span>
-                    {pool.five_hour_reset_at && (
-                        <span className="text-[11px] text-muted-foreground tabular-nums">
-                            5h窗口重置:{poolResetLabel(pool.five_hour_reset_at)}
-                        </span>
+                    <span className="font-semibold text-sm truncate">{pool.name}</span>
+                    <span className="hidden sm:inline text-[11px] text-muted-foreground truncate">{badgeText}</span>
+                </span>
+                <span className="flex items-center gap-2 shrink-0">
+                    {!open && (
+                        <span className="text-sm font-bold tabular-nums">{formatPoolNumber(pool.seven_day_remaining)}</span>
                     )}
-                </div>
-                <div className="h-1.5 rounded-full bg-muted overflow-hidden">
-                    <div
-                        className={`h-full rounded-full ${barColor} transition-all`}
-                        style={{ width: `${fivePct}%` }}
+                    <ChevronDown
+                        className={`size-4 shrink-0 text-muted-foreground transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
                     />
-                </div>
-                <div className="flex items-center justify-between mt-1.5 text-[11px] text-muted-foreground tabular-nums">
-                    <span>
-                        {formatPoolNumber(pool.five_hour_remaining)} / {formatPoolNumber(pool.five_hour_limit)}
-                    </span>
-                    <span>{fivePct.toFixed(1)}%</span>
-                </div>
-            </div>
+                </span>
+            </button>
 
-            {/* 周额度 + 下次重置 */}
-            <div className="grid grid-cols-2 gap-2">
-                <div className="rounded-lg bg-muted/50 p-2.5">
-                    <p className="text-[11px] text-muted-foreground mb-0.5">周额度</p>
-                    <p className="text-sm font-semibold tabular-nums">{formatPoolNumber(pool.seven_day_limit)}</p>
-                </div>
-                <div className="rounded-lg bg-muted/50 p-2.5">
-                    <p className="text-[11px] text-muted-foreground mb-0.5">下次重置</p>
-                    <p className="text-sm font-semibold tabular-nums">{poolResetLabel(pool.seven_day_reset_at)}</p>
-                </div>
-            </div>
-
-            {/* 活动固定积分 */}
-            {showGrant && (
-                <div className={`mt-2 rounded-lg p-2.5 ${isDefault ? 'bg-[#f2f3ff]' : 'bg-[#fff4e9]'}`}>
-                    <div className="flex items-center gap-1.5 mb-2">
-                        <span className={`size-1.5 shrink-0 rounded-full ${dotColor}`} />
-                        <p className="text-xs font-semibold">活动固定积分</p>
+            {/* 展开详情 */}
+            {open && (
+                <div className="px-4 pb-4 pt-0.5">
+                    {/* 可用范围（移动端折叠头隐藏时在此补上） */}
+                    <div className="flex items-center justify-between gap-2 mb-2 sm:hidden">
+                        <span className="text-[11px] text-muted-foreground truncate">{badgeText}</span>
                     </div>
+
+                    {/* 本周余额（主数字） */}
+                    <div className="mb-3">
+                        <p className="text-[11px] text-muted-foreground mb-0.5">周期刷新 · 本周余额</p>
+                        <p className="text-2xl font-bold leading-tight tabular-nums">{formatPoolNumber(pool.seven_day_remaining)}</p>
+                    </div>
+
+                    {/* 5h 窗口 */}
+                    <div className="rounded-lg bg-muted/50 p-2.5 mb-2">
+                        <div className="flex items-center justify-between mb-1.5">
+                            <span className="text-xs text-muted-foreground">5h 窗口可用</span>
+                            {pool.five_hour_reset_at && (
+                                <span className="text-[11px] text-muted-foreground tabular-nums">
+                                    5h窗口重置:{poolResetLabel(pool.five_hour_reset_at)}
+                                </span>
+                            )}
+                        </div>
+                        <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+                            <div
+                                className={`h-full rounded-full ${barColor} transition-all`}
+                                style={{ width: `${fivePct}%` }}
+                            />
+                        </div>
+                        <div className="flex items-center justify-between mt-1.5 text-[11px] text-muted-foreground tabular-nums">
+                            <span>
+                                {formatPoolNumber(pool.five_hour_remaining)} / {formatPoolNumber(pool.five_hour_limit)}
+                            </span>
+                            <span>{fivePct.toFixed(1)}%</span>
+                        </div>
+                    </div>
+
+                    {/* 周额度 + 下次重置 */}
                     <div className="grid grid-cols-2 gap-2">
-                        <div>
-                            <p className="text-[11px] text-muted-foreground">总量余额</p>
-                            <p className="text-lg font-bold leading-none tabular-nums mt-1">{formatPoolNumber(pool.grant_balance)}</p>
+                        <div className="rounded-lg bg-muted/50 p-2.5">
+                            <p className="text-[11px] text-muted-foreground mb-0.5">周额度</p>
+                            <p className="text-sm font-semibold tabular-nums">{formatPoolNumber(pool.seven_day_limit)}</p>
                         </div>
-                        <div className="border-l border-border pl-2">
-                            <div className="flex flex-wrap items-center gap-1">
-                                <p className="text-[11px] text-muted-foreground">最近一次到期</p>
-                                {pool.nearest_grant_expiry && (
-                                    <span className="inline-flex rounded bg-[#fff4d6] px-1.5 py-0.5 text-[11px] font-medium text-[#c47a1a] tabular-nums">
-                                        {poolDateLabel(pool.nearest_grant_expiry)}
-                                    </span>
-                                )}
-                            </div>
-                            <p className="text-lg font-bold leading-none tabular-nums mt-1 text-[#4f56d8]">
-                                {formatPoolNumber(pool.nearest_grant_expiring_balance)}
-                            </p>
+                        <div className="rounded-lg bg-muted/50 p-2.5">
+                            <p className="text-[11px] text-muted-foreground mb-0.5">下次重置</p>
+                            <p className="text-sm font-semibold tabular-nums">{poolResetLabel(pool.seven_day_reset_at)}</p>
                         </div>
                     </div>
+
+                    {/* 活动固定积分（深色模式适配：浅色底 → 深紫/深橙调） */}
+                    {showGrant && (
+                        <div className={`mt-2 rounded-lg p-2.5 ${isDefault ? 'bg-[#f2f3ff] dark:bg-[#2b2b52]' : 'bg-[#fff4e9] dark:bg-[#3a2b1f]'}`}>
+                            <div className="flex items-center gap-1.5 mb-2">
+                                <span className={`size-1.5 shrink-0 rounded-full ${dotColor}`} />
+                                <p className="text-xs font-semibold">活动固定积分</p>
+                            </div>
+                            <div className="grid grid-cols-2 gap-2">
+                                <div>
+                                    <p className="text-[11px] text-muted-foreground">总量余额</p>
+                                    <p className="text-lg font-bold leading-none tabular-nums mt-1">{formatPoolNumber(pool.grant_balance)}</p>
+                                </div>
+                                <div className="border-l border-border pl-2">
+                                    <div className="flex flex-wrap items-center gap-1">
+                                        <p className="text-[11px] text-muted-foreground">最近一次到期</p>
+                                        {pool.nearest_grant_expiry && (
+                                            <span className="inline-flex rounded bg-[#fff4d6] dark:bg-[#3d3517] px-1.5 py-0.5 text-[11px] font-medium text-[#c47a1a] dark:text-[#e8b45a] tabular-nums">
+                                                {poolDateLabel(pool.nearest_grant_expiry)}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="text-lg font-bold leading-none tabular-nums mt-1 text-[#4f56d8] dark:text-[#9da3ff]">
+                                        {formatPoolNumber(pool.nearest_grant_expiring_balance)}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    )}
                 </div>
             )}
         </div>
     );
 }
 
-// SenseNova 分池卡片容器：provider 级包裹，多池竖排
+// SenseNova 分池卡片容器：provider 级包裹，多池竖排；default 池默认展开，其余折叠
 function SenseNovaPoolCards({ pools }: { pools: TokenPlanPool[] }) {
     return (
         <div className="grid grid-cols-1 gap-2">
             {pools.map((pool) => (
-                <SenseNovaPoolCard key={pool.id} pool={pool} />
+                <SenseNovaPoolCard key={pool.id} pool={pool} defaultOpen={pool.pool_type === 'default'} />
             ))}
         </div>
     );

--- a/web/src/components/modules/plan-provider/PlanProviderSection.tsx
+++ b/web/src/components/modules/plan-provider/PlanProviderSection.tsx
@@ -767,12 +767,12 @@ function SenseNovaPoolCard({ pool, defaultOpen = false }: { pool: TokenPlanPool;
     );
 }
 
-// SenseNova 分池卡片容器：provider 级包裹，多池竖排；default 池默认展开，其余折叠
+// SenseNova 分池卡片容器：provider 级包裹，多池竖排；默认全部折叠，点击展开
 function SenseNovaPoolCards({ pools }: { pools: TokenPlanPool[] }) {
     return (
         <div className="grid grid-cols-1 gap-2">
             {pools.map((pool) => (
-                <SenseNovaPoolCard key={pool.id} pool={pool} defaultOpen={pool.pool_type === 'default'} />
+                <SenseNovaPoolCard key={pool.id} pool={pool} />
             ))}
         </div>
     );


### PR DESCRIPTION
## 背景

商汤日日新 Coding Plan 官方 2026-09 改版：旧接口 GET /lite/console/v1/user/coding-plan/usages 已废弃（新版前端 0 引用），新接口为无参数 GET /lite/console/v1/tokenplan/pool-usage。

## 改动内容

1. 后端 querySenseNovaPlanTokenPlan 适配新版 pool-usage 接口：Bearer JWT 鉴权，不再需要 account_id / model_ids 参数；响应 {plan, pools[]}，每池含 window_5h / window_7d 窗口额度 + grant_balance 授权余额 + nearest_grant_expiry（数值均为字符串）
2. 映射：five_hour ← window_5h，weekly ← window_7d，quota ← grant_balance（重置时间 = 最近授权到期）；多池（default + dedicated）汇总求和，重置时间取最晚
3. 删除不再使用的 decodeSenseNovaAccountID / senseNovaPlanModels
4. DB：plan_providers 增加 pools_json 列迁移（053，幂等兜底，跨方言）
5. 前端：sensenova_plan 类别渲染官方新版面板样式的分池卡片：每池本周余额大字 + 5h 窗口进度条 + 周额度/下次重置 + 活动固定积分与到期高亮；分池卡片折叠化 + 深色模式适配，默认收起；极简视图回退三档摘要；其他厂商不受影响

## 验证

- go build ./internal/... 通过
- go test ./internal/planprovider/ 与 ./internal/db/... 通过
- 前端 tsc：商汤相关文件 0 错误

## 范围

后端 + 前端 + DB 迁移，不含 CI/build 文件