### PR TITLE
feat: 前端数字格式化与卡片显示优化

### DIFF
--- a/web/src/components/modules/home/chart.tsx
+++ b/web/src/components/modules/home/chart.tsx
@@ -169,6 +169,29 @@ export function StatsChart() {
         return `${formatted.value}${formatted.unit}`;
     };
 
+    // Y 轴刻度：大跨度不需要小数点精度，中国化模式整数化（1500.00万 → 1500万），
+    // 避免 4 位数字 + 两位小数把刻度挤爆被截断；非中国化保持原样。
+    const axisCountTick = (value: number): string => {
+        if (chinaMode) {
+            const v = Number(value);
+            if (v >= 100_000_000) return `${Math.round(v / 100_000_000)}亿`;
+            if (v >= 10_000) return `${Math.round(v / 10_000)}万`;
+            return `${Math.round(v)}`;
+        }
+        const formatted = formatCount(value).formatted;
+        return `${formatted.value}${formatted.unit}`;
+    };
+
+    const axisCostTick = (value: number): string => {
+        if (chinaMode) {
+            const v = Number(value);
+            if (v >= 100_000_000) return `${Math.round(v / 100_000_000)}亿元`;
+            if (v >= 10_000) return `${Math.round(v / 10_000)}万元`;
+            return `${Math.round(v)}元`;
+        }
+        return costAxisFormatter(value);
+    };
+
     const costSummary = formatDisplayCost(totals.cost);
 
 
@@ -289,12 +312,11 @@ export function StatsChart() {
                         tickFormatter={(value) => {
                             const primary = chartMetrics[0] ?? 'cost';
                             if (primary === 'cost') {
-                                return costAxisFormatter(Number(value));
+                                return axisCostTick(Number(value));
                             } else if (primary === 'success-rate') {
                                 return `${value.toFixed(0)}%`;
                             } else if (primary === 'count' || primary === 'tokens') {
-                                const formatted = formatCount(value);
-                                return `${formatted.formatted.value}${formatted.formatted.unit}`;
+                                return axisCountTick(Number(value));
                             }
                             return value.toString();
                         }}

--- a/web/src/components/modules/home/hero.tsx
+++ b/web/src/components/modules/home/hero.tsx
@@ -28,6 +28,16 @@ function metricFontClass(width: number): string {
     return 'text-sm sm:text-base';
 }
 
+// 中国化模式大数量级整数化：794.25万 → 794万。大跨度展示不需要两位小数
+// 精度，整数化后保留单位、大幅缩短宽度（794万 / 978万），窄卡片不再挤。
+// k/m/b 模式（unit 为 M/K/B）与原始数值（unit 为空）保持原样。
+function chinaIntValue(value: string, unit: string): string {
+    if ((unit === '万' || unit === '亿') && value.includes('.')) {
+        return String(Math.round(parseFloat(value)));
+    }
+    return value;
+}
+
 export function HomeHero() {
     const t = useTranslations('home.hero');
     const statsRefreshMs = useHomeStatsRefreshMs();
@@ -50,10 +60,16 @@ export function HomeHero() {
         .reduce((sum, point) => sum + (point.cache_read_tokens ?? 0), 0);
     const cacheRate = totalTokens > 0 ? (todayCacheReadTokens / totalTokens) * 100 : 0;
 
-    const callsSuccess = formatCount(successCount).formatted;
-    const callsTotal = formatCount(requestCount).formatted;
-    const cacheRead = formatCount(todayCacheReadTokens).formatted;
-    const tokens = formatCount(totalTokens).formatted;
+    // 复合卡数值中国化整数化（794.25万 → 794万），单位保留；k/m/b 模式原样。
+    const fmtCount = (n?: number) => {
+        const f = formatCount(n).formatted;
+        return { value: chinaIntValue(f.value, f.unit), unit: f.unit };
+    };
+
+    const callsSuccess = fmtCount(successCount);
+    const callsTotal = fmtCount(requestCount);
+    const cacheRead = fmtCount(todayCacheReadTokens);
+    const tokens = fmtCount(totalTokens);
 
     // 2 列 × 2 行：第一行普通指标（平均响应时延 / 今日花费），第二行复合卡（今日调用 / 今日Token使用）。
     const cards = [
@@ -140,9 +156,7 @@ export function HomeHero() {
                                             {card.mainUnit ? <span className="text-sm text-muted-foreground">{card.mainUnit}</span> : null}
                                         </span>
                                         <span className="text-sm text-muted-foreground whitespace-nowrap">
-                                            / {card.dividerValue}
-                                            {/* 同一量纲（单位相同）时 divider 省略重复单位：794.25万 / 978.77，省宽度防换行 */}
-                                            {card.dividerUnit && card.dividerUnit !== card.mainUnit ? card.dividerUnit : null}
+                                            / {card.dividerValue}{card.dividerUnit}
                                         </span>
                                     </div>
                                     <div className="text-xs text-muted-foreground">

--- a/web/src/components/modules/home/hero.tsx
+++ b/web/src/components/modules/home/hero.tsx
@@ -28,11 +28,11 @@ function metricFontClass(width: number): string {
     return 'text-sm sm:text-base';
 }
 
-// 中国化模式大数量级整数化：794.25万 → 794万。大跨度展示不需要两位小数
-// 精度，整数化后保留单位、大幅缩短宽度（794万 / 978万），窄卡片不再挤。
-// k/m/b 模式（unit 为 M/K/B）与原始数值（unit 为空）保持原样。
+// 中国化模式万级整数化：794.25万 → 794万。大跨度展示两位小数无意义，
+// 整数化后保留单位、缩短宽度（794万 / 978万），窄卡片不再挤。
+// 亿级保留两位小数（1.02亿），k/m/b 模式与原始数值保持原样。
 function chinaIntValue(value: string, unit: string): string {
-    if ((unit === '万' || unit === '亿') && value.includes('.')) {
+    if (unit === '万' && value.includes('.')) {
         return String(Math.round(parseFloat(value)));
     }
     return value;

--- a/web/src/components/modules/home/hero.tsx
+++ b/web/src/components/modules/home/hero.tsx
@@ -135,12 +135,14 @@ export function HomeHero() {
                             {card.isComposite ? (
                                 <div className="mt-1 space-y-0.5">
                                     <div className="flex items-baseline gap-1.5 min-w-0">
-                                        <span className={`${metricFontClass(visualWidthOf(card.mainValue, card.mainUnit))} font-semibold tracking-tight`}>
+                                        <span className={`${metricFontClass(visualWidthOf(card.mainValue, card.mainUnit))} font-semibold tracking-tight whitespace-nowrap`}>
                                             <AnimatedNumber value={card.mainValue} />
                                             {card.mainUnit ? <span className="text-sm text-muted-foreground">{card.mainUnit}</span> : null}
                                         </span>
-                                        <span className="text-sm text-muted-foreground">
-                                            / {card.dividerValue}{card.dividerUnit}
+                                        <span className="text-sm text-muted-foreground whitespace-nowrap">
+                                            / {card.dividerValue}
+                                            {/* 同一量纲（单位相同）时 divider 省略重复单位：794.25万 / 978.77，省宽度防换行 */}
+                                            {card.dividerUnit && card.dividerUnit !== card.mainUnit ? card.dividerUnit : null}
                                         </span>
                                     </div>
                                     <div className="text-xs text-muted-foreground">

--- a/web/src/components/modules/home/hero.tsx
+++ b/web/src/components/modules/home/hero.tsx
@@ -11,6 +11,23 @@ import { AnimatedNumber } from '@/components/common/AnimatedNumber';
 import { EASING } from '@/lib/animations/fluid-transitions';
 import { formatCount, formatMoney, formatTime } from '@/lib/utils';
 
+// Adaptive metric font size: CJK units (万/亿/元) count double-width, so long
+// values (e.g. "2,008万" / "1,234.56万元") shrink instead of overflowing the
+// 2-column card grid (chinaMode 千万级 4 位数字场景).
+function visualWidthOf(value: string | undefined, unit: string | undefined): number {
+    let w = 0;
+    for (const ch of value ?? '') w += ch.charCodeAt(0) > 255 ? 2 : 1;
+    for (const ch of unit ?? '') w += ch.charCodeAt(0) > 255 ? 2 : 1;
+    return w;
+}
+
+function metricFontClass(width: number): string {
+    if (width <= 6) return 'text-xl sm:text-2xl';
+    if (width <= 8) return 'text-lg sm:text-xl';
+    if (width <= 10) return 'text-base sm:text-lg';
+    return 'text-sm sm:text-base';
+}
+
 export function HomeHero() {
     const t = useTranslations('home.hero');
     const statsRefreshMs = useHomeStatsRefreshMs();
@@ -117,8 +134,8 @@ export function HomeHero() {
                             <div className="text-xs font-medium text-muted-foreground">{card.label}</div>
                             {card.isComposite ? (
                                 <div className="mt-1 space-y-0.5">
-                                    <div className="flex items-baseline gap-1.5">
-                                        <span className="text-xl font-semibold tracking-tight sm:text-2xl">
+                                    <div className="flex items-baseline gap-1.5 min-w-0">
+                                        <span className={`${metricFontClass(visualWidthOf(card.mainValue, card.mainUnit))} font-semibold tracking-tight`}>
                                             <AnimatedNumber value={card.mainValue} />
                                             {card.mainUnit ? <span className="text-sm text-muted-foreground">{card.mainUnit}</span> : null}
                                         </span>
@@ -131,8 +148,8 @@ export function HomeHero() {
                                     </div>
                                 </div>
                             ) : (
-                                <div className="mt-1 flex items-baseline gap-1">
-                                    <span className="text-xl font-semibold tracking-tight sm:text-2xl">
+                                <div className="mt-1 flex items-baseline gap-1 min-w-0">
+                                    <span className={`${metricFontClass(visualWidthOf(card.value, card.unit))} font-semibold tracking-tight`}>
                                         <AnimatedNumber value={card.value} />
                                     </span>
                                     {card.unit ? <span className="text-sm text-muted-foreground">{card.unit}</span> : null}

--- a/web/src/components/modules/plan-provider/PlanProviderSection.tsx
+++ b/web/src/components/modules/plan-provider/PlanProviderSection.tsx
@@ -47,6 +47,8 @@ import { useSettingList, SettingKey } from '@/api/endpoints/setting';
 
 // 与后端 model.PlanProviderDeepSeek 对应的类别标识（DeepSeek 专属统计展示）
 const DEEPSEEK_PLAN_CATEGORY = 'deepseek';
+// MiMo 套餐类别标识：月度订阅固定额度、无滚动刷新，仅展示月档一个用量条
+const MIMO_PLAN_CATEGORY = 'mimo_plan';
 
 // --- Balance Section ---
 
@@ -732,6 +734,8 @@ function ProviderCard({
 
     // Find category info for display
     const isBalance = provider.provider_type === 'balance';
+    // MiMo 为月度订阅（固定额度、无滚动刷新），只展示月档一个用量条
+    const isMiMo = provider.category === MIMO_PLAN_CATEGORY;
 
     // 有效配额档（total>0）。外层先过滤，使 length/idx 反映真实渲染数，
     // 用于 normal 网格布局的"奇数末项跨两列"判断（QuotaTier 内部
@@ -740,7 +744,7 @@ function ProviderCard({
         { key: 'five_hour', label: t('plan.tierFiveHour') || '近5小时用量', total: provider.five_hour_total, used: provider.five_hour_used, resetAt: provider.five_hour_reset_at },
         { key: 'weekly', label: t('plan.tierWeekly') || '近一周用量', total: provider.weekly_total, used: provider.weekly_used, resetAt: provider.weekly_reset_at },
         { key: 'monthly', label: t('plan.tierMonthly') || '近一月用量', total: provider.quota_total, used: provider.quota_used, resetAt: provider.quota_reset_at },
-    ].filter((tier) => tier.total > 0);
+    ].filter((tier) => tier.total > 0 && !(isMiMo && tier.key !== 'monthly'));
 
     return (
         <div className={cn(
@@ -845,20 +849,24 @@ function ProviderCard({
                 </div>
             ) : compact ? (
                 <div className="flex items-center gap-4 flex-wrap text-xs">
-                    <QuotaTier
-                        label={t('plan.tierFiveHour') || '5h'}
-                        total={provider.five_hour_total}
-                        used={provider.five_hour_used}
-                        resetAt={provider.five_hour_reset_at}
-                        compact
-                    />
-                    <QuotaTier
-                        label={t('plan.tierWeekly') || '周'}
-                        total={provider.weekly_total}
-                        used={provider.weekly_used}
-                        resetAt={provider.weekly_reset_at}
-                        compact
-                    />
+                    {!isMiMo && (
+                        <QuotaTier
+                            label={t('plan.tierFiveHour') || '5h'}
+                            total={provider.five_hour_total}
+                            used={provider.five_hour_used}
+                            resetAt={provider.five_hour_reset_at}
+                            compact
+                        />
+                    )}
+                    {!isMiMo && (
+                        <QuotaTier
+                            label={t('plan.tierWeekly') || '周'}
+                            total={provider.weekly_total}
+                            used={provider.weekly_used}
+                            resetAt={provider.weekly_reset_at}
+                            compact
+                        />
+                    )}
                     <QuotaTier
                         label={t('plan.tierMonthly') || '月'}
                         total={provider.quota_total}


### PR DESCRIPTION
## 背景

首页/趋势图数字展示中国化格式化优化 + MiMo 套餐卡片显示修正，纯前端改动。

## 改动内容

1. 首页 hero 卡片：中国化模式千万级数字自适应字号防卡片溢出（794.25万→794万，亿级保留两位小数 1.02亿）
2. 趋势图 Y 轴：中国化刻度去小数点（1500.00万→1500万）
3. 复合卡：divider 同单位省略 + 防断行，窄卡片不再单位换行
4. MiMo 套餐卡片：月度订阅固定额度、无滚动刷新，仅展示月档一个用量条（详细网格与极简 compact 模式均生效）

## 验证

- 前端 tsc：无新增错误
- go build ./internal/... 通过（后端无改动）

## 范围

仅前端 3 个文件（home/hero.tsx、home/chart.tsx、plan-provider/PlanProviderSection.tsx），不含 CI/build 文件