### PR TITLE
fix: relay 熔断误判与 Responses 兼容修复

### DIFF
--- a/internal/relay/chat_responses_fallback_test.go
+++ b/internal/relay/chat_responses_fallback_test.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/lingyuins/octopus/internal/transformer/model"
@@ -344,9 +345,54 @@ func TestShouldTryAdapterFallbackSkipsClientErrorScopeNone(t *testing.T) {
 		Success:  false,
 		Written:  false,
 		Decision: RetryDecision{Scope: ScopeNone, Reason: "bad request, client error", Code: 400, IsError: true},
+		Err:      errors.New(`channel foo adapter=response attempt 1/4: upstream error: 400: {"error":{"message":"输入内容过长","code":"context_length_exceeded"}}`),
 	}
 
 	if shouldTryAdapterFallback(result, 0, 2) {
 		t.Fatal("expected client error ScopeNone to skip adapter fallback so upstream body can be returned immediately")
+	}
+}
+
+func TestShouldTryAdapterFallbackAllowsResponsesToolHistoryMismatch(t *testing.T) {
+	result := attemptResult{
+		Success:  false,
+		Written:  false,
+		Decision: RetryDecision{Scope: ScopeNone, Reason: "bad request, client error", Code: 400, IsError: true},
+		Err: errors.New(`channel 基元律动 adapter=response attempt 1/4: upstream error: 400: {"error":{"message":"No tool output found for tool call call_01_jCi6YrQJgn7qQhsWk5vD3152.","type":"invalid_request_error"}}`),
+	}
+
+	if !shouldTryAdapterFallback(result, 0, 2) {
+		t.Fatal("expected Responses tool-history 400 to allow adapter fallback to chat")
+	}
+	if shouldTryAdapterFallback(result, 1, 2) {
+		t.Fatal("expected last adapter attempt to stop even on format mismatch")
+	}
+}
+
+func TestShouldTryAdapterFallbackSkipsGenericInvalidRequest(t *testing.T) {
+	result := attemptResult{
+		Success:  false,
+		Written:  false,
+		Decision: RetryDecision{Scope: ScopeNone, Reason: "bad request, client error", Code: 400, IsError: true},
+		Err:      errors.New(`upstream error: 400: {"error":{"message":"invalid_request_error: unknown field","type":"invalid_request_error"}}`),
+	}
+
+	if shouldTryAdapterFallback(result, 0, 2) {
+		t.Fatal("expected generic 400 invalid_request to stay terminal")
+	}
+}
+
+func TestIsOutboundAdapterFormatMismatch(t *testing.T) {
+	if !isOutboundAdapterFormatMismatch(400, errors.New("No tool output found for function call abc")) {
+		t.Fatal("expected function_call wording to match")
+	}
+	if !isOutboundAdapterFormatMismatch(400, errors.New(`Invalid 'input[3].call_id': empty`)) {
+		t.Fatal("expected Invalid 'input[ to match")
+	}
+	if isOutboundAdapterFormatMismatch(400, errors.New("context_length_exceeded")) {
+		t.Fatal("context length must not match format mismatch")
+	}
+	if isOutboundAdapterFormatMismatch(500, errors.New("No tool output found for tool call x")) {
+		t.Fatal("non-400 must not match")
 	}
 }

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -98,11 +98,35 @@ func shouldTryAdapterFallback(result attemptResult, adapterIndex, attemptCount i
 	if result.Success || result.Written || adapterIndex >= attemptCount-1 {
 		return false
 	}
-	// 只有路由级失败（换候选）才值得尝试另一种出站 adapter 格式。
-	// 客户端错误 ScopeNone（如 context_length_exceeded 的 400）与 Key 级失败
-	// ScopeSameChannel 都不该再换 adapter：前者必须立刻把上游错误体回给下游，
-	// 后者换 adapter 只会用同一把 Key 多打一次，徒增延迟。
-	return result.Decision.Scope == ScopeNextChannel
+	// 路由级失败（换候选）值得试另一种出站 adapter。
+	if result.Decision.Scope == ScopeNextChannel {
+		return true
+	}
+	// Responses/Chat 协议形态不匹配的 400（如 tool 历史转换后上游报
+	// "No tool output found for tool call"）不是用户 prompt 写错，换下一个
+	// adapter（通常 Response→Chat）可能立刻恢复。其它 400（context_length 等）
+	// 与 Key 级失败仍不换 adapter，避免延迟和误伤。
+	return isOutboundAdapterFormatMismatch(result.Decision.Code, result.Err)
+}
+
+// isOutboundAdapterFormatMismatch 识别「当前出站 adapter 的 wire 形态」导致的
+// 上游 400，而不是通用客户端错误。匹配要保持窄，防止任意 invalid_request 被重试。
+func isOutboundAdapterFormatMismatch(statusCode int, err error) bool {
+	if statusCode != http.StatusBadRequest || err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, needle := range []string{
+		"no tool output found for tool call",
+		"no tool output found for function call",
+		"invalid 'input[",
+		"function_call_output",
+	} {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
 }
 func isZenCandidateChannelAllowed(requestModel string, channelType outbound.OutboundType, isEmbeddingRequest bool) bool {
 	preferred := detectZenPreferredChannelTypes(requestModel, isEmbeddingRequest)

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -1018,6 +1018,14 @@ func (ra *relayAttempt) handleStreamResponse(ctx context.Context, response *http
 			case <-ctx.Done():
 				return
 			}
+			// OpenAI 兼容 SSE 的流结束标志：收到 [DONE] 即代表上游流已结束。
+			// 部分上游（如 B.AI/chat.b.ai）发完 [DONE] 后保持连接不关闭，octopus
+			// 若继续等 EOF 会一直阻塞，最终由客户端正常断开触发 clientDone 被误判
+			// 为失败（进而 key 冷却/熔断，误伤健康渠道）。收到 [DONE] 后主动结束
+			// 读取（defer close(results) 让主循环走正常结束路径）。
+			if strings.TrimSpace(ev.Data) == "[DONE]" {
+				return
+			}
 		}
 	}()
 
@@ -1055,6 +1063,14 @@ func (ra *relayAttempt) handleStreamResponse(ctx context.Context, response *http
 		select {
 		case <-clientDone:
 			if ra.streamSession == nil {
+				// 客户端断开。若已向客户端写出可见内容，视为正常完成——
+				// 客户端已拿到完整输出并主动关闭连接（或上游发完 [DONE] 后
+				// 保持连接不关闭，octopus 等不到 EOF），不应记为失败，否则会
+				// 触发 key 冷却/熔断，误伤健康渠道。
+				if hasVisibleContent {
+					log.Infof("client disconnected after visible content, treating as completed")
+					return nil
+				}
 				log.Infof("client disconnected, stopping stream")
 				return errClientDisconnected
 			}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -1739,18 +1739,21 @@ func executeRelay(req *relayRequest, group dbmodel.Group, requestModel string, m
 					handlePoolAuthError(poolAccount, poolCredType, result.Decision.Code)
 				}
 
+				// Client disconnected — stop all retries immediately without
+				// recording failure hints, circuit-breaker failures, or attempting
+				// further channels. The client chose to stop, not the channel.
+				// 必须先于熔断记录：client disconnected 的 Decision.Scope 为 ScopeAbortAll，
+				// 若先执行熔断记录会把正常流结束误记为连续失败，触发误熔断（issue 修复）。
+				if errors.Is(result.Err, errClientDisconnected) {
+					req.metrics.Save(false, result.Err, currentAttempts)
+					return nil, result.Err
+				}
+
 				// 熔断器和 Auto 策略：在所有 adapter 类型（如 Responses→Chat）均失败后才记录，
 				// 避免 Response adapter 降级到 Chat 的过程中误触发熔断。
 				if channel.PoolID == 0 && (result.Decision.Scope == ScopeNextChannel || result.Decision.Scope == ScopeAbortAll) {
 					balancer.RecordFailure(channel.ID, usedKey.ID, resolvedModelName)
 					balancer.RecordAutoFailure(channel.ID, resolvedModelName)
-				}
-
-				// Client disconnected — stop all retries immediately without
-				// recording failure hints or attempting further channels.
-				if errors.Is(result.Err, errClientDisconnected) {
-					req.metrics.Save(false, result.Err, currentAttempts)
-					return nil, result.Err
 				}
 
 				// hold 路径：本轮 429 会立刻再试同一渠道，不写 failure hint / 不记 failedKey，

--- a/internal/transformer/outbound/openai/response.go
+++ b/internal/transformer/outbound/openai/response.go
@@ -600,30 +600,39 @@ func convertUserMessageToResponses(msg model.Message) ResponsesItem {
 func convertAssistantMessageToResponses(msg model.Message) []ResponsesItem {
 	var items []ResponsesItem
 
-	// Handle tool calls
+	// Handle tool calls. Historical function_call items are already executed by
+	// the client; mark them completed so strict Responses gateways do not treat
+	// them as pending calls that still need a matching live output.
 	for _, tc := range msg.ToolCalls {
 		items = append(items, ResponsesItem{
 			Type:      "function_call",
 			CallID:    tc.ID,
 			Name:      tc.Function.Name,
 			Arguments: tc.Function.Arguments,
+			Status:    lo.ToPtr("completed"),
 		})
 	}
 
-	// Handle content
+	// Handle content. Hermes and similar agents often send content:"" together
+	// with tool_calls; an empty output_text message between function_call and
+	// function_call_output breaks strict upstream pairing checks.
 	var contentItems []ResponsesItem
 	if msg.Content.Content != nil {
-		contentItems = append(contentItems, ResponsesItem{
-			Type: "output_text",
-			Text: msg.Content.Content,
-		})
+		if text := strings.TrimSpace(*msg.Content.Content); text != "" {
+			contentItems = append(contentItems, ResponsesItem{
+				Type: "output_text",
+				Text: lo.ToPtr(text),
+			})
+		}
 	} else {
 		for _, p := range msg.Content.MultipleContent {
 			if p.Type == "text" && p.Text != nil {
-				contentItems = append(contentItems, ResponsesItem{
-					Type: "output_text",
-					Text: p.Text,
-				})
+				if text := strings.TrimSpace(*p.Text); text != "" {
+					contentItems = append(contentItems, ResponsesItem{
+						Type: "output_text",
+						Text: lo.ToPtr(text),
+					})
+				}
 			}
 		}
 	}
@@ -664,6 +673,7 @@ func convertToolMessageToResponses(msg model.Message) ResponsesItem {
 		Type:   "function_call_output",
 		CallID: lo.FromPtr(msg.ToolCallID),
 		Output: &output,
+		Status: lo.ToPtr("completed"),
 	}
 }
 

--- a/internal/transformer/outbound/openai/response_test.go
+++ b/internal/transformer/outbound/openai/response_test.go
@@ -6,6 +6,67 @@ import (
 	"github.com/lingyuins/octopus/internal/transformer/model"
 )
 
+func TestConvertAssistantMessageToResponses_MarksToolCallsCompletedAndSkipsEmptyContent(t *testing.T) {
+	empty := ""
+	msg := model.Message{
+		Role:    "assistant",
+		Content: model.MessageContent{Content: &empty},
+		ToolCalls: []model.ToolCall{
+			{
+				ID: "call_01_jCi6YrQJgn7qQhsWk5vD3152",
+				Function: model.FunctionCall{
+					Name:      "terminal",
+					Arguments: `{"command":"ls"}`,
+				},
+			},
+		},
+	}
+
+	items := convertAssistantMessageToResponses(msg)
+	if len(items) != 1 {
+		t.Fatalf("expected only function_call item, got %#v", items)
+	}
+	if items[0].Type != "function_call" {
+		t.Fatalf("type = %q, want function_call", items[0].Type)
+	}
+	if items[0].CallID != "call_01_jCi6YrQJgn7qQhsWk5vD3152" {
+		t.Fatalf("call_id = %q", items[0].CallID)
+	}
+	if items[0].Status == nil || *items[0].Status != "completed" {
+		t.Fatalf("status = %#v, want completed", items[0].Status)
+	}
+}
+
+func TestConvertAssistantMessageToResponses_KeepsNonEmptyTextMessage(t *testing.T) {
+	msg := model.Message{
+		Role:    "assistant",
+		Content: model.MessageContent{Content: strPtr("done")},
+	}
+	items := convertAssistantMessageToResponses(msg)
+	if len(items) != 1 || items[0].Type != "message" {
+		t.Fatalf("expected one message item, got %#v", items)
+	}
+}
+
+func TestConvertToolMessageToResponses_MarksOutputCompleted(t *testing.T) {
+	toolCallID := "call_01_jCi6YrQJgn7qQhsWk5vD3152"
+	msg := model.Message{
+		Role:       "tool",
+		ToolCallID: &toolCallID,
+		Content:    model.MessageContent{Content: strPtr(`{"ok":true}`)},
+	}
+	item := convertToolMessageToResponses(msg)
+	if item.Type != "function_call_output" {
+		t.Fatalf("type = %q", item.Type)
+	}
+	if item.Status == nil || *item.Status != "completed" {
+		t.Fatalf("status = %#v, want completed", item.Status)
+	}
+	if item.CallID != toolCallID {
+		t.Fatalf("call_id = %q", item.CallID)
+	}
+}
+
 func TestConvertToResponsesRequest_OmitsNoneReasoningEffort(t *testing.T) {
 	req := &model.InternalLLMRequest{
 		Model:           "mimo-v2.5-pro",


### PR DESCRIPTION
## 背景

relay 层三个相互关联的修复：正常流结束被误判为 client disconnected 导致健康渠道误熔断、上游不关连接导致 SSE 悬挂、严格 Responses 网关多轮工具历史 400 无法回退。

## 改动内容

1. fix(relay): client disconnected 不计入熔断失败，修复正常流结束误熔断
   - 熔断条件排除 client disconnected 错误（客户端主动断开/正常流结束不应惩罚渠道）

2. fix(relay): [DONE] 后主动结束 SSE 读取，根治上游不关连接导致的 client disconnected 误判
   - SSE 流收到 [DONE] 后主动结束读取，不再等上游关闭连接

3. fix(relay): Responses tool-history 400 可回退 Chat，并硬化 function_call 回放
   - 严格 Responses 网关对历史 tool 轮次报 "No tool output found for tool call"：窄匹配格式性 400 后允许换下一个 adapter（Response→Chat）
   - 转换器给历史 function_call / function_call_output 标 status=completed，跳过 content 为空的 assistant 消息

## 验证

- go build ./internal/... 通过
- go test ./internal/relay/ 与 ./internal/transformer/... 通过（含新增单测：熔断排除、fallback 窄匹配、转换器硬化）

## 范围

仅 internal/relay + internal/transformer/outbound/openai，不含 CI/build 文件