### PR TITLE
fix: dnd 拖拽排序不跟手/选项消失修复（虚拟列表行定位 / 弹窗 translate 劫持 / draggable transform 过渡）

### DIFF
--- a/web/src/components/common/VirtualizedGrid.tsx
+++ b/web/src/components/common/VirtualizedGrid.tsx
@@ -38,6 +38,12 @@ interface VirtualizedGridProps<T> {
     reachEndEnabled?: boolean;
     reachEndOffset?: number;
     bottomPaddingClassName?: string;
+    /**
+     * 虚拟行定位方式。默认 'transform'（性能好，但 transform 会创建 containing block，
+     * 劫持 dnd 拖拽元素的 position:fixed → 拖动不跟手）。
+     * 页面内有 DnD（拖拽排序）时必须传 'inset'（top 定位，不劫持 fixed）。
+     */
+    rowPositioning?: 'transform' | 'inset';
 }
 
 function getColumnsForWidth(
@@ -68,6 +74,7 @@ export function VirtualizedGrid<T>({
     reachEndEnabled = false,
     reachEndOffset = 1,
     bottomPaddingClassName = 'pb-3 md:pb-4',
+    rowPositioning = 'transform',
 }: VirtualizedGridProps<T>) {
     'use no memo';
 
@@ -207,9 +214,14 @@ export function VirtualizedGrid<T>({
                                         data-index={virtualRow.index}
                                         ref={rowVirtualizer.measureElement}
                                         className="absolute left-0 top-0 w-full"
-                                        style={{
-                                            transform: `translateY(${translateY}px)`,
-                                        }}
+                                        style={
+                                            // 虚拟行定位：transform/translate 会创建 containing block，
+                                            // 把 dnd 拖拽元素的 position:fixed 参照系从视口劫持到本行，导致不跟手。
+                                            // inset(top) 定位不劫持 fixed，仅需 dnd 的分页启用。
+                                            rowPositioning === 'inset'
+                                                ? { top: `${translateY}px` }
+                                                : { transform: `translateY(${translateY}px)` }
+                                        }
                                     >
                                         {footer}
                                     </div>
@@ -227,9 +239,14 @@ export function VirtualizedGrid<T>({
                                     data-index={virtualRow.index}
                                     ref={rowVirtualizer.measureElement}
                                     className="absolute left-0 top-0 w-full"
-                                    style={{
-                                        transform: `translateY(${translateY}px)`,
-                                    }}
+                                    style={
+                                        // 虚拟行定位：transform/translate 会创建 containing block，
+                                        // 把 dnd 拖拽元素的 position:fixed 参照系从视口劫持到本行，导致不跟手。
+                                        // inset(top) 定位不劫持 fixed，仅需 dnd 的分页启用。
+                                        rowPositioning === 'inset'
+                                            ? { top: `${translateY}px` }
+                                            : { transform: `translateY(${translateY}px)` }
+                                    }
                                 >
                                     <div
                                         className="grid"

--- a/web/src/components/modules/group/index.tsx
+++ b/web/src/components/modules/group/index.tsx
@@ -132,13 +132,14 @@ export function Group() {
                     <GroupedRouteModelView categories={groupedCategories} />
                 ) : (
                     <VirtualizedGrid
-                        items={visibleGroups}
-                        columns={{ default: 1, sm: 2, md: 2, lg: 3 }}
-                        estimateItemHeight={72}
-                        getItemKey={(group, index) => group.id ?? `group-${index}`}
-                        renderItem={(group) => <GroupListItem group={group} />}
-                        bottomPaddingClassName="pb-3 md:pb-4"
-                    />
+                                            items={visibleGroups}
+                                            columns={{ default: 1, sm: 2, md: 2, lg: 3 }}
+                                            estimateItemHeight={72}
+                                            getItemKey={(group, index) => group.id ?? `group-${index}`}
+                                            renderItem={(group) => <GroupListItem group={group} />}
+                                            bottomPaddingClassName="pb-3 md:pb-4"
+                                            rowPositioning="inset"
+                                        />
                 )}
             </section>
         </div>

--- a/web/src/components/modules/setting/Appearance.tsx
+++ b/web/src/components/modules/setting/Appearance.tsx
@@ -201,7 +201,7 @@ function NavigationPreferences() {
                                                     ref={draggableProvided.innerRef}
                                                     {...draggableProvided.draggableProps}
                                                     className={cn(
-                                                        'flex items-center justify-between gap-3 rounded-lg border-border/30 bg-card px-3 py-3 shadow-sm transition-[transform,border-color,box-shadow]',
+                                                        'flex items-center justify-between gap-3 rounded-lg border-border/30 bg-card px-3 py-3 shadow-sm transition-[border-color,box-shadow]',
                                                         snapshot.isDragging && 'border-primary/40 shadow-md'
                                                     )}
                                                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -387,7 +387,7 @@ function SubTabPreferences() {
                                                                 ref={draggableProvided.innerRef}
                                                                 {...draggableProvided.draggableProps}
                                                                 className={cn(
-                                                                    'flex items-center justify-between gap-2 rounded-lg border-border/30 bg-card px-3 py-2 shadow-sm transition-[transform,border-color,box-shadow]',
+                                                                    'flex items-center justify-between gap-2 rounded-lg border-border/30 bg-card px-3 py-2 shadow-sm transition-[border-color,box-shadow]',
                                                                     snapshot.isDragging && 'border-primary/40 shadow-md'
                                                                 )}
                                                                 style={draggableProvided.draggableProps.style as React.CSSProperties}

--- a/web/src/components/modules/setting/SettingOrder.tsx
+++ b/web/src/components/modules/setting/SettingOrder.tsx
@@ -171,7 +171,7 @@ export function SettingOrder() {
                                                 ref={draggableProvided.innerRef}
                                                 {...draggableProvided.draggableProps}
                                                 className={cn(
-                                                    'flex items-center gap-3 rounded-lg border-border/30 bg-card px-3 py-3 shadow-sm transition-[transform,border-color,box-shadow]',
+                                                    'flex items-center gap-3 rounded-lg border-border/30 bg-card px-3 py-3 shadow-sm transition-[border-color,box-shadow]',
                                                     snapshot.isDragging && 'border-primary/40 shadow-md'
                                                 )}
                                                 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -58,14 +58,19 @@ function DialogContent({
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
-      <DialogPrimitive.Content
-        data-slot="dialog-content"
-        className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
-          className
-        )}
-        {...props}
-      >
+      {/* 居中 wrapper：fixed inset-0 + grid，自身无 transform/translate。
+          弹窗内容（Content）若自带 translate/transform 会导致其内部
+          position:fixed 后代（如 dnd 拖拽元素）的 containing block 被劫持，
+          拖起瞬间元素飞到弹窗外被裁剪（长按后选项消失）。 */}
+      <div className="fixed inset-0 z-50 grid place-items-center overflow-y-auto p-0">
+        <DialogPrimitive.Content
+          data-slot="dialog-content"
+          className={cn(
+            "relative grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+            className
+          )}
+          {...props}
+        >
         {children}
         {showCloseButton && (
           <DialogPrimitive.Close
@@ -77,6 +82,7 @@ function DialogContent({
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Content>
+      </div>
     </DialogPortal>
   )
 }


### PR DESCRIPTION
## 问题

分组页展开分组后长按模型拖拽排序，拖起的元素不跟手；设置-外观页长按拖拽排序时选项直接消失。

## 根因

`@hello-pangea/dnd` 拖起时将被拖元素设为 `position: fixed` + 视口坐标，但以下祖先属性会创建 containing block，把 fixed 参照系从视口劫持到该祖先，导致元素渲染位置错位/飞出容器被裁剪：

1. **虚拟列表行定位**：`VirtualizedGrid` 每行用 `transform: translateY(...)` 定位（@tanstack/react-virtual）。注意独立 `translate` 属性同样劫持（浏览器实测验证）；
2. **Draggable 自身 transition**：`Appearance`/`SettingOrder` 的 Draggable 元素带 `transition-[transform,...]`，dnd 每帧通过 transform 更新位置被过渡动画追赶 → 持续滞后；
3. **Dialog 居中 translate**：`ui/dialog` 的 DialogContent 用 `translate-x-[-50%] translate-y-[-50%]` 居中，常驻劫持弹窗内所有 fixed 后代 → 长按后选项飞出弹窗被 `overflow` 裁剪（消失）。

## 修复

- `VirtualizedGrid` 新增 `rowPositioning` prop：`'inset'`（`top` 定位，不劫持 fixed，用于带 DnD 的分组页）/ `'transform'`（默认，其余页面保持性能）；
- `Appearance`/`SettingOrder`：移除 Draggable 元素的 transform transition（保留 border/shadow 高亮过渡）；
- `ui/dialog`：DialogContent 居中移到外层 wrapper（`fixed inset-0 grid place-items-center`，自身无 transform），Content 改 `relative` —— 全站弹窗受益，点击外部关闭逻辑不受影响（Radix pointerdown-outside 判定）。

## 验证

- 分组页：展开任意分组（含列表深处）长按拖拽，任意位置跟手（修复前越靠下偏差越大）；
- 设置-外观：长按拖拽不再消失（修复前 lift 后元素 rect 与声明位置偏差 = 弹窗原点偏移，被滚动容器裁剪）；
- tsc 零错误、单测 167/167；
- 已在生产环境（HCS docker）热替验证通过。