### PR TITLE
feat: 新增基元律动 TokenRhythm 渠道额度监控

### DIFF
--- a/internal/model/plan_provider.go
+++ b/internal/model/plan_provider.go
@@ -263,6 +263,9 @@ type PlanProvider struct {
 	ProxyConfigID *int           `json:"proxy_config_id"`
 	Balance       float64        `json:"balance" gorm:"default:0"`
 	BalanceUsed   float64        `json:"balance_used" gorm:"default:0"`
+	// TotalTokens 历史累计 Token 用量（输入+输出）。仅部分 balance 类厂商
+	// （如基元律动 tokenrhythm）提供，其他厂商为 0。
+	TotalTokens int64 `json:"total_tokens" gorm:"default:0"`
 	// TokenPlan 专用
 	QuotaTotal    float64    `json:"quota_total" gorm:"default:0"`
 	QuotaUsed     float64    `json:"quota_used" gorm:"default:0"`

--- a/internal/model/plan_provider.go
+++ b/internal/model/plan_provider.go
@@ -23,6 +23,7 @@ const (
 	PlanProvider302AI       PlanProviderCategory = "302ai"
 	PlanProviderNovita      PlanProviderCategory = "novita"
 	PlanProviderOpenAI      PlanProviderCategory = "openai"
+	PlanProviderTokenRhythm PlanProviderCategory = "tokenrhythm"
 
 	// TokenPlan 类厂商
 	PlanProviderMiniMax        PlanProviderCategory = "minimax"
@@ -125,6 +126,15 @@ var PlanProviderCategories = []PlanProviderCategoryInfo{
 		Models:      "gpt-4.1,gpt-4.1-mini,gpt-4o,gpt-4o-mini,o3,o4-mini",
 		Description: "OpenAI 余额查询（部分账户可用 /v1/balances 接口）",
 		HelpURL:     "https://platform.openai.com/api-keys",
+	},
+	{
+		Category:    PlanProviderTokenRhythm,
+		Name:        "基元律动 (TokenRhythm)",
+		Type:        PlanProviderTypeBalance,
+		BaseURL:     "https://tokenrhythm.studio",
+		Models:      "*",
+		Description: "基元律动 TokenRhythm 渠道额度监控（浏览器 Cookie 鉴权）：账户余额、累计总成本、全部 Token 用量。纯监控不创建转发渠道。",
+		HelpURL:     "https://tokenrhythm.studio/account/account",
 	},
 	{
 		Category:    PlanProviderMiniMax,

--- a/internal/planprovider/query.go
+++ b/internal/planprovider/query.go
@@ -1177,6 +1177,13 @@ func queryOpenAIBalance(ctx context.Context, apiKey string) (*BalanceResult, err
 //   - 响应 data 字段：balanceCny（账户余额）、costCny（累计总成本）、
 //     inputTokens/outputTokens（全部 Token 用量）、calls/successCalls（调用统计）
 //
+// ⚠️ 口径确认（2026-08-09 实测）：usage-summary 本身就是「全部/累计」数据，
+// 不受网页「当天/全部」切换影响（网页切换走的是 /api/usage/panel?range=today|all，
+// usage-summary 带 range 参数结果不变，服务端忽略）。已验证：
+// costCny + balanceCny = 赠送总额（68.00 精确吻合），即 costCny 为全生命周期累计成本。
+//
+// tr_session Cookie 有效期约 29 天（Max-Age=2505001s），每次请求自动续期。
+//
 // 纯监控，不创建转发渠道（无独立 API Key 可供渠道使用）。
 var tokenRhythmUsageSummaryURL = "https://tokenrhythm.studio/api/usage-summary"
 

--- a/internal/planprovider/query.go
+++ b/internal/planprovider/query.go
@@ -118,6 +118,8 @@ func QueryBalance(ctx context.Context, category model.PlanProviderCategory, apiK
 		return queryNovitaBalance(ctx, apiKey)
 	case model.PlanProviderOpenAI:
 		return queryOpenAIBalance(ctx, apiKey)
+	case model.PlanProviderTokenRhythm:
+		return queryTokenRhythmBalance(ctx, apiKey)
 	default:
 		return nil, fmt.Errorf("unsupported balance provider: %s", category)
 	}
@@ -1165,6 +1167,90 @@ func queryOpenAIBalance(ctx context.Context, apiKey string) (*BalanceResult, err
 		BalanceUsed: resp.TotalUsedUSD,
 		Currency:    "USD",
 	}, nil
+}
+
+// --- 基元律动 TokenRhythm (tokenrhythm.studio) ---
+//
+// 渠道供应商额度监控，浏览器 Cookie 鉴权（与 MiMo 类似，非 API Key）：
+//   - 鉴权：Cookie 头携带 tr_session / tr_csrf / tr_ref_device（从浏览器 F12 复制）
+//   - 端点：GET https://tokenrhythm.studio/api/usage-summary
+//   - 响应 data 字段：balanceCny（账户余额）、costCny（累计总成本）、
+//     inputTokens/outputTokens（全部 Token 用量）、calls/successCalls（调用统计）
+//
+// 纯监控，不创建转发渠道（无独立 API Key 可供渠道使用）。
+var tokenRhythmUsageSummaryURL = "https://tokenrhythm.studio/api/usage-summary"
+
+func queryTokenRhythmBalance(ctx context.Context, cookie string) (*BalanceResult, error) {
+	if cookie == "" {
+		return nil, fmt.Errorf("tokenrhythm: cookie 不能为空")
+	}
+	if !strings.Contains(cookie, "tr_session=") && !strings.Contains(cookie, "tr_csrf=") {
+		return nil, fmt.Errorf("tokenrhythm: Cookie 缺少有效的鉴权字段，需包含 tr_session= 或 tr_csrf=")
+	}
+
+	body, err := doTokenRhythmGet(ctx, tokenRhythmUsageSummaryURL, cookie)
+	if err != nil {
+		return nil, fmt.Errorf("tokenrhythm: query usage-summary: %w", err)
+	}
+
+	var resp struct {
+		Code int `json:"code"`
+		Data struct {
+			Calls        int64   `json:"calls"`
+			SuccessCalls int64   `json:"successCalls"`
+			ErrorCalls   int64   `json:"errorCalls"`
+			InputTokens  int64   `json:"inputTokens"`
+			OutputTokens int64   `json:"outputTokens"`
+			CostCny      float64 `json:"costCny"`
+			BalanceCny   float64 `json:"balanceCny"`
+			Currency     string  `json:"currency"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("tokenrhythm: parse response: %w", err)
+	}
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("tokenrhythm: API error code=%d", resp.Code)
+	}
+
+	currency := resp.Data.Currency
+	if currency == "" {
+		currency = "CNY"
+	}
+
+	return &BalanceResult{
+		Balance:     resp.Data.BalanceCny,
+		BalanceUsed: resp.Data.CostCny,
+		Currency:    currency,
+	}, nil
+}
+
+// doTokenRhythmGet 执行基元律动的 GET 请求，使用 Cookie 鉴权（带浏览器 UA）。
+func doTokenRhythmGet(ctx context.Context, url, cookie string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Cookie", cookie)
+	req.Header.Set("Accept", "application/json, text/plain, */*")
+	req.Header.Set("Referer", "https://tokenrhythm.studio/account/account")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36")
+
+	client := &http.Client{Timeout: requestTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("http status %d: %s", resp.StatusCode, string(body))
+	}
+	return body, nil
 }
 
 // --- ChatGPT Codex 套餐 (WHAM API) ---

--- a/internal/planprovider/query.go
+++ b/internal/planprovider/query.go
@@ -74,6 +74,9 @@ type BalanceResult struct {
 	Balance     float64 `json:"balance"`
 	BalanceUsed float64 `json:"balance_used"`
 	Currency    string  `json:"currency"`
+	// TotalTokens 历史累计 Token 用量（输入+输出）。仅部分厂商提供
+	// （如基元律动 TokenRhythm 的 usage-summary），其他厂商为 0。
+	TotalTokens int64 `json:"total_tokens"`
 }
 
 // TokenPlanResult TokenPlan 查询结果
@@ -1229,6 +1232,7 @@ func queryTokenRhythmBalance(ctx context.Context, cookie string) (*BalanceResult
 		Balance:     resp.Data.BalanceCny,
 		BalanceUsed: resp.Data.CostCny,
 		Currency:    currency,
+		TotalTokens: resp.Data.InputTokens + resp.Data.OutputTokens,
 	}, nil
 }
 

--- a/internal/planprovider/query.go
+++ b/internal/planprovider/query.go
@@ -1190,6 +1190,32 @@ func queryOpenAIBalance(ctx context.Context, apiKey string) (*BalanceResult, err
 // 纯监控，不创建转发渠道（无独立 API Key 可供渠道使用）。
 var tokenRhythmUsageSummaryURL = "https://tokenrhythm.studio/api/usage-summary"
 
+// flexibleFloat64 兼容 API 返回数字或字符串两种格式的金额字段。
+// tokenrhythm.studio 的 usage-summary 金额字段（costCny/balanceCny 等）曾为
+// 数字（14.75376696），2026-08-16 起改为字符串（"44.36027476"）。
+// json.Number 只接受数字字面量，遇到字符串仍会报错，故自定义 UnmarshalJSON：
+// 引号包裹的数字剥掉引号后 ParseFloat，null/空串按 0 处理。
+type flexibleFloat64 float64
+
+func (f *flexibleFloat64) UnmarshalJSON(b []byte) error {
+	s := strings.TrimSpace(string(b))
+	if s == "null" || s == "" {
+		*f = 0
+		return nil
+	}
+	s = strings.Trim(s, `"`)
+	if s == "" {
+		*f = 0
+		return nil
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return err
+	}
+	*f = flexibleFloat64(v)
+	return nil
+}
+
 func queryTokenRhythmBalance(ctx context.Context, cookie string) (*BalanceResult, error) {
 	if cookie == "" {
 		return nil, fmt.Errorf("tokenrhythm: cookie 不能为空")
@@ -1206,14 +1232,14 @@ func queryTokenRhythmBalance(ctx context.Context, cookie string) (*BalanceResult
 	var resp struct {
 		Code int `json:"code"`
 		Data struct {
-			Calls        int64   `json:"calls"`
-			SuccessCalls int64   `json:"successCalls"`
-			ErrorCalls   int64   `json:"errorCalls"`
-			InputTokens  int64   `json:"inputTokens"`
-			OutputTokens int64   `json:"outputTokens"`
-			CostCny      float64 `json:"costCny"`
-			BalanceCny   float64 `json:"balanceCny"`
-			Currency     string  `json:"currency"`
+			Calls        int64            `json:"calls"`
+			SuccessCalls int64            `json:"successCalls"`
+			ErrorCalls   int64            `json:"errorCalls"`
+			InputTokens  int64            `json:"inputTokens"`
+			OutputTokens int64            `json:"outputTokens"`
+			CostCny      flexibleFloat64  `json:"costCny"`
+			BalanceCny   flexibleFloat64  `json:"balanceCny"`
+			Currency     string           `json:"currency"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(body, &resp); err != nil {
@@ -1229,8 +1255,8 @@ func queryTokenRhythmBalance(ctx context.Context, cookie string) (*BalanceResult
 	}
 
 	return &BalanceResult{
-		Balance:     resp.Data.BalanceCny,
-		BalanceUsed: resp.Data.CostCny,
+		Balance:     float64(resp.Data.BalanceCny),
+		BalanceUsed: float64(resp.Data.CostCny),
 		Currency:    currency,
 		TotalTokens: resp.Data.InputTokens + resp.Data.OutputTokens,
 	}, nil

--- a/internal/planprovider/service.go
+++ b/internal/planprovider/service.go
@@ -324,7 +324,9 @@ func AddProvider(ctx context.Context, category model.PlanProviderCategory, apiKe
 
 	// 2. 渠道创建/复用
 	var channelID int
-	needCreateChannel := info.Type == model.PlanProviderTypeBalance ||
+	// balance 类默认自动创建转发渠道；tokenrhythm（基元律动）例外：
+	// 纯监控（Cookie 鉴权，无独立 API Key），不创建转发渠道。
+	needCreateChannel := (info.Type == model.PlanProviderTypeBalance && category != model.PlanProviderTokenRhythm) ||
 		(isConsoleTokenPlanCategory(category) && forwardAPIKey != "") ||
 		category == model.PlanProviderCodex
 	if needCreateChannel {

--- a/internal/planprovider/service.go
+++ b/internal/planprovider/service.go
@@ -286,6 +286,7 @@ func AddProvider(ctx context.Context, category model.PlanProviderCategory, apiKe
 
 	// 1. 查询余额 / TokenPlan
 	var balance, balanceUsed float64
+	var totalTokens int64
 	var quotaTotal, quotaUsed, weeklyTotal, weeklyUsed float64
 	var fiveHourTotal, fiveHourUsed float64
 	var quotaResetAt, weeklyResetAt, fiveHourResetAt *string
@@ -297,6 +298,7 @@ func AddProvider(ctx context.Context, category model.PlanProviderCategory, apiKe
 		}
 		balance = result.Balance
 		balanceUsed = result.BalanceUsed
+		totalTokens = result.TotalTokens
 	} else {
 		result, err := QueryTokenPlan(ctx, category, apiKey, info.BaseURL, proxyMode, proxyConfigID, teamOrgID, teamProjectID)
 		if err != nil {
@@ -425,6 +427,7 @@ func AddProvider(ctx context.Context, category model.PlanProviderCategory, apiKe
 		LastQuotaUsed: quotaUsed,
 		Balance:       balance,
 		BalanceUsed:   balanceUsed,
+		TotalTokens:   totalTokens,
 		QuotaTotal:    quotaTotal,
 		QuotaUsed:     quotaUsed,
 		WeeklyTotal:   weeklyTotal,
@@ -494,6 +497,7 @@ func RefreshProvider(ctx context.Context, id int) (*model.PlanProvider, error) {
 		provider.LastBalance = lastBalance
 		provider.Balance = result.Balance
 		provider.BalanceUsed = result.BalanceUsed
+		provider.TotalTokens = result.TotalTokens
 		provider.TotalUsed += max(0, lastBalance-provider.Balance)
 	} else {
 		// 商汤日日新：若配置了账号密码，先确保控制台 access_token 有效
@@ -650,6 +654,7 @@ func UpdateProviderCredentials(ctx context.Context, id int, newAPIKey, newForwar
 		provider.LastBalance = lastBalance
 		provider.Balance = result.Balance
 		provider.BalanceUsed = result.BalanceUsed
+		provider.TotalTokens = result.TotalTokens
 		provider.TotalUsed += max(0, lastBalance-provider.Balance)
 	} else {
 		lastQuotaUsed := provider.QuotaUsed

--- a/internal/planprovider/tokenrhythm_plan_test.go
+++ b/internal/planprovider/tokenrhythm_plan_test.go
@@ -79,6 +79,94 @@ func TestQueryTokenRhythmBalanceMissingCookie(t *testing.T) {
 	}
 }
 
+// 金额字段字符串格式（2026-08-16 tokenrhythm.studio 变更后真实格式）：
+// costCny/balanceCny 等金额全部变为字符串，整数统计字段保持数字。
+func TestQueryTokenRhythmBalanceStringAmounts(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"code": 0,
+			"message": "ok",
+			"data": {
+				"calls": 2087,
+				"successCalls": 2027,
+				"errorCalls": 54,
+				"abortedCalls": 6,
+				"inputTokens": 526263332,
+				"outputTokens": 1537879,
+				"costCny": "44.36027476",
+				"tokenCostCny": "44.36027476",
+				"imageCostCny": "0.00000000",
+				"balanceCny": "23.63972524",
+				"frozenBalanceCny": "0.00000000",
+				"availableBalanceCny": "23.63972524",
+				"expiringBalanceCny": "23.63972524",
+				"currency": "CNY"
+			},
+			"traceId": "trace_str"
+		}`))
+	}))
+	defer ts.Close()
+
+	old := tokenRhythmUsageSummaryURL
+	tokenRhythmUsageSummaryURL = ts.URL + "/api/usage-summary"
+	defer func() { tokenRhythmUsageSummaryURL = old }()
+
+	cookie := "tr_session=sess_str"
+	got, err := queryTokenRhythmBalance(context.Background(), cookie)
+	if err != nil {
+		t.Fatalf("queryTokenRhythmBalance (string amounts): %v", err)
+	}
+	if got.Balance != 23.63972524 {
+		t.Errorf("Balance = %v, want 23.63972524", got.Balance)
+	}
+	if got.BalanceUsed != 44.36027476 {
+		t.Errorf("BalanceUsed = %v, want 44.36027476", got.BalanceUsed)
+	}
+	if got.Currency != "CNY" {
+		t.Errorf("Currency = %q, want CNY", got.Currency)
+	}
+	if got.TotalTokens != 526263332+1537879 {
+		t.Errorf("TotalTokens = %d, want %d", got.TotalTokens, 526263332+1537879)
+	}
+}
+
+// 金额字段为 null / 空串时按 0 处理，不报错
+func TestQueryTokenRhythmBalanceNullAmounts(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"code": 0,
+			"message": "ok",
+			"data": {
+				"calls": 0,
+				"inputTokens": 0,
+				"outputTokens": 0,
+				"costCny": null,
+				"balanceCny": "",
+				"currency": "CNY"
+			},
+			"traceId": "trace_null"
+		}`))
+	}))
+	defer ts.Close()
+
+	old := tokenRhythmUsageSummaryURL
+	tokenRhythmUsageSummaryURL = ts.URL + "/api/usage-summary"
+	defer func() { tokenRhythmUsageSummaryURL = old }()
+
+	got, err := queryTokenRhythmBalance(context.Background(), "tr_session=sess_null")
+	if err != nil {
+		t.Fatalf("queryTokenRhythmBalance (null amounts): %v", err)
+	}
+	if got.Balance != 0 || got.BalanceUsed != 0 {
+		t.Errorf("Balance=%v BalanceUsed=%v, want both 0", got.Balance, got.BalanceUsed)
+	}
+	if got.Currency != "CNY" {
+		t.Errorf("Currency = %q, want CNY", got.Currency)
+	}
+}
+
 // API 返回非 0 code 时应报错
 func TestQueryTokenRhythmBalanceAPIError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/planprovider/tokenrhythm_plan_test.go
+++ b/internal/planprovider/tokenrhythm_plan_test.go
@@ -60,6 +60,9 @@ func TestQueryTokenRhythmBalance(t *testing.T) {
 	if got.Currency != "CNY" {
 		t.Errorf("Currency = %q, want CNY", got.Currency)
 	}
+	if got.TotalTokens != 350732048+1107942 {
+		t.Errorf("TotalTokens = %d, want %d", got.TotalTokens, 350732048+1107942)
+	}
 }
 
 // 缺少有效 Cookie 时应报错

--- a/internal/planprovider/tokenrhythm_plan_test.go
+++ b/internal/planprovider/tokenrhythm_plan_test.go
@@ -1,0 +1,95 @@
+package planprovider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// 基元律动 TokenRhythm balance 查询：httptest mock server 验证
+// 响应结构与真实 /api/usage-summary 一致。
+func TestQueryTokenRhythmBalance(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/usage-summary" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		// 验证 Cookie 透传
+		if got := r.Header.Get("Cookie"); got == "" {
+			t.Errorf("expected Cookie header, got empty")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"code": 0,
+			"message": "ok",
+			"data": {
+				"calls": 1457,
+				"successCalls": 1444,
+				"errorCalls": 11,
+				"abortedCalls": 2,
+				"inputTokens": 350732048,
+				"outputTokens": 1107942,
+				"costCny": 14.75376696,
+				"balanceCny": 53.24623304,
+				"frozenBalanceCny": 0,
+				"availableBalanceCny": 53.24623304,
+				"currency": "CNY"
+			},
+			"traceId": "trace_test"
+		}`))
+	}))
+	defer ts.Close()
+
+	// 替换包级 URL 指向 mock server
+	old := tokenRhythmUsageSummaryURL
+	tokenRhythmUsageSummaryURL = ts.URL + "/api/usage-summary"
+	defer func() { tokenRhythmUsageSummaryURL = old }()
+
+	cookie := "tr_ref_device=test; tr_session=sess_test; tr_csrf=csrf_test"
+	got, err := queryTokenRhythmBalance(context.Background(), cookie)
+	if err != nil {
+		t.Fatalf("queryTokenRhythmBalance: %v", err)
+	}
+
+	if got.Balance != 53.24623304 {
+		t.Errorf("Balance = %v, want 53.24623304", got.Balance)
+	}
+	if got.BalanceUsed != 14.75376696 {
+		t.Errorf("BalanceUsed = %v, want 14.75376696", got.BalanceUsed)
+	}
+	if got.Currency != "CNY" {
+		t.Errorf("Currency = %q, want CNY", got.Currency)
+	}
+}
+
+// 缺少有效 Cookie 时应报错
+func TestQueryTokenRhythmBalanceMissingCookie(t *testing.T) {
+	_, err := queryTokenRhythmBalance(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty cookie, got nil")
+	}
+
+	// 无 tr_session/tr_csrf 字段
+	_, err = queryTokenRhythmBalance(context.Background(), "foo=bar")
+	if err == nil {
+		t.Fatal("expected error for invalid cookie, got nil")
+	}
+}
+
+// API 返回非 0 code 时应报错
+func TestQueryTokenRhythmBalanceAPIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"code": 401, "message": "unauthorized", "data": null}`))
+	}))
+	defer ts.Close()
+
+	old := tokenRhythmUsageSummaryURL
+	tokenRhythmUsageSummaryURL = ts.URL + "/api/usage-summary"
+	defer func() { tokenRhythmUsageSummaryURL = old }()
+
+	_, err := queryTokenRhythmBalance(context.Background(), "tr_session=bad")
+	if err == nil {
+		t.Fatal("expected error for API code != 0, got nil")
+	}
+}

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -185,6 +185,8 @@
       "mimoServiceTokenPlaceholder": "Paste full Cookie from platform.xiaomimimo.com",
       "mimoPassTokenHint": "Required fields: passToken=, userId=, cUserId=. Valid 30 days (auto-renewed on each use). ⚠️ Security risk: passToken is a long-lived Xiaomi account session token, may have lateral movement risk, not fully tested. System auto-refreshes serviceToken via SSO.",
       "mimoServiceTokenHint": "Required fields: api-platform_serviceToken=, userId=, api-platform_slh=, api-platform_ph=. Valid ~1 day (server-controlled), manual update required. Login platform.xiaomimimo.com -> F12 -> Application -> Cookies, copy all cookies under api-platform domain.",
+      "tokenRhythmCookiePlaceholder": "Paste full Cookie from tokenrhythm.studio (must contain tr_session=)",
+      "tokenRhythmCookieHint": "Login tokenrhythm.studio → F12 → Network → any request → Request Headers, copy the full Cookie value (containing tr_session=, tr_csrf=). Re-fetch after session expiry.",
       "codexOAuthLabel": "OAuth JSON",
       "codexOAuthPlaceholder": "Paste OAuth JSON credential (with access_token and account_id)",
       "codexOAuthHint": "Obtain OAuth JSON credential (with access_token and account_id) from a ChatGPT subscription account. A Codex forwarding channel is automatically created (endpoint: chatgpt.com/backend-api/codex/responses). access_token has a short validity; re-obtain after expiry.",

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -138,6 +138,7 @@
       "delete": "Delete",
       "balanceAvailable": "Available Balance",
       "balanceUsed": "Used",
+      "totalTokens": "Total Tokens",
       "totalUsed": "Total Used",
       "tierFiveHour": "Last 5 Hours Usage",
       "tierWeekly": "Last Week Usage",

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -187,7 +187,7 @@
       "mimoPassTokenHint": "Required fields: passToken=, userId=, cUserId=. Valid 30 days (auto-renewed on each use). ⚠️ Security risk: passToken is a long-lived Xiaomi account session token, may have lateral movement risk, not fully tested. System auto-refreshes serviceToken via SSO.",
       "mimoServiceTokenHint": "Required fields: api-platform_serviceToken=, userId=, api-platform_slh=, api-platform_ph=. Valid ~1 day (server-controlled), manual update required. Login platform.xiaomimimo.com -> F12 -> Application -> Cookies, copy all cookies under api-platform domain.",
       "tokenRhythmCookiePlaceholder": "Paste full Cookie from tokenrhythm.studio (must contain tr_session=)",
-      "tokenRhythmCookieHint": "Login tokenrhythm.studio → F12 → Network → any request → Request Headers, copy the full Cookie value (containing tr_session=, tr_csrf=). Re-fetch after session expiry.",
+      "tokenRhythmCookieHint": "Login tokenrhythm.studio → F12 → Network → any request → Request Headers, copy the full Cookie value (containing tr_session=, tr_csrf=). tr_session is valid ~29 days and auto-renews on each request; no manual update needed during that period.",
       "codexOAuthLabel": "OAuth JSON",
       "codexOAuthPlaceholder": "Paste OAuth JSON credential (with access_token and account_id)",
       "codexOAuthHint": "Obtain OAuth JSON credential (with access_token and account_id) from a ChatGPT subscription account. A Codex forwarding channel is automatically created (endpoint: chatgpt.com/backend-api/codex/responses). access_token has a short validity; re-obtain after expiry.",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -187,7 +187,7 @@
       "mimoPassTokenHint": "需包含字段：passToken=、userId=、cUserId=。有效期 30 天（每次使用自动续期）。⚠️ 安全风险：passToken 是小米账号长期会话凭证，可能存在横向移动风险，未进行全方面测试。填入后系统自动通过 SSO 刷新 serviceToken，无需手动更新。",
       "mimoServiceTokenHint": "需包含字段：api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph=。有效期约 1 天（服务端控制），过期需手动更新。登录 platform.xiaomimimo.com -> F12 -> Application -> Cookies，复制 api-platform 域下所有 Cookie。",
       "tokenRhythmCookiePlaceholder": "粘贴 tokenrhythm.studio 的完整 Cookie（需包含 tr_session= 字段）",
-      "tokenRhythmCookieHint": "登录 tokenrhythm.studio → F12 → Network → 任意请求 → Request Headers，复制完整 Cookie 值（含 tr_session=、tr_csrf= 字段）。会话过期后需重新获取。",
+      "tokenRhythmCookieHint": "登录 tokenrhythm.studio → F12 → Network → 任意请求 → Request Headers，复制完整 Cookie 值（含 tr_session=、tr_csrf= 字段）。tr_session 有效期约 29 天，每次请求自动续期，期间无需手动更新。",
       "codexOAuthLabel": "OAuth JSON",
       "codexOAuthPlaceholder": "粘贴 OAuth JSON 凭据（含 access_token 和 account_id）",
       "codexOAuthHint": "从 ChatGPT 订阅账号获取 OAuth JSON 凭据（含 access_token 和 account_id）。系统将自动创建 Codex 类型转发渠道（接入点 chatgpt.com/backend-api/codex/responses）。access_token 有效期较短，过期后需重新获取。",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -138,6 +138,7 @@
       "delete": "删除",
       "balanceAvailable": "可用余额",
       "balanceUsed": "已用额度",
+      "totalTokens": "历史 Token",
       "totalUsed": "累计已用",
       "tierFiveHour": "近5小时用量",
       "tierWeekly": "近一周用量",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -185,6 +185,8 @@
       "mimoServiceTokenPlaceholder": "粘贴 platform.xiaomimimo.com 的完整 Cookie",
       "mimoPassTokenHint": "需包含字段：passToken=、userId=、cUserId=。有效期 30 天（每次使用自动续期）。⚠️ 安全风险：passToken 是小米账号长期会话凭证，可能存在横向移动风险，未进行全方面测试。填入后系统自动通过 SSO 刷新 serviceToken，无需手动更新。",
       "mimoServiceTokenHint": "需包含字段：api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph=。有效期约 1 天（服务端控制），过期需手动更新。登录 platform.xiaomimimo.com -> F12 -> Application -> Cookies，复制 api-platform 域下所有 Cookie。",
+      "tokenRhythmCookiePlaceholder": "粘贴 tokenrhythm.studio 的完整 Cookie（需包含 tr_session= 字段）",
+      "tokenRhythmCookieHint": "登录 tokenrhythm.studio → F12 → Network → 任意请求 → Request Headers，复制完整 Cookie 值（含 tr_session=、tr_csrf= 字段）。会话过期后需重新获取。",
       "codexOAuthLabel": "OAuth JSON",
       "codexOAuthPlaceholder": "粘贴 OAuth JSON 凭据（含 access_token 和 account_id）",
       "codexOAuthHint": "从 ChatGPT 订阅账号获取 OAuth JSON 凭据（含 access_token 和 account_id）。系统将自动创建 Codex 类型转发渠道（接入点 chatgpt.com/backend-api/codex/responses）。access_token 有效期较短，过期后需重新获取。",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -185,6 +185,8 @@
       "mimoServiceTokenPlaceholder": "貼上 platform.xiaomimimo.com 的完整 Cookie",
       "mimoPassTokenHint": "需包含欄位：passToken=、userId=、cUserId=。有效期 30 天（每次使用自動續期）。⚠️ 安全風險：passToken 是小米帳號長期會話憑證，可能存在橫向移動風險，未進行全方面測試。填入後系統自動透過 SSO 刷新 serviceToken，無需手動更新。",
       "mimoServiceTokenHint": "需包含欄位：api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph=。有效期約 1 天（服務端控制），過期需手動更新。登入 platform.xiaomimimo.com -> F12 -> Application -> Cookies，複製 api-platform 域下所有 Cookie。",
+      "tokenRhythmCookiePlaceholder": "貼上 tokenrhythm.studio 的完整 Cookie（需包含 tr_session= 欄位）",
+      "tokenRhythmCookieHint": "登入 tokenrhythm.studio → F12 → Network → 任意請求 → Request Headers，複製完整 Cookie 值（含 tr_session=、tr_csrf= 欄位）。會話過期後需重新獲取。",
       "codexOAuthLabel": "OAuth JSON",
       "codexOAuthPlaceholder": "貼上 OAuth JSON 憑證（含 access_token 和 account_id）",
       "codexOAuthHint": "從 ChatGPT 訂閱帳號取得 OAuth JSON 憑證（含 access_token 和 account_id）。系統將自動建立 Codex 類型轉發渠道（接入點 chatgpt.com/backend-api/codex/responses）。access_token 有效期較短，過期後需重新取得。",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -187,7 +187,7 @@
       "mimoPassTokenHint": "需包含欄位：passToken=、userId=、cUserId=。有效期 30 天（每次使用自動續期）。⚠️ 安全風險：passToken 是小米帳號長期會話憑證，可能存在橫向移動風險，未進行全方面測試。填入後系統自動透過 SSO 刷新 serviceToken，無需手動更新。",
       "mimoServiceTokenHint": "需包含欄位：api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph=。有效期約 1 天（服務端控制），過期需手動更新。登入 platform.xiaomimimo.com -> F12 -> Application -> Cookies，複製 api-platform 域下所有 Cookie。",
       "tokenRhythmCookiePlaceholder": "貼上 tokenrhythm.studio 的完整 Cookie（需包含 tr_session= 欄位）",
-      "tokenRhythmCookieHint": "登入 tokenrhythm.studio → F12 → Network → 任意請求 → Request Headers，複製完整 Cookie 值（含 tr_session=、tr_csrf= 欄位）。會話過期後需重新獲取。",
+      "tokenRhythmCookieHint": "登入 tokenrhythm.studio → F12 → Network → 任意請求 → Request Headers，複製完整 Cookie 值（含 tr_session=、tr_csrf= 欄位）。tr_session 有效期約 29 天，每次請求自動續期，期間無需手動更新。",
       "codexOAuthLabel": "OAuth JSON",
       "codexOAuthPlaceholder": "貼上 OAuth JSON 憑證（含 access_token 和 account_id）",
       "codexOAuthHint": "從 ChatGPT 訂閱帳號取得 OAuth JSON 憑證（含 access_token 和 account_id）。系統將自動建立 Codex 類型轉發渠道（接入點 chatgpt.com/backend-api/codex/responses）。access_token 有效期較短，過期後需重新取得。",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -138,6 +138,7 @@
       "delete": "刪除",
       "balanceAvailable": "可用餘額",
       "balanceUsed": "已用額度",
+      "totalTokens": "歷史 Token",
       "totalUsed": "累計已用",
       "tierFiveHour": "近5小時用量",
       "tierWeekly": "近一週用量",

--- a/web/src/api/endpoints/plan-provider.ts
+++ b/web/src/api/endpoints/plan-provider.ts
@@ -35,6 +35,7 @@ export interface PlanProvider {
     channel_id: number;
     balance: number;
     balance_used: number;
+    total_tokens: number;
     total_used: number;
     quota_total: number;
     quota_used: number;

--- a/web/src/components/modules/plan-provider/PlanProviderSection.tsx
+++ b/web/src/components/modules/plan-provider/PlanProviderSection.tsx
@@ -833,7 +833,7 @@ function ProviderCard({
 
             {/* Balance / TokenPlan Info */}
             {isBalance ? (
-                <div className="grid grid-cols-2 gap-3">
+                <div className={`grid gap-3 ${provider.total_tokens > 0 ? 'grid-cols-3' : 'grid-cols-2'}`}>
                     <div className="rounded-lg bg-muted/50 p-2.5">
                         <p className="text-xs text-muted-foreground mb-1">
                             {t('plan.balanceAvailable') || '可用余额'}
@@ -852,6 +852,16 @@ function ProviderCard({
                             {formatBalance(provider.balance_used > 0 ? provider.balance_used : provider.total_used)}
                         </p>
                     </div>
+                    {provider.total_tokens > 0 && (
+                        <div className="rounded-lg bg-muted/50 p-2.5">
+                            <p className="text-xs text-muted-foreground mb-1">
+                                {t('plan.totalTokens') || '历史 Token'}
+                            </p>
+                            <p className="text-lg font-bold tabular-nums text-muted-foreground">
+                                {formatTokens(provider.total_tokens)}
+                            </p>
+                        </div>
+                    )}
                 </div>
             ) : compact ? (
                 <div className="flex items-center gap-4 flex-wrap text-xs">

--- a/web/src/components/modules/plan-provider/PlanProviderSection.tsx
+++ b/web/src/components/modules/plan-provider/PlanProviderSection.tsx
@@ -146,6 +146,7 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
     const visibleCategories = categories.filter((c) => c.category !== 'volcengine_plan_ak');
     const isZhipuTeam = selectedCategory === 'zhipu_team';
     const isMiMoPlan = selectedCategory === 'mimo_plan';
+    const isTokenRhythm = selectedCategory === 'tokenrhythm';
     const isSenseNovaPlan = selectedCategory === 'sensenova_plan';
     const isCodexPlan = selectedCategory === 'codex';
     const supportsForwardApiKey = isConsoleTokenPlan && !isMiMoPlan;
@@ -338,11 +339,13 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
                                 <label className="text-sm font-medium">
                                     {isMiMoPlan
                                         ? (t('plan.cookieLabel') || 'Cookie')
-                                        : isCodexPlan
-                                            ? (t('plan.codexOAuthLabel') || 'OAuth JSON')
-                                            : isConsoleTokenPlan
-                                                ? (t('plan.consoleTokenLabel') || '控制台 Token')
-                                                : (t('plan.apiKeyLabel') || 'API Key')}
+                                        : isTokenRhythm
+                                            ? (t('plan.cookieLabel') || 'Cookie')
+                                            : isCodexPlan
+                                                ? (t('plan.codexOAuthLabel') || 'OAuth JSON')
+                                                : isConsoleTokenPlan
+                                                    ? (t('plan.consoleTokenLabel') || '控制台 Token')
+                                                    : (t('plan.apiKeyLabel') || 'API Key')}
                                 </label>
                                 {isMiMoPlan && (
                                     <div className="space-y-1">
@@ -387,19 +390,21 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
                                         ? (mimoAuthMode === 'passToken'
                                             ? (t('plan.mimoPassTokenPlaceholder') || '粘贴 account.xiaomi.com 的完整 Cookie（需包含 passToken=、userId=、cUserId= 字段）')
                                             : (t('plan.mimoServiceTokenPlaceholder') || '粘贴 platform.xiaomimimo.com 的完整 Cookie（需包含 api-platform_serviceToken=、userId=、api-platform_slh=、api-platform_ph= 字段）'))
-                                        : isCodexPlan
-                                            ? (t('plan.codexOAuthPlaceholder') || '粘贴 OAuth JSON 凭据（含 access_token 和 account_id）')
-                                            : isConsoleTokenPlan
-                                                ? (isVolcengineAKSK
-                                                    ? (t('plan.volcengineAKSKPlaceholder') || 'AccessKey ID|||Secret Access Key（火山控制面 OpenAPI 签名用，与推理 Key 不同）')
-                                                    : isVolcenginePlan
-                                                        ? (t('plan.volcengineCredentialPlaceholder') || 'Cookie值|||x-csrf-token值（从控制台请求头复制，用竖线分隔）')
-                                                        : selectedInfo?.category === 'sensenova_plan'
-                                                            ? (t('plan.sensenovaTokenPlaceholder') || '粘贴控制台 Bearer Token 值')
-                                                            : selectedInfo?.category === 'bailian_plan'
-                                                                ? (t('plan.bailianTokenPlaceholder') || '粘贴控制台完整 Cookie 值')
-                                                                : (t('plan.oasisTokenPlaceholder') || '粘贴控制台 Cookie 中的 Oasis-Token 值'))
-                                                : (t('plan.apiKeyPlaceholder') || '请输入 API Key')}
+                                        : isTokenRhythm
+                                            ? (t('plan.tokenRhythmCookiePlaceholder') || '粘贴 tokenrhythm.studio 的完整 Cookie（需包含 tr_session= 字段）')
+                                            : isCodexPlan
+                                                ? (t('plan.codexOAuthPlaceholder') || '粘贴 OAuth JSON 凭据（含 access_token 和 account_id）')
+                                                : isConsoleTokenPlan
+                                                    ? (isVolcengineAKSK
+                                                        ? (t('plan.volcengineAKSKPlaceholder') || 'AccessKey ID|||Secret Access Key（火山控制面 OpenAPI 签名用，与推理 Key 不同）')
+                                                        : isVolcenginePlan
+                                                            ? (t('plan.volcengineCredentialPlaceholder') || 'Cookie值|||x-csrf-token值（从控制台请求头复制，用竖线分隔）')
+                                                            : selectedInfo?.category === 'sensenova_plan'
+                                                                ? (t('plan.sensenovaTokenPlaceholder') || '粘贴控制台 Bearer Token 值')
+                                                                : selectedInfo?.category === 'bailian_plan'
+                                                                    ? (t('plan.bailianTokenPlaceholder') || '粘贴控制台完整 Cookie 值')
+                                                                    : (t('plan.oasisTokenPlaceholder') || '粘贴控制台 Cookie 中的 Oasis-Token 值'))
+                                                    : (t('plan.apiKeyPlaceholder') || '请输入 API Key')}
                                     value={apiKey}
                                     onChange={(e) => setApiKey(e.target.value)}
                                 />
@@ -412,6 +417,11 @@ function PlanProviderSection({ type, title, providers, categories, isLoading, er
                                 {isMiMoPlan && mimoAuthMode === 'serviceToken' && (
                                     <p className="text-[11px] leading-tight text-amber-500">
                                         {t('plan.mimoServiceTokenHint') || '登录 platform.xiaomimimo.com → F12 → Application → Cookies，复制 api-platform 域下所有 Cookie。有效期约 1 天，过期后需手动更新。'}
+                                    </p>
+                                )}
+                                {isTokenRhythm && (
+                                    <p className="text-[11px] leading-tight text-amber-500">
+                                        {t('plan.tokenRhythmCookieHint') || '登录 tokenrhythm.studio → F12 → Network → 任意请求 → Request Headers，复制完整 Cookie 值（含 tr_session=、tr_csrf= 字段）。会话过期后需重新获取。'}
                                     </p>
                                 )}
                                 {isConsoleTokenPlan && !isMiMoPlan && !(isSenseNovaPlan && senseNovaAuthMode === 'account') && (
@@ -1019,6 +1029,7 @@ function EditCredentialsDialog({
     const isVolcengineAKSK = category === 'volcengine_plan_ak';
     const isZhipuTeam = category === 'zhipu_team';
     const isMiMoPlan = category === 'mimo_plan';
+    const isTokenRhythm = category === 'tokenrhythm';
     const isCodexPlan = category === 'codex';
     const isDeepSeek = category === 'deepseek';
     const supportsForwardApiKey = isConsoleTokenPlan && !isMiMoPlan;
@@ -1104,11 +1115,13 @@ function EditCredentialsDialog({
                         <label className="text-sm font-medium">
                             {isMiMoPlan
                                 ? (t('plan.cookieLabel') || 'Cookie')
-                                : isCodexPlan
-                                    ? (t('plan.codexOAuthLabel') || 'OAuth JSON')
-                                    : isConsoleTokenPlan
-                                        ? (t('plan.consoleTokenLabel') || '控制台 Token')
-                                        : (t('plan.apiKeyLabel') || 'API Key')}
+                                : isTokenRhythm
+                                    ? (t('plan.cookieLabel') || 'Cookie')
+                                    : isCodexPlan
+                                        ? (t('plan.codexOAuthLabel') || 'OAuth JSON')
+                                        : isConsoleTokenPlan
+                                            ? (t('plan.consoleTokenLabel') || '控制台 Token')
+                                            : (t('plan.apiKeyLabel') || 'API Key')}
                         </label>
                         {category === 'sensenova_plan' && senseNovaAuthMode === 'account' ? (
                             <div className="space-y-2">
@@ -1138,9 +1151,11 @@ function EditCredentialsDialog({
                             type="password"
                             placeholder={isMiMoPlan
                                 ? (t('plan.mimoServiceTokenPlaceholder') || '粘贴 platform.xiaomimimo.com 的完整 Cookie')
-                                : isCodexPlan
-                                    ? (t('plan.codexOAuthPlaceholder') || '粘贴 OAuth JSON 凭据')
-                                    : isConsoleTokenPlan
+                                : isTokenRhythm
+                                    ? (t('plan.tokenRhythmCookiePlaceholder') || '粘贴 tokenrhythm.studio 的完整 Cookie（需包含 tr_session= 字段）')
+                                    : isCodexPlan
+                                        ? (t('plan.codexOAuthPlaceholder') || '粘贴 OAuth JSON 凭据')
+                                        : isConsoleTokenPlan
                                         ? (isVolcenginePlan
                                             ? (t('plan.volcengineCredentialPlaceholder') || 'Cookie值|||x-csrf-token值')
                                             : isVolcengineAKSK


### PR DESCRIPTION
## 背景

新增基元律动（TokenRhythm）渠道额度监控：balance 类厂商，浏览器 Cookie 鉴权，纯监控不创建转发渠道（无独立 API Key，与 MiMo 类似）。

## 改动内容

1. 后端：新增 tokenrhythm 厂商，查询 /api/usage-summary：账户余额(balanceCny)、累计总成本(costCny)、全部 Token 用量
2. 前端：添加/编辑表单 Cookie 输入标签、占位符、提示文案；卡片新增历史 Token 总量指标（1×3）
3. 兼容：金额字段兼容字符串格式
4. i18n：三语新增 tokenRhythmCookiePlaceholder/Hint
5. 测试：httptest mock 验证解析、Cookie 校验、API 错误分支、金额字符串兼容

## 验证

- go build ./internal/... 通过
- go test ./internal/planprovider/ 与 ./internal/db/... 通过
- 前端 tsc：plan-provider/tokenrhythm 相关文件 0 错误

## 范围

后端 + 前端 + i18n，不含 CI/build 文件